### PR TITLE
[ci] Move back ios rendering test to cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,6 +41,35 @@ android_integratinon_test_task:
     - flutter doctor -v
     - bash ci/run_flutter_integration_test_android.sh
 
+android_build_task:
+  <<: *default_filters
+  <<: *default_macos_container
+
+  matrix:
+    - name: FLUTTER_VERSION 2.10.5
+      env:
+        FLUTTER_VERSION: 2.10.5
+    - name: FLUTTER_VERSION 3.7.0
+      env:
+        FLUTTER_VERSION: 3.7.0
+  switch_flutter_version_script:
+    - cd ${MACOS_HOST_FLUTTER_SDK_DIR}
+    - git fetch
+    - git checkout ${FLUTTER_VERSION} && flutter precache
+
+  build_android_x86_64_script:
+    - cd example
+    - arch -x86_64 flutter doctor -v
+    - arch -x86_64 flutter packages get
+    - arch -x86_64 flutter build apk
+
+  build_android_arm64_script:
+    - cd example
+    - flutter doctor -v
+    - flutter clean
+    - flutter packages get
+    - flutter build apk
+
 ios_rendering_test_task:
   <<: *default_filters
   <<: *default_macos_container

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,37 +41,22 @@ android_integratinon_test_task:
     - flutter doctor -v
     - bash ci/run_flutter_integration_test_android.sh
 
-android_build_task:
+ios_rendering_test_task:
   <<: *default_filters
   <<: *default_macos_container
 
-  matrix:
-    - name: FLUTTER_VERSION 2.10.5
-      env:
-        FLUTTER_VERSION: 2.10.5
-    - name: FLUTTER_VERSION 3.0.0
-      env:
-        FLUTTER_VERSION: 3.0.0
-    - name: FLUTTER_VERSION 3.3.0
-      env:
-        FLUTTER_VERSION: 3.3.0
-    - name: FLUTTER_VERSION 3.7.0
-      env:
-        FLUTTER_VERSION: 3.7.0
   switch_flutter_version_script:
+    - export FLUTTER_VERSION=3.0.0
     - cd ${MACOS_HOST_FLUTTER_SDK_DIR}
     - git fetch
     - git checkout ${FLUTTER_VERSION} && flutter precache
 
-  build_android_x86_64_script:
-    - cd example
-    - arch -x86_64 flutter doctor -v
-    - arch -x86_64 flutter packages get
-    - arch -x86_64 flutter build apk
+  create_ios_simulator_script:
+    - xcrun simctl list
+    # We generate the screenshots base on the simulator "iPhone 13 Pro Max", so we set the SimDeviceType to iPhone-13-Pro-Max.
+    # If you need to change the SimDeviceType, you may need to re-generate the screenshots first.
+    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-13-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-16-0 | xargs xcrun simctl boot
 
-  build_android_arm64_script:
-    - cd example
+  run_ios_test_script:
     - flutter doctor -v
-    - flutter clean
-    - flutter packages get
-    - flutter build apk
+    - bash ci/rendering_test_ios.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,47 +202,6 @@ jobs:
   #         disk-size: 8192M
   #         script: bash ci/rendering_test_android.sh
 
-  rendering_test_ios:
-    name: Run Flutter iOS Rendering Tests
-    strategy:
-      matrix:
-        version: ['3.0.0']
-    runs-on: macos-13 # Rendering test on ios simulator need macos 13+
-    timeout-minutes: 120
-    env:
-      TEST_APP_ID: ${{ secrets.MY_APP_ID }}
-    steps:
-      - uses: actions/checkout@v1
-      - uses: subosito/flutter-action@v1
-        with:
-          flutter-version: ${{ matrix.version }}
-      - name: Checkout hoe
-        uses: actions/checkout@v3
-        with:
-          repository: littleGnAl/hoe
-          ref: littlegnal/update
-          path: hoe
-      - name: Download iris artifacts
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'integration_test:iris_artifacts') }}
-        run: |
-          source scripts/artifacts_version.sh
-          PROJECT_DIR=$(pwd)
-          mkdir -p output
-          cd hoe
-          dart pub get
-          dart run bin/hoe.dart build-agora-flutter-example \
-            --setup-local-dev \
-            --project-dir=${PROJECT_DIR} \
-            --artifacts-output-dir=${PROJECT_DIR}/output \
-            --platforms=ios \
-            --apple-package-name=io.agora.agoraRtcEngineExample \
-            --flutter-package-name=agora_rtc_engine \
-            --iris-ios-cdn-url=${IRIS_CDN_URL_IOS}
-      - uses: futureware-tech/simulator-action@v2
-        with:
-          model: 'iPhone 14 Pro Max'
-      - run: bash ci/rendering_test_ios.sh
-
   rendering_test_macos:
     name: Run Flutter macOS Rendering Tests
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}


### PR DESCRIPTION
After moving the ios rendering test to github action runner period of time, we notice that the ios rendering test on github action runner is unstable. I am not sure if it causes by the `macos-13` not yet being stable or not. To avoid the CI block we process the test, we decide to move back the ios rendering test to cirrus ci at this time.

And only build the android with the min and latest flutter sdk on macOS VM to reduce the build time in cirrus ci.