### PR TITLE
[example] fix Android build on macos m1

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 


### PR DESCRIPTION
After the cirrus ci update the Android toolchain `Platform android-33, build-tools 33.0.1` of `ghcr.io/cirruslabs/macos-ventura-xcode:14` caused the build to fail.
see https://github.com/cirruslabs/macos-image-templates/commit/9b63d54a046bfe49ce2aede918680d8f8dc3feea
see fail https://cirrus-ci.com/task/4709914724007936

Upgrade the AGP 7.1.2 to fix it.