### PR TITLE
fix: [android] Fix reset the log file in RtcEngine.initialize cause incorrect log file path

### DIFF
--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -259,11 +259,8 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
     _initializingCompleter = Completer<void>();
     engineMethodChannel = const MethodChannel('agora_rtc_ng');
 
-    String externalFilesDir = '';
     if (defaultTargetPlatform == TargetPlatform.android) {
-      final androidInitResult =
-          await engineMethodChannel.invokeMethod('androidInit');
-      externalFilesDir = androidInitResult['externalFilesDir'] ?? '';
+      await engineMethodChannel.invokeMethod('androidInit');
     }
 
     List<int> args = [];
@@ -283,16 +280,6 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
       'RtcEngine_setAppType',
       jsonEncode({'appType': 4}),
     ));
-
-    if (externalFilesDir.isNotEmpty) {
-      try {
-        // Reset the sdk log file to ensure the iris log path has been set
-        await setLogFile('$externalFilesDir/agorasdk.log');
-      } catch (e) {
-        debugPrint(
-            '[RtcEngine] setLogFile fail, make sure the permission is granted.');
-      }
-    }
 
     _rtcEngineState.isInitialzed = true;
     _isReleased = false;

--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -35,8 +35,7 @@ import 'package:agora_rtc_engine/src/impl/native_iris_api_engine_binding_delegat
 import 'package:flutter/foundation.dart'
     show ChangeNotifier, defaultTargetPlatform;
 import 'package:flutter/services.dart' show MethodChannel;
-import 'package:flutter/widgets.dart'
-    show VoidCallback, TargetPlatform, debugPrint;
+import 'package:flutter/widgets.dart' show VoidCallback, TargetPlatform;
 import 'package:iris_method_channel/iris_method_channel.dart';
 import 'package:meta/meta.dart';
 


### PR DESCRIPTION
After upgrading the native sdk 4.2.0, iris fixed the iris log path that can not be set when initialization in Android. So it's not necessary to call the `setLogFile ` inside the `RtcEngine.initialize` again, or it cause the incorrect log file path.