### PR TITLE
fix: no-op if call RtcEngine.release without calling RtcEngine.initialize directly

### DIFF
--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -312,13 +312,15 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
 
   @override
   Future<void> release({bool sync = false}) async {
-    if (_isReleased) return;
-
     // Same as explanation inside `initialize`. We should wait for
     // the `initialize` function is completed here.
     if (_initializingCompleter != null &&
         !_initializingCompleter!.isCompleted) {
       await _initializingCompleter?.future;
+    }
+
+    if (!_rtcEngineState.isInitialzed || _isReleased) {
+      return;
     }
 
     _releasingCompleter = Completer<void>();
@@ -328,8 +330,8 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
 
     await _objectPool.clear();
 
-    await _globalVideoViewController!
-        .detachVideoFrameBufferManager(irisMethodChannel.getNativeHandle());
+    await _globalVideoViewController
+        ?.detachVideoFrameBufferManager(irisMethodChannel.getNativeHandle());
     _globalVideoViewController = null;
 
     await irisMethodChannel.unregisterEventHandlers(_rtcEngineImplScopedKey);

--- a/test_shard/integration_test_app/integration_test/testcases/rtcengine_smoke_test_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/rtcengine_smoke_test_testcases.dart
@@ -371,5 +371,24 @@ void testCases() {
         await rtcEngine.setupLocalVideo(const VideoCanvas());
       },
     );
+
+    testWidgets(
+      'call release without calling initialize directly, do not thorw error',
+      (WidgetTester tester) async {
+        app.main();
+        await tester.pumpAndSettle();
+
+        String engineAppId = const String.fromEnvironment('TEST_APP_ID',
+            defaultValue: '<YOUR_APP_ID>');
+
+        RtcEngineEx rtcEngine = createAgoraRtcEngineEx();
+        await rtcEngine.release();
+
+        await rtcEngine.initialize(RtcEngineContext(
+          appId: engineAppId,
+          areaCode: AreaCode.areaCodeGlob.value(),
+        ));
+      },
+    );
   });
 }


### PR DESCRIPTION
Currently, if call the `RtcEngine.release` directly, but do not call `RtcEngine.initialize`, it will throw an error, this should be a bug. This PR let the `RtcEngine.release` as a no-op if do not call `RtcEngine.initialize` ever.