### PR TITLE
[ci] Fix the  daily update doc PR had been closed immediately in every schedule

### DIFF
--- a/.github/workflows/auto-close-daily-doc-update.yaml
+++ b/.github/workflows/auto-close-daily-doc-update.yaml
@@ -16,10 +16,9 @@ jobs:
         uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-pr-label: 'ci:doc'
           stale-pr-message: 'This auto daily doc update PR is stale because it has been open for 3 days with no activity. Close.'
-          days-before-stale: 3
-          days-before-close: 0
+          days-before-stale: 1
+          days-before-close: 1
           remove-stale-when-updated: false
           delete-branch: true
           only-labels: 'ci:doc'


### PR DESCRIPTION
The `stale-pr-label: 'ci:doc'` and `days-before-close: 0` will cause the PR to be closed immediately in every schedule. 

We need to remove the `stale-pr-label: 'ci:doc'` and let the action add the default `Stale` label, see https://github.com/actions/stale#stale-pr-label. Change the `days-before-stale: 1` and `days-before-close: 1`, now the PR will be closed in 2 days if it's stale.