### PR TITLE
[example][ios] disable bitcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         version: ['2.10.5', '3.0.0']
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -71,6 +71,7 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings['ONLY_ACTIVE_ARCH'] = 'YES'
       config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386"
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
     end
   end
 end


### PR DESCRIPTION
Disable the bitcode in ios example since:
* After xcode 14, bitcode is removed
* The native sdk 4.1.1.x and later version have disabled the bitcode by default.