### PR TITLE
fix: Add missing `NetworkType.networkTypeMobile5g`

### DIFF
--- a/lib/src/agora_base.dart
+++ b/lib/src/agora_base.dart
@@ -4247,6 +4247,10 @@ enum NetworkType {
   /// 5: The network type is mobile 4G.
   @JsonValue(5)
   networkTypeMobile4g,
+
+  /// 6: The network type is mobile 5G.
+  @JsonValue(6)
+  networkTypeMobile5g,
 }
 
 /// @nodoc

--- a/lib/src/agora_base.g.dart
+++ b/lib/src/agora_base.g.dart
@@ -2444,6 +2444,7 @@ const _$NetworkTypeEnumMap = {
   NetworkType.networkTypeMobile2g: 3,
   NetworkType.networkTypeMobile3g: 4,
   NetworkType.networkTypeMobile4g: 5,
+  NetworkType.networkTypeMobile5g: 6,
 };
 
 const _$AudioTrackTypeEnumMap = {

--- a/lib/src/binding/event_handler_param_json.g.dart
+++ b/lib/src/binding/event_handler_param_json.g.dart
@@ -1906,6 +1906,7 @@ const _$NetworkTypeEnumMap = {
   NetworkType.networkTypeMobile2g: 3,
   NetworkType.networkTypeMobile3g: 4,
   NetworkType.networkTypeMobile4g: 5,
+  NetworkType.networkTypeMobile5g: 6,
 };
 
 RtcEngineEventHandlerOnEncryptionErrorJson


### PR DESCRIPTION
Add 5G to available network types on Dart side to fix the argument error when method channel returns 6 from native side which corresponds to 5G.