### PR TITLE
Deploy to pub.dev

### DIFF
--- a/.github/workflows/pubdev.yml
+++ b/.github/workflows/pubdev.yml
@@ -1,0 +1,31 @@
+name: Publish to Pub.dev 🚀
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ format('{0}/{1}/versions/{2}', "https://pub.dev/packages", steps.publish.outputs.package, steps.publish.outputs.remoteVersion) }}
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - name: Check Versions 🔎
+        run: |
+          set -eo pipefail
+          export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+          export PUBSPEC_VERSION=$(grep 'version: ' pubspec.yaml | sed -e 's,.*: \(.*\),\1,')
+          if [ "$LIB_VERSION" != "$PUBSPEC_VERSION" ]; then
+            echo "Version in 'pubspec.yaml' does not match tag.";
+            exit 1;
+          fi
+      - name: Publish Dart Package 🚢
+        id: publish
+        uses: k-paxian/dart-package-publisher@1.5
+        with:
+          accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
+          refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}


### PR DESCRIPTION
- Deploy to pub.dev on new release creation. Relevant tokens have been added to the organisation and exposed to this repo.

> Based on the [VideoUIKit-Flutter deployment script](https://github.com/AgoraIO-Community/VideoUIKit-Flutter/actions/runs/3136447317/jobs/5093370342).

@LichKing-2234 @littleGnAl please give any feedback on this or ask any questions if anything's unclear.
The objective is to make deployment easier, and have GitHub as the source of truth for this package and its versions.