### PR TITLE
feat: upgrade native sdk dependencies 20230621

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,9 +51,9 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.0-build.3'
-    api 'io.agora.rtc:full-sdk:4.2.0'
-    api 'io.agora.rtc:full-screen-sharing:4.2.0'
+    api 'io.agora.rtc:iris-rtc:4.2.1-dev.2'
+    api 'io.agora.rtc:agora-full-preview:4.2.1-dev.2'
+    api 'io.agora.rtc:full-screen-sharing-special:4.2.1-dev.2'
   }
 }
 

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-    s.dependency 'AgoraIrisRTC_iOS', '4.2.0-build.3'
-    s.dependency 'AgoraRtcEngine_iOS', '4.2.0'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.1-dev.2'
+  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.2.1-dev.2'
   end
   
   s.platform = :ios, '9.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -21,8 +21,8 @@ A new flutter plugin project.
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.framework'
   else
-    s.dependency 'AgoraRtcEngine_macOS', '4.2.0'
-    s.dependency 'AgoraIrisRTC_macOS', '4.2.0-build.3'
+  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.2.1-dev.2'
+  s.dependency 'AgoraIrisRTC_macOS', '4.2.1-dev.2'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.0-build.3_DCG_Android_Video_20230525_0541.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.0-build.3_DCG_iOS_Video_20230525_0544.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.0-build.3_DCG_Mac_Video_20230525_0545.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.0-build.3_DCG_Windows_Video_20230525_0541.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Android_Video_20230620_0413.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_iOS_Video_20230620_0413.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Mac_Video_20230620_0413.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Windows_Video_20230620_0413.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.0-build.3_DCG_Windows_Video_20230525_0541.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.0-build.3_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Windows_Video_20230620_0413.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.1-dev.2_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native sdk dependencies 20230621
native sdk dependencies:
```
implementation 'io.agora.rtc:agora-full-preview:4.2.1-dev.2' Packages: implementation 'io.agora.rtc:full-screen-sharing-special:4.2.1-dev.2' Packages: pod 'AgoraRtcEngine_macOS_Preview', '4.2.1-dev.2' Packages: pod 'AgoraRtcEngine_iOS_Preview', '4.2.1-dev.2'
```

iris dependencies:
```
Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.1-dev.2/iris_4.2.1-dev.2_DCG_Mac_Video_20230620_0413.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Mac_Video_20230620_0413.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.2.1-dev.2'  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.1-dev.2/iris_4.2.1-dev.2_DCG_Windows_Video_20230620_0413.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Windows_Video_20230620_0413.zip  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.1-dev.2/iris_4.2.1-dev.2_DCG_iOS_Video_20230620_0413.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_iOS_Video_20230620_0413.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.1-dev.2'  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.1-dev.2/iris_4.2.1-dev.2_DCG_Android_Video_20230620_0413.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.1-dev.2_DCG_Android_Video_20230620_0413.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.1-dev.2'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.