### PR TITLE
[action][pubdev] Only publish if stable or pre-release

### DIFF
--- a/.github/workflows/pubdev.yml
+++ b/.github/workflows/pubdev.yml
@@ -1,10 +1,8 @@
 name: Publish to Pub.dev 🚀
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  release:
+    types: [published]
 
 jobs:
   publishing:

--- a/.github/workflows/pubdev.yml
+++ b/.github/workflows/pubdev.yml
@@ -3,7 +3,8 @@ name: Publish to Pub.dev 🚀
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 jobs:
   publishing:


### PR DESCRIPTION
We want to use the tag to manage the special version and dev version, but we only want to publish a stable and pre-release version to pub.dev, so we strictly match the tag version here.