### PR TITLE
Optimize initilizate time of AgoraVideoView with PlatformView rendering

### DIFF
--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -16,7 +16,6 @@ class JoinChannelVideo extends StatefulWidget {
 
 class _State extends State<JoinChannelVideo> {
   late final RtcEngine _engine;
-  bool _isReadyPreview = false;
 
   bool isJoined = false, switchCamera = true, switchRender = true;
   Set<int> remoteUid = {};
@@ -96,12 +95,6 @@ class _State extends State<JoinChannelVideo> {
         bitrate: 0,
       ),
     );
-
-    await _engine.startPreview();
-
-    setState(() {
-      _isReadyPreview = true;
-    });
   }
 
   Future<void> _joinChannel() async {
@@ -131,7 +124,6 @@ class _State extends State<JoinChannelVideo> {
   Widget build(BuildContext context) {
     return ExampleActionsWidget(
       displayContentBuilder: (context, isLayoutHorizontal) {
-        if (!_isReadyPreview) return Container();
         return Stack(
           children: [
             AgoraVideoView(
@@ -141,6 +133,9 @@ class _State extends State<JoinChannelVideo> {
                 useFlutterTexture: _isUseFlutterTexture,
                 useAndroidSurfaceView: _isUseAndroidSurfaceView,
               ),
+              onAgoraVideoViewCreated: (viewId) {
+                _engine.startPreview();
+              },
             ),
             Align(
               alignment: Alignment.topLeft,

--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -12,57 +12,13 @@ import 'agora_rtc_renderer.dart';
 
 // ignore_for_file: public_member_api_docs
 
+VideoViewControllerBaseMixin _controller(VideoViewControllerBase controller) {
+  return controller as VideoViewControllerBaseMixin;
+}
+
 class AgoraVideoViewState extends State<AgoraVideoView> {
-  AgoraVideoViewState() {
-    _listener = () {
-      bool isInitialzed = _controller(widget.controller).isInitialzed;
-      if (isInitialzed != _isInitialzed) {
-        setState(() {
-          _isInitialzed = isInitialzed;
-        });
-      }
-    };
-  }
-
-  late VoidCallback _listener;
-  late bool _isInitialzed;
-
-  VideoViewControllerBaseMixin _controller(VideoViewControllerBase controller) {
-    return controller as VideoViewControllerBaseMixin;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    _isInitialzed = _controller(widget.controller).isInitialzed;
-    _controller(widget.controller).addInitializedCompletedListener(_listener);
-  }
-
-  @override
-  void didUpdateWidget(covariant AgoraVideoView oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    _controller(oldWidget.controller)
-        .removeInitializedCompletedListener(_listener);
-    // Refresh the `_isInitialzed` to the current widget.controller `isInitialzed`
-    _isInitialzed = _controller(widget.controller).isInitialzed;
-    _controller(widget.controller).addInitializedCompletedListener(_listener);
-  }
-
-  @override
-  void deactivate() {
-    super.deactivate();
-    _controller(widget.controller)
-        .removeInitializedCompletedListener(_listener);
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (!_isInitialzed) {
-      return Container();
-    }
-
     if (defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows) {
       return AgoraRtcRenderTexture(
@@ -80,7 +36,10 @@ class AgoraVideoViewState extends State<AgoraVideoView> {
     }
 
     return AgoraRtcRenderPlatformView(
-        key: widget.key, controller: widget.controller);
+      key: widget.key,
+      controller: widget.controller,
+      onAgoraVideoViewCreated: widget.onAgoraVideoViewCreated,
+    );
   }
 }
 
@@ -88,9 +47,12 @@ class AgoraRtcRenderPlatformView extends StatefulWidget {
   const AgoraRtcRenderPlatformView({
     Key? key,
     required this.controller,
+    this.onAgoraVideoViewCreated,
   }) : super(key: key);
 
   final VideoViewControllerBase controller;
+
+  final AgoraVideoViewCreatedCallback? onAgoraVideoViewCreated;
 
   @override
   State<AgoraRtcRenderPlatformView> createState() =>
@@ -104,6 +66,8 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
 
   int _nativeViewIntPtr = 0;
   late String _viewType;
+
+  VoidCallback? _listener;
 
   @override
   void initState() {
@@ -122,6 +86,16 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
     }
 
     widget.controller.initializeRender();
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+    if (_listener != null) {
+      _controller(widget.controller)
+          .removeInitializedCompletedListener(_listener!);
+      _listener = null;
+    }
   }
 
   @override
@@ -155,11 +129,32 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
     );
   }
 
+  Future<void> _setupNativeView() async {
+    if (_nativeViewIntPtr == 0) {
+      return;
+    }
+
+    await widget.controller.setupView(_nativeViewIntPtr);
+    widget.onAgoraVideoViewCreated?.call(_nativeViewIntPtr);
+  }
+
   Future<void> _setupVideo() async {
     _nativeViewIntPtr =
         (await getMethodChannel()!.invokeMethod<int>('getNativeViewPtr'))!;
     if (!mounted) return;
-    await widget.controller.setupView(_nativeViewIntPtr);
+    if (!_controller(widget.controller).isInitialzed) {
+      _listener ??= () {
+        _controller(widget.controller)
+            .removeInitializedCompletedListener(_listener!);
+        _listener = null;
+
+        _setupNativeView();
+      };
+      _controller(widget.controller)
+          .addInitializedCompletedListener(_listener!);
+    } else {
+      await _setupNativeView();
+    }
   }
 
   Future<void> _disposeRender() async {
@@ -185,13 +180,31 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
   int _width = 0;
   int _height = 0;
 
+  VoidCallback? _listener;
+
   @override
   void initState() {
     super.initState();
+
     _initialize();
   }
 
   Future<void> _initialize() async {
+    if (!_controller(widget.controller).isInitialzed) {
+      _listener ??= () {
+        _controller(widget.controller)
+            .removeInitializedCompletedListener(_listener!);
+        _listener = null;
+        _initializeTexture();
+      };
+      _controller(widget.controller)
+          .addInitializedCompletedListener(_listener!);
+    } else {
+      await _initializeTexture();
+    }
+  }
+
+  Future<void> _initializeTexture() async {
     final oldTextureId = widget.controller.getTextureId();
     await widget.controller.initializeRender();
     if (oldTextureId != widget.controller.getTextureId()) {
@@ -218,6 +231,16 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
       _initialize();
     } else {
       widget.controller.setTextureId(oldWidget.controller.getTextureId());
+    }
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+    if (_listener != null) {
+      _controller(widget.controller)
+          .removeInitializedCompletedListener(_listener!);
+      _listener = null;
     }
   }
 

--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -12,6 +12,9 @@ import 'agora_rtc_renderer.dart';
 
 // ignore_for_file: public_member_api_docs
 
+/// Callback when [AgoraVideoView] created.
+typedef AgoraVideoViewCreatedCallback = void Function(int viewId);
+
 VideoViewControllerBaseMixin _controller(VideoViewControllerBase controller) {
   return controller as VideoViewControllerBaseMixin;
 }

--- a/lib/src/impl/media_player_controller_impl.dart
+++ b/lib/src/impl/media_player_controller_impl.dart
@@ -358,7 +358,7 @@ class MediaPlayerControllerImpl
   }
 
   @override
-  Future<void> setupView(int nativeViewPtr) async {
+  Future<void> setupNativeViewInternal(int nativeViewPtr) async {
     return setView(nativeViewPtr);
   }
 
@@ -371,7 +371,7 @@ class MediaPlayerControllerImpl
   }
 
   @override
-  Future<void> disposeRender() async {
+  Future<void> disposeRenderInternal() async {
     if (shouldUseFlutterTexture) {
       await super.disposeRender();
     }

--- a/lib/src/render/agora_video_view.dart
+++ b/lib/src/render/agora_video_view.dart
@@ -3,9 +3,6 @@ import 'package:flutter/material.dart';
 
 import '../impl/agora_video_view_impl.dart';
 
-/// Callback when [AgoraVideoView] created.
-typedef AgoraVideoViewCreatedCallback = void Function(int viewId);
-
 /// The AgoraVideoView Class for rendering local and remote video.
 class AgoraVideoView extends StatefulWidget {
   /// @nodoc
@@ -18,7 +15,8 @@ class AgoraVideoView extends StatefulWidget {
   /// Controls the type of video to render:If you want to render video of the RtcEngine, see VideoViewController .If you want to render video of the media player, see MediaPlayerController .
   final VideoViewControllerBase controller;
 
-  final AgoraVideoViewCreatedCallback? onAgoraVideoViewCreated;
+  /// Callback when [AgoraVideoView] created.
+  final void Function(int viewId)? onAgoraVideoViewCreated;
 
   @override
   State<AgoraVideoView> createState() => AgoraVideoViewState();

--- a/lib/src/render/agora_video_view.dart
+++ b/lib/src/render/agora_video_view.dart
@@ -3,13 +3,22 @@ import 'package:flutter/material.dart';
 
 import '../impl/agora_video_view_impl.dart';
 
+/// Callback when [AgoraVideoView] created.
+typedef AgoraVideoViewCreatedCallback = void Function(int viewId);
+
 /// The AgoraVideoView Class for rendering local and remote video.
 class AgoraVideoView extends StatefulWidget {
   /// @nodoc
-  const AgoraVideoView({Key? key, required this.controller}) : super(key: key);
+  const AgoraVideoView({
+    Key? key,
+    required this.controller,
+    this.onAgoraVideoViewCreated,
+  }) : super(key: key);
 
   /// Controls the type of video to render:If you want to render video of the RtcEngine, see VideoViewController .If you want to render video of the media player, see MediaPlayerController .
   final VideoViewControllerBase controller;
+
+  final AgoraVideoViewCreatedCallback? onAgoraVideoViewCreated;
 
   @override
   State<AgoraVideoView> createState() => AgoraVideoViewState();


### PR DESCRIPTION
1. Create flutter Platform View when `AgoraVideoView` is created, reduce the time spent on the `RtcEngine.setupLocalVideo` flow: create flutter Platform View -> `RtcEngine.setupLocalVideo`
2. Add `onAgoraVideoViewCreated ` callback to indicate that the `AgoraVideoView` created