### PR TITLE
[iOS] Move rendering test to cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,21 +10,6 @@ default_macos_container: &default_macos_container
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:14
 
-# default_macos_container: &default_macos_container
-#   matrix:
-#     - name: macos-monterey-xcode:13
-#       macos_instance:
-#         image: ghcr.io/cirruslabs/macos-monterey-xcode:13
-
-#     - name: macos-monterey-xcode:14
-#       macos_instance:
-#         image: ghcr.io/cirruslabs/macos-monterey-xcode:14
-
-#     - name: macos-ventura-xcode:14
-#       macos_instance:
-#         image: ghcr.io/cirruslabs/macos-ventura-xcode:14
-
-
 android_integratinon_test_task:
   container:
     # Only run min support flutter sdk 2.10.5, and latest flutter sdk version
@@ -89,88 +74,16 @@ android_build_task:
     - flutter packages get
     - flutter build apk
 
-# TODO(littlegnal): Complete after Android migration completed.
-# ios_integration_test_task:
-#   <<: *organization_filter
-#   <<: *default_macos_container
+ios_rendering_test_task:
+  <<: *organization_filter
+  <<: *default_macos_container
 
-#   create_ios_simulator_script:
-#     - xcrun simctl list
-#     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-16-0 | xargs xcrun simctl boot
+  create_ios_simulator_script:
+    - xcrun simctl list
+    # We generate the screenshots base on the simulator "iPhone 13 Pro Max", so we set the SimDeviceType to iPhone-13-Pro-Max.
+    # If you need to change the SimDeviceType, you may need to re-generate the screenshots first.
+    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-13-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-16-0 | xargs xcrun simctl boot
 
-#   matrix:
-#     - name: FLUTTER_VERSION 2.10.5
-#       env:
-#         FLUTTER_VERSION: 2.10.5
-#     - name: FLUTTER_VERSION 3.0.0
-#       env:
-#         FLUTTER_VERSION: 3.0.0
-#     - name: FLUTTER_VERSION 3.3.0
-#       env:
-#         FLUTTER_VERSION: 3.3.0
-#     - name: FLUTTER_VERSION 3.7.0
-#       env:
-#         FLUTTER_VERSION: 3.7.0
-#   switch_flutter_version_script:
-#     - cd ${MACOS_HOST_FLUTTER_SDK_DIR}
-#     - git fetch
-#     - git checkout ${FLUTTER_VERSION} && flutter precache
-
-#   run_ios_test_script:
-#     - flutter doctor -v
-#     - bash ci/run_flutter_integration_test_ios.sh
-
-# ios_rendering_test_task:
-#   <<: *organization_filter
-#   <<: *default_macos_container
-
-#   create_ios_simulator_script:
-#     - xcrun simctl list
-#     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-16-0 | xargs xcrun simctl boot
-
-#   switch_flutter_version_script:
-#     - cd ${MACOS_HOST_FLUTTER_SDK_DIR}
-#     - git fetch
-#     - git checkout 3.0.0 && flutter precache
-
-#   run_ios_test_script:
-#     - bash ci/rendering_test_ios.sh
-
-# ios_build_task:
-#   <<: *organization_filter
-
-#   matrix:
-#     - name: macos-monterey-xcode:13
-#       macos_instance:
-#         image: ghcr.io/cirruslabs/macos-monterey-xcode:13
-
-#   matrix:
-#     - name: FLUTTER_VERSION 2.10.5
-#       env:
-#         FLUTTER_VERSION: 2.10.5
-#     - name: FLUTTER_VERSION 3.0.0
-#       env:
-#         FLUTTER_VERSION: 3.0.0
-#     - name: FLUTTER_VERSION 3.3.0
-#       env:
-#         FLUTTER_VERSION: 3.3.0
-#     - name: FLUTTER_VERSION 3.7.0
-#       env:
-#         FLUTTER_VERSION: 3.7.0
-#   switch_flutter_version_script:
-#     - cd ${MACOS_HOST_FLUTTER_SDK_DIR}
-#     - git fetch
-#     - git checkout ${FLUTTER_VERSION} && flutter precache
-
-#   build_ios_x86_64_script:
-#     - cd example
-#     - arch -x86_64 flutter doctor -v
-#     - arch -x86_64 flutter packages get
-#     - arch -x86_64 flutter build ios --no-codesign
-
-#   build_ios_arm64_script:
-#     - cd example
-#     - flutter doctor -v
-#     - flutter clean
-#     - flutter packages get
-#     - flutter build ios --no-codesign
+  run_ios_test_script:
+    - flutter doctor -v
+    - bash ci/rendering_test_ios.sh

--- a/.github/workflows/rendering_test.yml
+++ b/.github/workflows/rendering_test.yml
@@ -66,49 +66,6 @@ jobs:
   #         disk-size: 8192M
   #         script: bash ci/rendering_test_android.sh
 
-  rendering_test_ios:
-    name: Run Flutter iOS Integration Tests
-    strategy:
-      matrix:
-        version: ['3.0.0']
-    runs-on: macos-12
-    timeout-minutes: 120
-    env:
-      TEST_APP_ID: ${{ secrets.MY_APP_ID }}
-    steps:
-      - uses: actions/checkout@v1
-      - uses: subosito/flutter-action@v1
-        with:
-          flutter-version: ${{ matrix.version }}
-      - uses: futureware-tech/simulator-action@v2
-        with:
-          model: 'iPhone 13 Pro Max'
-      - name: Checkout hoe
-        uses: actions/checkout@v3
-        with:
-          repository: littleGnAl/hoe
-          ref: littlegnal/update
-          path: hoe
-      - name: Download iris artifacts
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'integration_test:iris_artifacts') }}
-        run: |
-          source scripts/artifacts_version.sh
-
-          PROJECT_DIR=$(pwd)
-
-          mkdir -p output
-          cd hoe
-          dart pub get
-          dart run bin/hoe.dart build-agora-flutter-example \
-            --setup-local-dev \
-            --project-dir=${PROJECT_DIR} \
-            --artifacts-output-dir=${PROJECT_DIR}/output \
-            --platforms=ios \
-            --apple-package-name=io.agora.agoraRtcEngineExample \
-            --flutter-package-name=agora_rtc_engine \
-            --iris-ios-cdn-url=${IRIS_CDN_URL_IOS}
-      - run: bash ci/rendering_test_ios.sh
-
   rendering_test_macos:
     name: Run Flutter macOS Integration Tests
     strategy:

--- a/test_shard/rendering_test/integration_test/agora_video_view_render_test.dart
+++ b/test_shard/rendering_test/integration_test/agora_video_view_render_test.dart
@@ -590,14 +590,6 @@ void main() {
             );
           });
         },
-        // TODO(littlegnal): Flutter texture with software rendering on simulator is not supported.
-        // The log like below:
-        // Flutter: Attempted to composite external texture sources using the software backend.
-        // This backend is only used on simulators. This feature is only available
-        // on actual devices where OpenGL or Metal is used for rendering.
-        //
-        // Temporily skip flutter texture rendering test on ios at this time.
-        skip: true,
       );
     },
     skip: !Platform.isIOS,


### PR DESCRIPTION
After Ventura, we notice that the flutter texture can be worked on the iOS simulator, but the GitHub action runner still [does not support the macos-13](https://github.com/actions/runner-images/issues/6426) at this time, but cirrus ci does, so we try to move the iOS rendering test to cirrus ci.