### PR TITLE
[ci][ios][rendering-test] Use github action to manipulate the ios simulator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,11 +238,9 @@ jobs:
             --apple-package-name=io.agora.agoraRtcEngineExample \
             --flutter-package-name=agora_rtc_engine \
             --iris-ios-cdn-url=${IRIS_CDN_URL_IOS}
-      - run: |
-          xcrun simctl list
-          # We generate the screenshots base on the simulator "iPhone 13 Pro Max", so we set the SimDeviceType to iPhone-13-Pro-Max.
-          # If you need to change the SimDeviceType, you may need to re-generate the screenshots first.
-          xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-13-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-16-2 | xargs xcrun simctl boot
+        - uses: futureware-tech/simulator-action@v2
+          with:
+            model: 'iPhone 14 Pro Max'
       - run: bash ci/rendering_test_ios.sh
 
   rendering_test_macos:

--- a/ci/rendering_test_ios.sh
+++ b/ci/rendering_test_ios.sh
@@ -9,8 +9,8 @@ pushd ${MY_PATH}/../test_shard/rendering_test
 
 flutter packages get
 
-flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_render_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_render_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}" --verbose
 
-flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_smoke_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_smoke_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}" --verbose
 
 popd


### PR DESCRIPTION
It's so weird that the ios rendering test failed https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/pull/1166 after this change https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/commit/8b2436cc0209baa0c39e175f8f4b7caf9138cbd1, add more log to see what's happening.