### PR TITLE
feat: upgrade native sdk dependencies 20230906

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.2-build.1'
-    api 'io.agora.rtc:full-sdk:4.2.2'
-    api 'io.agora.rtc:full-screen-sharing:4.2.2'
+    api 'io.agora.rtc:iris-rtc:4.2.2.1-build.2'
+    api 'io.agora.rtc:agora-special-full:4.2.2.1'
+    api 'io.agora.rtc:full-screen-sharing:4.2.2.1'
   }
 }
 

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.2-build.1'
-  s.dependency 'AgoraRtcEngine_iOS', '4.2.2'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.2.1-build.2'
+  s.dependency 'AgoraRtcEngine_Special_iOS', '4.2.2.1'
   end
   
   s.platform = :ios, '9.0'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.2-build.1_DCG_Android_Video_20230727_1158.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.2-build.1_DCG_iOS_Video_20230727_1200.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.2.1-build.2_DCG_Android_Video_20230906_1234.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.2.1-build.2_DCG_iOS_Video_20230906_1234.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.2-build.1_DCG_Mac_Video_20230727_1159.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.2-build.1_DCG_Windows_Video_20230727_1158.zip"


### PR DESCRIPTION
Update native sdk dependencies 20230906
native sdk dependencies:
```
【maven】 implementation 'io.agora.rtc:full-screen-sharing:4.2.2.1' implementation 'io.agora.rtc:agora-special-full:4.2.2.1'  pod 'AgoraRtcEngine_Special_iOS', '4.2.2.1'
```

iris dependencies:
```
Iris: CDN: https://download.agora.io/sdk/release/iris_4.2.2.1-build.2_DCG_Android_Video_20230906_1234.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.2.1-build.2'  Iris: CDN: https://download.agora.io/sdk/release/iris_4.2.2.1-build.2_DCG_iOS_Video_20230906_1234.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.2.1-build.2'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.