### PR TITLE
[windows] remove Dispose in TextureRender destructor

### DIFF
--- a/windows/texture_render.cc
+++ b/windows/texture_render.cc
@@ -30,7 +30,6 @@ TextureRender::TextureRender(flutter::BinaryMessenger *messenger,
 
 TextureRender::~TextureRender()
 {
-    Dispose();
 }
 
 int64_t TextureRender::texture_id() { return texture_id_; }


### PR DESCRIPTION
The call to `Dispose` in the `TextureRender` destructor is unnecessary, and may cause unexpected behavior, so remove it.