### PR TITLE
fix: Fix MediaRecorder.startRecording return -4 after the previous destroy

### DIFF
--- a/example/lib/examples/advanced/media_recorder/media_recorder.dart
+++ b/example/lib/examples/advanced/media_recorder/media_recorder.dart
@@ -44,9 +44,6 @@ class _State extends State<MediaRecorderExample> {
   }
 
   Future<void> _dispose() async {
-    if (_mediaRecorder != null) {
-      await _engine.destroyMediaRecorder(_mediaRecorder!);
-    }
     await _engine.release();
   }
 
@@ -146,7 +143,11 @@ class _State extends State<MediaRecorderExample> {
   }
 
   Future<void> _stopMediaRecording() async {
-    await _mediaRecorder?.stopRecording();
+    if (_mediaRecorder != null) {
+      await _mediaRecorder!.stopRecording();
+      await _engine.destroyMediaRecorder(_mediaRecorder!);
+      _mediaRecorder = null;
+    }
     setState(() {
       _recordingFileStoragePath = '';
       _isStartedMediaRecording = false;

--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -1038,6 +1038,8 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
   Future<void> destroyMediaRecorder(MediaRecorder mediaRecorder) async {
     final impl = mediaRecorder as media_recorder_impl.MediaRecorderImpl;
 
+    await impl.dispose();
+
     final apiType =
         '${isOverrideClassName ? className : 'RtcEngine'}_destroyMediaRecorder';
     final param = createParams({'nativeHandle': impl.strNativeHandle});

--- a/test_shard/integration_test_app/integration_test/fake_apis_call_integration_test.dart
+++ b/test_shard/integration_test_app/integration_test/fake_apis_call_integration_test.dart
@@ -1,0 +1,9 @@
+import 'package:integration_test/integration_test.dart';
+
+import 'testcases/mediarecorder_fake_test_testcases.dart' as fake_mediarecorder;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  fake_mediarecorder.testCases();
+}

--- a/test_shard/integration_test_app/integration_test/testcases/mediarecorder_fake_test_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/mediarecorder_fake_test_testcases.dart
@@ -1,0 +1,132 @@
+import 'package:agora_rtc_engine/agora_rtc_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:agora_rtc_engine/src/impl/native_iris_api_engine_binding_delegate.dart';
+import '../fake/fake_iris_method_channel.dart';
+import 'package:agora_rtc_engine/src/impl/agora_rtc_engine_impl.dart';
+import 'package:iris_method_channel/iris_method_channel.dart';
+
+class MediaRecorderFakeIrisMethodChannel extends FakeIrisMethodChannel {
+  MediaRecorderFakeIrisMethodChannel(NativeBindingsProvider provider)
+      : super(provider);
+
+  @override
+  Future<CallApiResult> invokeMethod(IrisMethodCall methodCall) async {
+    final result = super.invokeMethod(methodCall);
+    if (methodCall.funcName == 'RtcEngine_createMediaRecorder') {
+      return CallApiResult(data: {'result': '1000'}, irisReturnCode: 0);
+    }
+
+    return result;
+  }
+
+  Future<CallApiResult> registerEventHandler(
+      ScopedEvent scopedEvent, String params) async {
+    IrisMethodCall methodCall =
+        IrisMethodCall(scopedEvent.registerName, params);
+
+    return invokeMethod(methodCall);
+  }
+
+  Future<CallApiResult> unregisterEventHandler(
+      ScopedEvent scopedEvent, String params) async {
+    IrisMethodCall methodCall =
+        IrisMethodCall(scopedEvent.unregisterName, params);
+
+    return invokeMethod(methodCall);
+  }
+}
+
+void testCases() {
+  bool _isCallOnce(
+      MediaRecorderFakeIrisMethodChannel irisMethodChannel, String apiName) {
+    final calls = irisMethodChannel.methodCallQueue
+        .where((e) => e.funcName == apiName)
+        .toList();
+
+    return calls.length == 1;
+  }
+
+  group('FakeIrisMethodChannel integration test', () {
+    final MediaRecorderFakeIrisMethodChannel irisMethodChannel =
+        MediaRecorderFakeIrisMethodChannel(
+            IrisApiEngineNativeBindingDelegateProvider());
+    final RtcEngine rtcEngine =
+        RtcEngineImpl.create(irisMethodChannel: irisMethodChannel);
+
+    setUp(() {
+      irisMethodChannel.reset();
+    });
+
+    testWidgets(
+      'can call startRecording after previous MediaRecorder destroy',
+      (WidgetTester tester) async {
+        String engineAppId = const String.fromEnvironment('TEST_APP_ID',
+            defaultValue: '<YOUR_APP_ID>');
+
+        await rtcEngine.initialize(RtcEngineContext(
+          appId: engineAppId,
+          areaCode: AreaCode.areaCodeGlob.value(),
+        ));
+
+        MediaRecorder? recorder = await rtcEngine.createMediaRecorder(
+            const RecorderStreamInfo(channelId: 'test', uid: 0));
+        recorder?.setMediaRecorderObserver(MediaRecorderObserver(
+          onRecorderStateChanged: (channelId, uid, state, error) {},
+        ));
+        await recorder?.startRecording(
+            const MediaRecorderConfiguration(storagePath: 'path'));
+        await recorder?.stopRecording();
+        await rtcEngine.destroyMediaRecorder(recorder!);
+
+        expect(_isCallOnce(irisMethodChannel, 'RtcEngine_createMediaRecorder'),
+            isTrue);
+        expect(
+            _isCallOnce(
+                irisMethodChannel, 'MediaRecorder_setMediaRecorderObserver'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'MediaRecorder_startRecording'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'MediaRecorder_stopRecording'),
+            isTrue);
+        // When `RtcEngine.destroyMediaRecorder` is called, will call `MediaRecorderImpl.dispose`
+        expect(
+            _isCallOnce(
+                irisMethodChannel, 'MediaRecorder_unsetMediaRecorderObserver'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'RtcEngine_destroyMediaRecorder'),
+            isTrue);
+
+        irisMethodChannel.reset();
+
+        recorder = await rtcEngine.createMediaRecorder(
+            const RecorderStreamInfo(channelId: 'test', uid: 0));
+        recorder?.setMediaRecorderObserver(MediaRecorderObserver(
+          onRecorderStateChanged: (channelId, uid, state, error) {},
+        ));
+        await recorder?.startRecording(
+            const MediaRecorderConfiguration(storagePath: 'path'));
+        await recorder?.stopRecording();
+        await rtcEngine.destroyMediaRecorder(recorder!);
+
+        expect(_isCallOnce(irisMethodChannel, 'RtcEngine_createMediaRecorder'),
+            isTrue);
+        expect(
+            _isCallOnce(
+                irisMethodChannel, 'MediaRecorder_setMediaRecorderObserver'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'MediaRecorder_startRecording'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'MediaRecorder_stopRecording'),
+            isTrue);
+        // When `RtcEngine.destroyMediaRecorder` is called, will call `MediaRecorderImpl.dispose`
+        expect(
+            _isCallOnce(
+                irisMethodChannel, 'MediaRecorder_unsetMediaRecorderObserver'),
+            isTrue);
+        expect(_isCallOnce(irisMethodChannel, 'RtcEngine_destroyMediaRecorder'),
+            isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
`RtcEngine.destroyMediaRecorder` does not trigger `MediaRecorderImpl.dispose`, causing the newly created `MediaRecorder`'s `setMediaRecorderObserver` not to be called, causing the newly created `MediaRecorder`'s `startRecording` return -4.

Issue https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/issues/1190