### PR TITLE
[ci] add action to tag the special version after PR merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Tag the special version 🚀
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  release_special_if_merged:
+    if: ${{ github.event.pull_request.merged == true && 
+            contains(github.event.pull_request.labels.*.name, 'ci:release_special') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+      - name: git config
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - run: |
+          PUBSPEC_VERSION=$(grep 'version: ' pubspec.yaml | sed -e 's,.*: \(.*\),\1,')
+          echo "pubspec version: ${PUBSPEC_VERSION}"
+
+          TAG_NAME=v${PUBSPEC_VERSION}
+          TAG_MSG="Release ${PUBSPEC_VERSION}"
+          git tag -a ${TAG_NAME} -m ${TAG_MSG}
+          git push origin ${TAG_NAME}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_special_version.yml
+++ b/.github/workflows/release_special_version.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release_special_if_merged:
     if: ${{ github.event.pull_request.merged == true && 
-            contains(github.event.pull_request.labels.*.name, 'ci:release_special') }}
+            contains(github.event.pull_request.labels.*.name, 'ci:ready_release_special') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
If the PR with the label `ci:ready_release_special` is merged, this action will be triggered to tag a special version.