### PR TITLE
[ci] Add github workflow to auto close the inactivity PR of the daily doc update

### DIFF
--- a/.github/workflows/auto-close-daily-doc-update.yaml
+++ b/.github/workflows/auto-close-daily-doc-update.yaml
@@ -1,0 +1,25 @@
+name: Auto-close Stale Daily Doc Update Pull Requests
+
+on:
+  schedule:
+    - cron: '0 16 * * *'  # Runs daily at midnight Beijing time
+
+permissions:
+  contents: write # only for delete-branch option
+  pull-requests: write
+
+jobs:
+  close-stale-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Pull Requests
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-label: 'ci:doc'
+          stale-pr-message: 'This auto daily doc update PR is stale because it has been open for 3 days with no activity. Close.'
+          days-before-stale: 3
+          days-before-close: 0
+          remove-stale-when-updated: false
+          delete-branch: true
+          only-labels: 'ci:doc'


### PR DESCRIPTION
Auto-close the daily doc update PR rather than close it manually.