### PR TITLE
[ci][schedule-run-ci-internal] Add skip ci check

### DIFF
--- a/.github/workflows/schedule-run-ci-internal.yml
+++ b/.github/workflows/schedule-run-ci-internal.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   check_permission:
     name: Check permission
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:


### PR DESCRIPTION
Add `ci:skip` label check in `schedule-run-ci-internal.yaml` to avoid adding the label check in each step in `build.yaml`.