### PR TITLE
fix: fix RtcEngine.release be called due to inaccurate app lifecycle callback in add2app scenario

### DIFF
--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -154,21 +154,6 @@ extension MetadataObserverExt on MetadataObserver {
   }
 }
 
-class _Lifecycle with WidgetsBindingObserver {
-  const _Lifecycle(this.onDestroy);
-
-  final VoidCallback onDestroy;
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    super.didChangeAppLifecycleState(state);
-
-    if (state == AppLifecycleState.detached) {
-      onDestroy();
-    }
-  }
-}
-
 @internal
 class InitializationState extends ChangeNotifier {
   bool _isInitialzed = false;
@@ -202,8 +187,6 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
 
   final ScopedObjects _objectPool = ScopedObjects();
 
-  _Lifecycle? _lifecycle;
-
   @internal
   final MethodChannel engineMethodChannel = const MethodChannel('agora_rtc_ng');
 
@@ -220,15 +203,6 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
   }
 
   Future<void> _initializeInternal(RtcEngineContext context) async {
-    _lifecycle ??= _Lifecycle(
-      () {
-        release(sync: true);
-      },
-    );
-    // Compatible with 2.10
-    // ignore: invalid_null_aware_operator
-    _ambiguate(WidgetsBinding.instance)?.addObserver(_lifecycle!);
-
     await _globalVideoViewController
         .attachVideoFrameBufferManager(irisMethodChannel.getNativeHandle());
 
@@ -296,13 +270,6 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
   @override
   Future<void> release({bool sync = false}) async {
     if (_instance == null) return;
-
-    if (_lifecycle != null) {
-      // Compatible with 2.10
-      // ignore: invalid_null_aware_operator
-      _ambiguate(WidgetsBinding.instance)?.removeObserver(_lifecycle!);
-      _lifecycle = null;
-    }
 
     _rtcEngineState.dispose();
 


### PR DESCRIPTION
We listen to the `WidgetsBindingObserver.didChangeAppLifecycleState` in `RtcEngine.initialize`, and when the `AppLifecycleState.detached` is triggered, we call `RtcEngine.release` to clean up the `RtcEngine`.

In Android

For the standalone Flutter APP, the `AppLifecycleState.detached` is triggered when `FlutterActivity.onDestroy` is called, the APP is closed at this time.

But in add2app scenario, the `AppLifecycleState.detached` is triggered when the `FlutterActivity` finish, the APP is not closed at this time, e.g., the user just detaches the `FlutterEngine` from the `FlutterActivity`, so we should not call `RtcEngine.release` at this time.

Since after migrating to `iris_method_channel`, the `RtcEngine` can be clean up correctly, so it's ok to remove the listener.