### PR TITLE
fix: Fix AgoraVideoView not showing correctly when reusing the same VideoViewController

### DIFF
--- a/ci/rendering_test_ios.sh
+++ b/ci/rendering_test_ios.sh
@@ -9,8 +9,8 @@ pushd ${MY_PATH}/../test_shard/rendering_test
 
 flutter packages get
 
-flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_render_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_render_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}" --verbose
 
-flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_smoke_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+flutter drive --driver=test_driver/integration_test.dart --target=integration_test/agora_video_view_smoke_test.dart --dart-define=TEST_APP_ID="${TEST_APP_ID}" --verbose
 
 popd

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -204,6 +204,7 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     await setupNativeViewInternal(nativeViewPtr);
 
     _isCreatedRender = true;
+    _isDisposeRender = false;
   }
 
   @internal


### PR DESCRIPTION
fix: Fix `AgoraVideoView` not showing correctly when resued the same `VideoViewController`.

When reusing the same `VideoViewController`, and create/dispose of the `AgoraVideoView` multiple times, the `VideoViewControllerBaseMixin._isDisposeRender ` flag is not reset correctly in the `setupView`, which causes the `disposeRender ` not to be called.

It's better to use state management for the `AgoraVideoView` in the future, at this time, just fix the bug first.