### PR TITLE
fix: do not setup native view if the widget is disposed in platform view rendering

### DIFF
--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -78,6 +78,8 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
 
   VoidCallback? _listener;
 
+  bool _isDisposed = false;
+
   @override
   void initState() {
     super.initState();
@@ -139,7 +141,7 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
   }
 
   Future<void> _setupNativeView() async {
-    if (_nativeViewIntPtr == 0) {
+    if (_isDisposed || _nativeViewIntPtr == 0) {
       return;
     }
 
@@ -167,6 +169,9 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
   }
 
   Future<void> _disposeRender() async {
+    _isDisposed = true;
+    _nativeViewIntPtr = 0;
+
     await widget.controller.disposeRender();
     await getMethodChannel()?.invokeMethod<int>('deleteNativeViewPtr');
   }

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -97,15 +97,19 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
       setupMode: canvas.setupMode,
       mediaPlayerId: canvas.mediaPlayerId,
     );
-    if (canvas.uid != 0) {
-      if (connection != null && rtcEngine is RtcEngineEx) {
-        await (rtcEngine as RtcEngineEx)
-            .setupRemoteVideoEx(canvas: videoCanvas, connection: connection!);
+    try {
+      if (canvas.uid != 0) {
+        if (connection != null && rtcEngine is RtcEngineEx) {
+          await (rtcEngine as RtcEngineEx)
+              .setupRemoteVideoEx(canvas: videoCanvas, connection: connection!);
+        } else {
+          await rtcEngine.setupRemoteVideo(videoCanvas);
+        }
       } else {
-        await rtcEngine.setupRemoteVideo(videoCanvas);
+        await rtcEngine.setupLocalVideo(videoCanvas);
       }
-    } else {
-      await rtcEngine.setupLocalVideo(videoCanvas);
+    } catch (e) {
+      debugPrint('disposeRenderInternal error: ${e.toString()}');
     }
   }
 
@@ -158,7 +162,9 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
               VideoViewSetupMode.videoViewSetupReplace.value(),
         );
       }
-    } else {}
+    } else {
+      // do nothing if platform view rendering
+    }
   }
 
   @protected
@@ -173,15 +179,19 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
       setupMode: canvas.setupMode,
       mediaPlayerId: canvas.mediaPlayerId,
     );
-    if (canvas.uid != 0) {
-      if (connection != null) {
-        await (rtcEngine as RtcEngineEx)
-            .setupRemoteVideoEx(canvas: videoCanvas, connection: connection!);
+    try {
+      if (canvas.uid != 0) {
+        if (connection != null) {
+          await (rtcEngine as RtcEngineEx)
+              .setupRemoteVideoEx(canvas: videoCanvas, connection: connection!);
+        } else {
+          await rtcEngine.setupRemoteVideo(videoCanvas);
+        }
       } else {
-        await rtcEngine.setupRemoteVideo(videoCanvas);
+        await rtcEngine.setupLocalVideo(videoCanvas);
       }
-    } else {
-      await rtcEngine.setupLocalVideo(videoCanvas);
+    } catch (e) {
+      debugPrint('setupNativeViewInternal error: ${e.toString()}');
     }
   }
 

--- a/test_shard/integration_test_app/integration_test/testcases/agora_video_view_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/agora_video_view_testcases.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:flutter/foundation.dart';
@@ -294,4 +295,34 @@ void testCases() {
     },
     skip: Platform.isAndroid,
   );
+
+  testWidgets('Show Local AgoraVideoView pressure test',
+      (WidgetTester tester) async {
+    for (int i = 0; i < 5; i++) {
+      await tester.pumpWidget(_RenderViewWidget(
+        builder: (context, engine) {
+          return SizedBox(
+            height: 100,
+            width: 100,
+            child: AgoraVideoView(
+              controller: VideoViewController(
+                rtcEngine: engine,
+                canvas: const VideoCanvas(uid: 0),
+              ),
+            ),
+          );
+        },
+      ));
+
+      final random = Random();
+      final waitDuration = random.nextInt(5000);
+
+      await tester.pumpAndSettle(Duration(milliseconds: waitDuration));
+
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    }
+
+    expect(find.byType(AgoraVideoView), findsNothing);
+  });
 }


### PR DESCRIPTION
In platform view rendering, we call "getNativeViewPtr" through the method channel, which is an async call, it's a potential crash that we may get an invalid view ptr, if the widget is disposed before the call is completed. Add a disposal check when setup the native view.

May fix https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/issues/1131.