### PR TITLE
fix: [iOS/macOS] Fix CFBundleShortVersionString not correct in AgoraRtcWrapper framework

### DIFF
--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.3-build.3'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.3-build.4'
   s.dependency 'AgoraRtcEngine_iOS', '4.2.3'
   end
   

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -22,7 +22,7 @@ A new flutter plugin project.
     s.vendored_frameworks = 'libs/*.framework'
   else
   s.dependency 'AgoraRtcEngine_macOS', '4.2.3'
-  s.dependency 'AgoraIrisRTC_macOS', '4.2.3-build.3'
+  s.dependency 'AgoraIrisRTC_macOS', '4.2.3-build.4'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
 export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.3-build.3_DCG_Android_Video_20231012_0417.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.3-build.3_DCG_iOS_Video_20231012_0456.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.3-build.3_DCG_Mac_Video_20231012_0417.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.3-build.4_DCG_iOS_Video_20231019_0355.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.3-build.4_DCG_Mac_Video_20231019_0355.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.3-build.3_DCG_Windows_Video_20231012_0417.zip"


### PR DESCRIPTION
The `CFBundleShortVersionString` is not correct in `AgoraRtcWrapper` frameworks, cause the user can not submit the APP to the APP Store, which affects the iOS/macOS.

- Update `s.dependency 'AgoraIrisRTC_iOS', '4.2.3-build.4'`
- Update `s.dependency 'AgoraIrisRTC_macOS', '4.2.3-build.4'`

Fix https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/issues/1375