### PR TITLE
[ci] Add more-detial-wanted.yaml action

### DIFF
--- a/.github/workflows/more-detail-wanted.yaml
+++ b/.github/workflows/more-detail-wanted.yaml
@@ -1,0 +1,20 @@
+name: Ask the user for more detail of the issue
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'more detail wanted'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          
+          body: |
+            Please follow the [issue template](https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) to fill in more details about this issue so that we can investigate this issue more easily, thanks!
+            


### PR DESCRIPTION
Add an action to request more details of the issue by the github action bot.

When labeling the "more detail wanted", the bot will comment with the following message:
```
Please follow the [issue template](https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) to fill in more details about this issue so that we can investigate this issue more easily, thanks!
```