### PR TITLE
fix: Fix VideoViewController state not correct when the AgoraVideoViews are reused

### DIFF
--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -127,6 +127,8 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
     if (!oldWidget.controller.isSame(widget.controller)) {
       await oldWidget.controller.disposeRender();
       await _setupVideo();
+    } else {
+      _controller(widget.controller).updateController(oldWidget.controller);
     }
   }
 
@@ -243,13 +245,9 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
 
   Future<void> _didUpdateWidget(
       covariant AgoraRtcRenderTexture oldWidget) async {
-    if (!oldWidget.controller.isSame(widget.controller)) {
-      await oldWidget.controller.dispose();
-      if (!mounted) return;
-      _initialize();
-    } else {
-      widget.controller.setTextureId(oldWidget.controller.getTextureId());
-    }
+    // For flutter texture rendering, only update the texture id and other state, and the 
+    // Flutter framework will handle the rest.
+    _controller(widget.controller).updateController(oldWidget.controller);
   }
 
   @override

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -67,9 +67,13 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
   @override
   int getTextureId() => _textureId;
 
-  @override
-  void setTextureId(int textureId) {
-    _textureId = textureId;
+  @internal
+  void updateController(VideoViewControllerBase oldController) {
+    assert(oldController is VideoViewControllerBaseMixin);
+    final oldControllerMixin = oldController as VideoViewControllerBaseMixin;
+    _textureId = oldControllerMixin.getTextureId();
+    _isCreatedRender = oldControllerMixin._isCreatedRender;
+    _isDisposeRender = oldControllerMixin._isDisposeRender;
   }
 
   @override

--- a/lib/src/render/video_view_controller.dart
+++ b/lib/src/render/video_view_controller.dart
@@ -25,9 +25,6 @@ abstract class VideoViewControllerBase {
   bool get useAndroidSurfaceView;
 
   @internal
-  void setTextureId(int textureId);
-
-  @internal
   int getTextureId();
 
   @internal

--- a/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:agora_rtc_engine/src/impl/agora_rtc_engine_impl.dart';
 import 'package:agora_rtc_engine/src/impl/native_iris_api_engine_binding_delegate.dart';
@@ -15,11 +16,14 @@ class _RenderViewWidget extends StatefulWidget {
     Key? key,
     required this.builder,
     required this.rtcEngine,
+    this.onRtcEngineInitialized,
   }) : super(key: key);
 
   final Function(BuildContext context, RtcEngine engine) builder;
 
   final RtcEngine rtcEngine;
+
+  final VoidCallback? onRtcEngineInitialized;
 
   @override
   State<_RenderViewWidget> createState() => _RenderViewWidgetState();
@@ -55,6 +59,8 @@ class _RenderViewWidgetState extends State<_RenderViewWidget> {
       areaCode: AreaCode.areaCodeGlob.value(),
     ));
 
+    widget.onRtcEngineInitialized?.call();
+
     try {
       await _engine.enableVideo();
       await _engine.startPreview();
@@ -77,6 +83,38 @@ class _RenderViewWidgetState extends State<_RenderViewWidget> {
   }
 }
 
+class FakeGlobalVideoViewController {
+  FakeGlobalVideoViewController(
+      this.rtcEngine, this.testDefaultBinaryMessenger) {
+    testDefaultBinaryMessenger.setMockMethodCallHandler(
+        rtcEngine.globalVideoViewController.methodChannel, ((message) async {
+      methodCallQueue.add(message);
+
+      if (message.method == 'createTextureRender') {
+        return 1000;
+      }
+
+      return 0;
+    }));
+  }
+
+  final RtcEngine rtcEngine;
+
+  final TestDefaultBinaryMessenger testDefaultBinaryMessenger;
+
+  final List<MethodCall> methodCallQueue = [];
+
+  void reset() {
+    methodCallQueue.clear();
+  }
+
+  void dispose() {
+    testDefaultBinaryMessenger.setMockMethodCallHandler(
+        rtcEngine.globalVideoViewController.methodChannel, null);
+    reset();
+  }
+}
+
 void testCases() {
   group('Test with FakeIrisMethodChannel', () {
     final FakeIrisMethodChannel irisMethodChannel =
@@ -88,240 +126,571 @@ void testCases() {
       irisMethodChannel.reset();
     });
 
-    testWidgets(
-      'Show local AgoraVideoView after RtcEngine.initialize',
-      (WidgetTester tester) async {
-        final videoViewCreatedCompleter = Completer<void>();
+    group(
+      'PlatformView rendering',
+      () {
+        testWidgets(
+          'Show local AgoraVideoView after RtcEngine.initialize',
+          (WidgetTester tester) async {
+            final videoViewCreatedCompleter = Completer<void>();
 
-        await tester.pumpWidget(_RenderViewWidget(
-          rtcEngine: rtcEngine,
-          builder: (context, engine) {
-            return SizedBox(
-              height: 100,
-              width: 100,
-              child: AgoraVideoView(
-                controller: VideoViewController(
-                  rtcEngine: engine,
-                  canvas: const VideoCanvas(uid: 0),
-                ),
-                onAgoraVideoViewCreated: (viewId) {
-                  if (!videoViewCreatedCompleter.isCompleted) {
-                    videoViewCreatedCompleter.complete(null);
-                  }
-                },
-              ),
-            );
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return SizedBox(
+                  height: 100,
+                  width: 100,
+                  child: AgoraVideoView(
+                    controller: VideoViewController(
+                      rtcEngine: engine,
+                      canvas: const VideoCanvas(uid: 0),
+                    ),
+                    onAgoraVideoViewCreated: (viewId) {
+                      if (!videoViewCreatedCompleter.isCompleted) {
+                        videoViewCreatedCompleter.complete(null);
+                      }
+                    },
+                  ),
+                );
+              },
+            ));
+
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            await videoViewCreatedCompleter.future;
+
+            final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
+                .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                .toList();
+
+            final jsonMap2 = jsonDecode(setupLocalVideoCalls[0].params);
+            expect(jsonMap2['canvas']['view'] != 0, isTrue);
+
+            await tester.pumpWidget(Container());
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            // Delay 5 seconds to ensure that previous Widget.dipose call completed.
+            await Future.delayed(const Duration(seconds: 5));
+
+            expect(find.byType(AgoraVideoView), findsNothing);
+
+            // Check `VideoViewControllerBaseMixin`'s `disposeRender` called
+            final disposeLocalVideoCalls = irisMethodChannel.methodCallQueue
+                .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                .toList();
+
+            final disposeLocalVideoCallsJsonMap =
+                jsonDecode(disposeLocalVideoCalls[1].params);
+            expect(
+                disposeLocalVideoCallsJsonMap['canvas']['view'] == 0, isTrue);
           },
-        ));
-
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-        // pumpAndSettle again to ensure the `AgoraVideoView` shown
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-
-        await videoViewCreatedCompleter.future;
-
-        final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
-            .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
-            .toList();
-
-        final jsonMap2 = jsonDecode(setupLocalVideoCalls[0].params);
-        expect(jsonMap2['canvas']['view'] != 0, isTrue);
-
-        await tester.pumpWidget(Container());
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-
-        // Delay 5 seconds to ensure that previous Widget.dipose call completed.
-        await Future.delayed(const Duration(seconds: 5));
-
-        expect(find.byType(AgoraVideoView), findsNothing);
-
-        // Check `VideoViewControllerBaseMixin`'s `disposeRender` called
-        final disposeLocalVideoCalls = irisMethodChannel.methodCallQueue
-            .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
-            .toList();
-
-        final disposeLocalVideoCallsJsonMap =
-            jsonDecode(disposeLocalVideoCalls[1].params);
-        expect(disposeLocalVideoCallsJsonMap['canvas']['view'] == 0, isTrue);
-      },
-      skip: !(Platform.isAndroid || Platform.isIOS),
-    );
-
-    testWidgets(
-      'Show/Dispose local AgoraVideoView multiple times with a reused VideoViewController',
-      (WidgetTester tester) async {
-        VideoViewController videoViewController = VideoViewController(
-          rtcEngine: rtcEngine,
-          canvas: const VideoCanvas(uid: 0),
         );
 
-        for (int i = 0; i < 5; i++) {
-          irisMethodChannel.reset();
-          expect(irisMethodChannel.methodCallQueue.isEmpty, isTrue);
+        testWidgets(
+          'Show/Dispose local AgoraVideoView multiple times with a reused VideoViewController',
+          (WidgetTester tester) async {
+            VideoViewController videoViewController = VideoViewController(
+              rtcEngine: rtcEngine,
+              canvas: const VideoCanvas(uid: 0),
+            );
 
-          final videoViewCreatedCompleter = Completer<void>();
+            for (int i = 0; i < 5; i++) {
+              irisMethodChannel.reset();
+              expect(irisMethodChannel.methodCallQueue.isEmpty, isTrue);
 
-          await tester.pumpWidget(_RenderViewWidget(
-            rtcEngine: rtcEngine,
-            builder: (context, engine) {
-              return SizedBox(
-                height: 100,
-                width: 100,
-                child: AgoraVideoView(
-                  controller: videoViewController,
-                  onAgoraVideoViewCreated: (viewId) {
-                    if (!videoViewCreatedCompleter.isCompleted) {
-                      videoViewCreatedCompleter.complete(null);
-                    }
-                  },
-                ),
-              );
-            },
-          ));
+              final videoViewCreatedCompleter = Completer<void>();
 
-          await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-          // pumpAndSettle again to ensure the `AgoraVideoView` shown
-          await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+              await tester.pumpWidget(_RenderViewWidget(
+                rtcEngine: rtcEngine,
+                builder: (context, engine) {
+                  return SizedBox(
+                    height: 100,
+                    width: 100,
+                    child: AgoraVideoView(
+                      controller: videoViewController,
+                      onAgoraVideoViewCreated: (viewId) {
+                        if (!videoViewCreatedCompleter.isCompleted) {
+                          videoViewCreatedCompleter.complete(null);
+                        }
+                      },
+                    ),
+                  );
+                },
+              ));
 
-          await videoViewCreatedCompleter.future;
+              await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+              // pumpAndSettle again to ensure the `AgoraVideoView` shown
+              await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-          final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
-              .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
-              .toList();
+              await videoViewCreatedCompleter.future;
 
-          final jsonMap2 = jsonDecode(setupLocalVideoCalls[0].params);
-          expect(jsonMap2['canvas']['view'] != 0, isTrue);
+              final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                  .toList();
 
-          await tester.pumpWidget(Container());
-          await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+              final jsonMap2 = jsonDecode(setupLocalVideoCalls[0].params);
+              expect(jsonMap2['canvas']['view'] != 0, isTrue);
 
-          // Delay 5 seconds to ensure that previous Widget.dipose call completed.
-          await Future.delayed(const Duration(seconds: 5));
+              await tester.pumpWidget(Container());
+              await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-          expect(find.byType(AgoraVideoView), findsNothing);
+              // Delay 5 seconds to ensure that previous Widget.dipose call completed.
+              await Future.delayed(const Duration(seconds: 5));
 
-          // Check `VideoViewControllerBaseMixin`'s `disposeRender` called
-          final disposeLocalVideoCalls = irisMethodChannel.methodCallQueue
-              .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
-              .toList();
+              expect(find.byType(AgoraVideoView), findsNothing);
 
-          final disposeLocalVideoCallsJsonMap =
-              jsonDecode(disposeLocalVideoCalls[1].params);
-          expect(disposeLocalVideoCallsJsonMap['canvas']['view'] == 0, isTrue);
-        }
+              // Check `VideoViewControllerBaseMixin`'s `disposeRender` called
+              final disposeLocalVideoCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                  .toList();
+
+              final disposeLocalVideoCallsJsonMap =
+                  jsonDecode(disposeLocalVideoCalls[1].params);
+              expect(
+                  disposeLocalVideoCallsJsonMap['canvas']['view'] == 0, isTrue);
+            }
+          },
+        );
+
+        testWidgets(
+          'Switch local/remote AgoraVideoView with RtcConnection',
+          (WidgetTester tester) async {
+            // This case run this following steps:
+            // 1. Show a local `AgoraVideoView`.
+            // 2. Show local and remote `AgoraVideoView`, this step will trigger the `State.didUpdateWidget`.
+            // 3. Switch the local and remote `AgoraVideoView`.
+
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
+
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            // Check `setupLocalVideo` calls
+            {
+              final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                  .toList();
+
+              final jsonMap2 = jsonDecode(setupLocalVideoCalls[0].params);
+              expect(jsonMap2['canvas']['view'] != 0, isTrue);
+            }
+
+            // Clear the methodCall records
+            irisMethodChannel.reset();
+
+            // This step will call `didUpdateWidget`
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController.remote(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 1000),
+                          connection: const RtcConnection(
+                            channelId: 'switch_video_view',
+                            localUid: 1000,
+                          ),
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
+
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            if (defaultTargetPlatform == TargetPlatform.android) {
+              expect(find.byType(AndroidView), findsNWidgets(2));
+            }
+
+            if (defaultTargetPlatform == TargetPlatform.iOS) {
+              expect(find.byType(UiKitView), findsNWidgets(2));
+            }
+
+            // Check `setupRemoteVideoEx` calls
+            {
+              final setupRemoteVideoExCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngineEx_setupRemoteVideoEx')
+                  .toList();
+
+              final jsonMap1 = jsonDecode(setupRemoteVideoExCalls[0].params);
+              expect(jsonMap1['canvas']['view'] != 0, isTrue);
+            }
+
+            // Clear the methodCall records
+            irisMethodChannel.reset();
+
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController.remote(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 1000),
+                          connection: const RtcConnection(
+                            channelId: 'switch_video_view',
+                            localUid: 1000,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
+
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            if (defaultTargetPlatform == TargetPlatform.android) {
+              expect(find.byType(AndroidView), findsNWidgets(2));
+            }
+            if (defaultTargetPlatform == TargetPlatform.iOS) {
+              expect(find.byType(UiKitView), findsNWidgets(2));
+            }
+
+            // Check `setupLocalVideo` calls
+            {
+              final setupLocalVideoCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngine_setupLocalVideo')
+                  .toList();
+
+              final jsonMap1 = jsonDecode(setupLocalVideoCalls[0].params);
+              expect(jsonMap1['canvas']['view'] == 0, isTrue);
+
+              final jsonMap2 = jsonDecode(setupLocalVideoCalls[1].params);
+              expect(jsonMap2['canvas']['view'] != 0, isTrue);
+            }
+
+            // Check `setupRemoteVideoEx` calls
+            {
+              final setupRemoteVideoExCalls = irisMethodChannel.methodCallQueue
+                  .where((e) => e.funcName == 'RtcEngineEx_setupRemoteVideoEx')
+                  .toList();
+
+              final jsonMap1 = jsonDecode(setupRemoteVideoExCalls[0].params);
+              expect(jsonMap1['canvas']['view'] == 0, isTrue);
+
+              final jsonMap2 = jsonDecode(setupRemoteVideoExCalls[1].params);
+              expect(jsonMap2['canvas']['view'] != 0, isTrue);
+            }
+
+            await tester.pumpWidget(Container());
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            await Future.delayed(const Duration(seconds: 5));
+          },
+        );
       },
       skip: !(Platform.isAndroid || Platform.isIOS),
     );
 
-    testWidgets(
-      'Switch local/remote AgoraVideoView with RtcConnection',
-      (WidgetTester tester) async {
-        await tester.pumpWidget(_RenderViewWidget(
-          rtcEngine: rtcEngine,
-          builder: (context, engine) {
-            return Column(
-              children: [
-                SizedBox(
-                  height: 100,
-                  width: 100,
-                  child: AgoraVideoView(
-                    controller: VideoViewController(
-                      rtcEngine: engine,
-                      canvas: const VideoCanvas(uid: 0),
-                    ),
-                  ),
-                ),
-                SizedBox(
-                  height: 100,
-                  width: 100,
-                  child: AgoraVideoView(
-                    controller: VideoViewController.remote(
-                      rtcEngine: engine,
-                      canvas: const VideoCanvas(uid: 1000),
-                      connection: const RtcConnection(
-                        channelId: 'switch_video_view',
-                        localUid: 1000,
-                      ),
-                    ),
-                  ),
-                )
-              ],
-            );
-          },
-        ));
+    // TODO(littlegnal): The texture rendering test case are crash, since it need to call the 
+    // real `IrisMethodChannel` implementation, but not just implement a fake `GlobalVideoViewController`. 
+    // Need figure it out how to re-enable these test cases it the future.
+    //
+    // group(
+    //   'Texture Rendering',
+    //   () {
+    //     testWidgets(
+    //       'Show local AgoraVideoView after RtcEngine.initialize',
+    //       (WidgetTester tester) async {
+    //         late FakeGlobalVideoViewController fakeGlobalVideoViewController;
 
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-        // pumpAndSettle again to ensure the `AgoraVideoView` shown
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    //         final videoViewCreatedCompleter = Completer<void>();
 
-        if (defaultTargetPlatform == TargetPlatform.android) {
-          expect(find.byType(AndroidView), findsNWidgets(2));
-        }
+    //         print('1111');
 
-        if (defaultTargetPlatform == TargetPlatform.iOS) {
-          expect(find.byType(UiKitView), findsNWidgets(2));
-        }
+    //         await tester.pumpWidget(_RenderViewWidget(
+    //           rtcEngine: rtcEngine,
+    //           onRtcEngineInitialized: () {
+    //             fakeGlobalVideoViewController = FakeGlobalVideoViewController(
+    //               rtcEngine,
+    //               tester.binding.defaultBinaryMessenger,
+    //             );
+    //           },
+    //           builder: (context, engine) {
+    //             return SizedBox(
+    //               height: 100,
+    //               width: 100,
+    //               child: AgoraVideoView(
+    //                 controller: VideoViewController(
+    //                   rtcEngine: engine,
+    //                   canvas: const VideoCanvas(uid: 0),
+    //                   useFlutterTexture: true,
+    //                 ),
+    //                 onAgoraVideoViewCreated: (viewId) {
+    //                   if (!videoViewCreatedCompleter.isCompleted) {
+    //                     videoViewCreatedCompleter.complete(null);
+    //                   }
+    //                 },
+    //               ),
+    //             );
+    //           },
+    //         ));
 
-        // Clear the methodCall records
-        irisMethodChannel.reset();
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-        await tester.pumpWidget(_RenderViewWidget(
-          rtcEngine: rtcEngine,
-          builder: (context, engine) {
-            return Column(
-              children: [
-                SizedBox(
-                  height: 100,
-                  width: 100,
-                  child: AgoraVideoView(
-                    controller: VideoViewController.remote(
-                      rtcEngine: engine,
-                      canvas: const VideoCanvas(uid: 1000),
-                      connection: const RtcConnection(
-                        channelId: 'switch_video_view',
-                        localUid: 1000,
-                      ),
-                    ),
-                  ),
-                ),
-                SizedBox(
-                  height: 100,
-                  width: 100,
-                  child: AgoraVideoView(
-                    controller: VideoViewController(
-                      rtcEngine: engine,
-                      canvas: const VideoCanvas(uid: 0),
-                    ),
-                  ),
-                )
-              ],
-            );
-          },
-        ));
+    //         await videoViewCreatedCompleter.future;
 
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-        if (defaultTargetPlatform == TargetPlatform.android) {
-          expect(find.byType(AndroidView), findsNWidgets(2));
-        }
-        if (defaultTargetPlatform == TargetPlatform.iOS) {
-          expect(find.byType(UiKitView), findsNWidgets(2));
-        }
+    //         print('videoViewCreatedCompleter.future completed');
 
-        final setupRemoteVideoExCalls = irisMethodChannel.methodCallQueue
-            .where((e) => e.funcName == 'RtcEngineEx_setupRemoteVideoEx')
-            .toList();
+    //         {
+    //           final createTextureRenderCalls = fakeGlobalVideoViewController
+    //               .methodCallQueue
+    //               .where((e) => e.method == 'createTextureRender')
+    //               .toList();
 
-        final jsonMap1 = jsonDecode(setupRemoteVideoExCalls[0].params);
-        expect(jsonMap1['canvas']['view'] == 0, isTrue);
+    //           final createTextureRenderArg = Map<String, Object>.from(
+    //               createTextureRenderCalls[0].arguments);
 
-        final jsonMap2 = jsonDecode(setupRemoteVideoExCalls[1].params);
-        expect(jsonMap2['canvas']['view'] != 0, isTrue);
+    //           expect(createTextureRenderArg['uid'] == 0, isTrue);
+    //         }
 
-        await tester.pumpWidget(Container());
-        await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-        await Future.delayed(const Duration(seconds: 5));
-      },
-      skip: !(Platform.isAndroid || Platform.isIOS),
-    );
+    //         fakeGlobalVideoViewController.reset();
+
+    //         await tester.pumpWidget(Container());
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+    //         // Delay 5 seconds to ensure that previous Widget.dipose call completed.
+    //         await Future.delayed(const Duration(seconds: 5));
+
+    //         {
+    //           final disposeTextureRenderCalls = fakeGlobalVideoViewController
+    //               .methodCallQueue
+    //               .where((e) => e.method == 'destroyTextureRender')
+    //               .toList();
+
+    //           // texture id
+    //           final disposeTextureRenderTextureId =
+    //               disposeTextureRenderCalls[0].arguments as int;
+
+    //           expect(disposeTextureRenderTextureId != 0, isTrue);
+    //         }
+
+    //         fakeGlobalVideoViewController.dispose();
+    //       },
+    //     );
+
+    //     testWidgets(
+    //       'Switch local/remote AgoraVideoView with RtcConnection',
+    //       (WidgetTester tester) async {
+    //         // This case run this following steps:
+    //         // 1. Show a local `AgoraVideoView`.
+    //         // 2. Show local and remote `AgoraVideoView`, this step will trigger the `State.didUpdateWidget`.
+    //         // 3. Switch the local and remote `AgoraVideoView`.
+
+    //         late FakeGlobalVideoViewController fakeGlobalVideoViewController;
+
+    //         await tester.pumpWidget(_RenderViewWidget(
+    //           rtcEngine: rtcEngine,
+    //           onRtcEngineInitialized: () {
+    //             fakeGlobalVideoViewController = FakeGlobalVideoViewController(
+    //               rtcEngine,
+    //               tester.binding.defaultBinaryMessenger,
+    //             );
+    //           },
+    //           builder: (context, engine) {
+    //             return Column(
+    //               children: [
+    //                 SizedBox(
+    //                   height: 100,
+    //                   width: 100,
+    //                   child: AgoraVideoView(
+    //                     controller: VideoViewController(
+    //                       rtcEngine: engine,
+    //                       canvas: const VideoCanvas(uid: 0),
+    //                       useFlutterTexture: true,
+    //                     ),
+    //                   ),
+    //                 )
+    //               ],
+    //             );
+    //           },
+    //         ));
+
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+    //         // Check `GlobalVideoViewController.createTextureRender` calls
+    //         {
+    //           final createTextureRenderCalls = fakeGlobalVideoViewController
+    //               .methodCallQueue
+    //               .where((e) => e.method == 'createTextureRender')
+    //               .toList();
+
+    //           final createTextureRenderArg = Map<String, Object>.from(
+    //               createTextureRenderCalls[0].arguments);
+
+    //           expect(createTextureRenderArg['uid'] == 0, isTrue);
+    //         }
+
+    //         // Clear the methodCall records
+    //         fakeGlobalVideoViewController.reset();
+
+    //         // This step will call `didUpdateWidget`
+    //         await tester.pumpWidget(_RenderViewWidget(
+    //           rtcEngine: rtcEngine,
+    //           builder: (context, engine) {
+    //             return Column(
+    //               children: [
+    //                 SizedBox(
+    //                   height: 100,
+    //                   width: 100,
+    //                   child: AgoraVideoView(
+    //                     controller: VideoViewController(
+    //                       rtcEngine: engine,
+    //                       canvas: const VideoCanvas(uid: 0),
+    //                       useFlutterTexture: true,
+    //                     ),
+    //                   ),
+    //                 ),
+    //                 SizedBox(
+    //                   height: 100,
+    //                   width: 100,
+    //                   child: AgoraVideoView(
+    //                     controller: VideoViewController.remote(
+    //                       rtcEngine: engine,
+    //                       canvas: const VideoCanvas(uid: 1000),
+    //                       connection: const RtcConnection(
+    //                         channelId: 'switch_video_view',
+    //                         localUid: 1000,
+    //                       ),
+    //                       useFlutterTexture: true,
+    //                     ),
+    //                   ),
+    //                 )
+    //               ],
+    //             );
+    //           },
+    //         ));
+
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+    //         // Check `GlobalVideoViewController.createTextureRender` calls for remote `AgoraVideoView`
+    //         {
+    //           final createTextureRenderCalls = fakeGlobalVideoViewController
+    //               .methodCallQueue
+    //               .where((e) => e.method == 'createTextureRender')
+    //               .toList();
+
+    //           final createTextureRenderArg = Map<String, Object>.from(
+    //               createTextureRenderCalls[0].arguments);
+
+    //           expect(createTextureRenderArg['uid'] != 0, isTrue);
+    //         }
+
+    //         // Clear the methodCall records
+    //         fakeGlobalVideoViewController.reset();
+
+    //         await tester.pumpWidget(_RenderViewWidget(
+    //           rtcEngine: rtcEngine,
+    //           builder: (context, engine) {
+    //             return Column(
+    //               children: [
+    //                 SizedBox(
+    //                   height: 100,
+    //                   width: 100,
+    //                   child: AgoraVideoView(
+    //                     controller: VideoViewController.remote(
+    //                       rtcEngine: engine,
+    //                       canvas: const VideoCanvas(uid: 1000),
+    //                       connection: const RtcConnection(
+    //                         channelId: 'switch_video_view',
+    //                         localUid: 1000,
+    //                       ),
+    //                       useFlutterTexture: true,
+    //                     ),
+    //                   ),
+    //                 ),
+    //                 SizedBox(
+    //                   height: 100,
+    //                   width: 100,
+    //                   child: AgoraVideoView(
+    //                     controller: VideoViewController(
+    //                       rtcEngine: engine,
+    //                       canvas: const VideoCanvas(uid: 0),
+    //                       useFlutterTexture: true,
+    //                     ),
+    //                   ),
+    //                 )
+    //               ],
+    //             );
+    //           },
+    //         ));
+
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+    //         // When switch the local and remote `AgoraVideoView`, which will trigger the
+    //         // `State.didUpdateWidget`, so there're no method call records here.
+    //         expect(
+    //             fakeGlobalVideoViewController.methodCallQueue.isEmpty, isTrue);
+
+    //         fakeGlobalVideoViewController.dispose();
+
+    //         await tester.pumpWidget(Container());
+    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+    //         await Future.delayed(const Duration(seconds: 5));
+    //       },
+    //     );
+    //   },
+    //   skip: Platform.isAndroid,
+    // );
   });
 }


### PR DESCRIPTION
When the `AgoraVideoView`s are reused, say that the parent widget call `setState` many times(trigger `build` function), 
the `VideoViewController` with the same config (`VideoCanvas`, `RtcConntection`, ...) does not keep updated to date.

Add a new function `VideoViewControllerBaseMixin.updateController ` to update the states from the old `VideoViewController` in the `State.didUpdateWidget`.