### PR TITLE
feat: upgrade native sdk dependencies 20230525

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,9 +47,9 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.0-build.1'
-     api 'io.agora.rtc:agora-full-preview:4.2.0-dev.13'
-     implementation 'io.agora.rtc:full-screen-sharing-special:4.2.0-dev.3'
+    api 'io.agora.rtc:iris-rtc:4.2.0-build.2'
+    api 'io.agora.rtc:full-sdk:4.2.0'
+    api 'io.agora.rtc:full-screen-sharing:4.2.0'
   }
 }
 

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*.{h,mm,m,swift}'
   s.dependency 'Flutter'
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.0-build.1'
-  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.2.0-dev.13'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.0-build.2'
+  s.dependency 'AgoraRtcEngine_iOS', '4.2.0'
   # s.dependency 'AgoraRtcWrapper'
   s.platform = :ios, '9.0'
   s.swift_version = '5.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -16,8 +16,8 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*.{h,mm}', 'Classes/File.swift'
   s.dependency 'FlutterMacOS'
   # s.dependency 'AgoraRtcWrapper'
-  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.2.0-dev.13'
-  s.dependency 'AgoraIrisRTC_macOS', '4.2.0-build.1'
+  s.dependency 'AgoraRtcEngine_macOS', '4.2.0'
+  s.dependency 'AgoraIrisRTC_macOS', '4.2.0-build.2'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.0-build.1_DCG_Android_Video_20230523_0209.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.0-build.1_DCG_iOS_Video_20230523_0214.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.0-build.1_DCG_Mac_Video_20230523_0209.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.0-build.1_DCG_Windows_Video_20230523_0209.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Android_Video_20230524_0304.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_iOS_Video_20230524_0304.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Mac_Video_20230524_0307.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Windows_Video_20230524_0304.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.0-build.1_DCG_Windows_Video_20230523_0209.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.0-build.1_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Windows_Video_20230524_0304.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.0-build.2_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native sdk dependencies 20230525
native sdk dependencies:
```
implementation 'io.agora.rtc:full-screen-sharing:4.2.0'  implementation 'io.agora.rtc:full-sdk:4.2.0'   pod 'AgoraRtcEngine_iOS', '4.2.0'  pod 'AgoraRtcEngine_macOS', '4.2.0' 
```

iris dependencies:
```
Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.0-build.2/iris_4.2.0-build.2_DCG_Windows_Video_20230524_0304.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Windows_Video_20230524_0304.zip  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.0-build.2/iris_4.2.0-build.2_DCG_Mac_Video_20230524_0307.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Mac_Video_20230524_0307.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.2.0-build.2'  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.0-build.2/iris_4.2.0-build.2_DCG_iOS_Video_20230524_0304.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_iOS_Video_20230524_0304.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.0-build.2'  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.0-build.2/iris_4.2.0-build.2_DCG_Android_Video_20230524_0304.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.0-build.2_DCG_Android_Video_20230524_0304.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.0-build.2'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.