### PR TITLE
fix: Fix build error due to iris_method_channel break change

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: ^2.8.2
   meta: ^1.7.0
-  iris_method_channel: ^1.1.0-rc.5
+  iris_method_channel: 1.1.0-rc.5
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
The [iris_method_channel](https://pub.dev/packages/iris_method_channel/versions/1.1.0) had released version 1.1.0 but with a breaking change, but the `agora_rtc_engine` dependent it with caret-syntax `^`, so the `iris_method_channel` will be upgraded automatically when run `flutter packages get`, set a fixed version to avoid this. And the `iris_method_channel` should increase the major or minor version num if there're breaking changes in the future.