### PR TITLE
[ci] Fix schedule-run-ci* not work as expected for external contributors

### DIFF
--- a/.github/workflows/schedule-run-ci-external.yml
+++ b/.github/workflows/schedule-run-ci-external.yml
@@ -28,30 +28,41 @@ jobs:
             const org = "AgoraIO-Extensions"
             const userName = "${{ github.event.pull_request.user.login }}"
 
-            // see https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            const response = await github.request('GET /orgs/{org}/members/{username}', {
-                org: org,
-                username: userName,
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-              })
+            let contributorStatus = -1; // unknown
 
-            console.log(`response: ${response.data}`);
-            if (response.status == 204) {
-                console.log(`Internal contributor: ${userName}`);
-            } else {
-                console.log(`External contributor: ${userName}`);
+            try {
+              // see https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+              const response = await github.request('GET /orgs/{org}/members/{username}', {
+                  org: org,
+                  username: userName,
+                  headers: {
+                    'X-GitHub-Api-Version': '2022-11-28'
+                  }
+                })
+
+              console.log(`response: ${response.data}`);
+              if (response.status == 204) {
+                  console.log(`Internal contributor: ${userName}`);
+              } else {
+                  console.log(`External contributor: ${userName}`);
+              }
+
+              // 0: internal contributors
+              // 1: external contributors
+              contributorStatus = response.status == 204 ? 0 : 1
+            } catch (error) {
+              console.log(`Error: ${error.message}`);
+              // 404 mean external contributors
+              contributorStatus = error.status == 404 ? 1 : contributorStatus
+              console.log(`contributorStatus: ${contributorStatus}`);
             }
 
-            // 0: internal contributors
-            // 1: external contributors
-            return response.status == 204 ? 0 : 1
+            return contributorStatus;
 
       - name: Remove label ci:schedule_run_ci if necessary
-        # If the external contributor (steps.check-contributors-result.outputs.result == 1) push a new commit (github.event.action == 'synchronize'), 
+        # If the external contributor (steps.check-contributors-result.outputs.result > 0) push a new commit (github.event.action == 'synchronize'), 
         # remove the label: ci:schedule_run_ci to avoid the contributor do some harmful things.
-        if: ${{ github.event.action == 'synchronize' && steps.check-contributors-result.outputs.result == 1 }}
+        if: ${{ github.event.action == 'synchronize' && steps.check-contributors-result.outputs.result > 0 }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.LABEL_ACTION_PAT }}

--- a/.github/workflows/schedule-run-ci-internal.yml
+++ b/.github/workflows/schedule-run-ci-internal.yml
@@ -9,24 +9,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:
-        is_schedule_run_ci: ${{ steps.check-label-step.outputs.result }}
+        is_schedule_run_ci: ${{ steps.check-label-step.outputs.is_schedule_run_ci }}
     steps:
       - name: Check for Secret availability
         id: check-label-step
         # perform secret check & put boolean result as an output
         shell: bash
         run: |
-          if [ "${{ secrets.MY_APP_ID }}" != '' ]; then
-            echo "is_schedule_run_ci=0" >> $GITHUB_OUTPUT;
-          else
+          APP_ID="${{ secrets.MY_APP_ID }}"
+          if [ ! -z "${APP_ID}" ]; then
             echo "is_schedule_run_ci=1" >> $GITHUB_OUTPUT;
+            echo "secrets.MY_APP_ID is not empty, PR opened by the internal contributors"
+          else
+            echo "is_schedule_run_ci=-1" >> $GITHUB_OUTPUT;
+            echo "secrets.MY_APP_ID is empty, PR opened by the external contributors"
           fi
 
   schedule_ci:
     name: Schedule run ci
     needs: check_permission
     # If the PR requested by a external contributor, the secrets.MY_APP_ID should be empty, and skip this workflow
-    if: ${{ needs.check_permission.outputs.is_schedule_run_ci == 0 }}
+    if: ${{ needs.check_permission.outputs.is_schedule_run_ci == 1 }}
     uses: ./.github/workflows/build.yml
     secrets:
       MY_APP_ID: ${{ secrets.MY_APP_ID }}


### PR DESCRIPTION
This PR fixes the following errors:
1. The `schedule-run-ci-internal` had run for external contributors
https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/5517948306/jobs/10061924087?pr=1205
2. The `schedule-run-ci-external` throw exception when checking the user status
https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/5518328576/jobs/10062123801?pr=1205