### PR TITLE
fix the new AgoraVieoView not be shown when reuse the same MediaPlayerController

### DIFF
--- a/lib/src/impl/media_player_controller_impl.dart
+++ b/lib/src/impl/media_player_controller_impl.dart
@@ -350,7 +350,7 @@ class MediaPlayerControllerImpl
   @override
   Future<int> createTextureRender(
       int uid, String channelId, int videoSourceType) {
-    return rtcEngine.globalVideoViewController.createTextureRender(
+    return super.createTextureRender(
       getMediaPlayerId(),
       channelId,
       videoSourceType,
@@ -373,7 +373,7 @@ class MediaPlayerControllerImpl
   @override
   Future<void> disposeRenderInternal() async {
     if (shouldUseFlutterTexture) {
-      await super.disposeRender();
+      await super.disposeRenderInternal();
     }
   }
 }

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -128,7 +128,7 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     int videoSourceType,
   ) async {
     if (_isCreatedRender) {
-      return kTextureNotInit;
+      return _textureId;
     }
     final textureId =
         await rtcEngine.globalVideoViewController.createTextureRender(
@@ -138,6 +138,7 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     );
 
     _isCreatedRender = true;
+    _isDisposeRender = false;
 
     return textureId;
   }


### PR DESCRIPTION
The `MediaPlayerController` is `initialize`/`dispose` by the user, so we can reuse the same `MediaPlayerController` for the `AgoraVieoView` when an existing `AgoraVieoView` is disposed, and then a new `AgoraVieoView` to be rendered, to new `AgoraVieoView` can not be shown, due to the incorrect value of `_isCreatedRender `, `_isDisposeRender `