### PR TITLE
fix: fix _HotRestartFinalizer._onExitPort not be initialized in release build

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: ^2.8.2
   meta: ^1.7.0
-  iris_method_channel: ^1.1.0-rc.2
+  iris_method_channel: ^1.1.0-rc.3
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Update `iris_method_channel` to 1.1.0-rc.3 to fix _HotRestartFinalizer._onExitPort not be initialized in release build
see fix https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/pull/34