### PR TITLE
[example][RgbaImage] Avoid use DecorderCallback which is removed after Flutter SDK 3.16

### DIFF
--- a/example/lib/components/rgba_image.dart
+++ b/example/lib/components/rgba_image.dart
@@ -1,62 +1,63 @@
-import 'dart:typed_data';
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
+import 'package:flutter/material.dart';
 
-class RgbaImage extends ImageProvider<RgbaImage> {
+class RgbaImage extends StatefulWidget {
+  const RgbaImage({
+    Key? key,
+    required this.bytes,
+    required this.width,
+    required this.height,
+    this.format = ui.PixelFormat.rgba8888,
+  }) : super(key: key);
+
   final Uint8List bytes;
   final int width;
   final int height;
-  final double scale;
+  final ui.PixelFormat format;
 
-  const RgbaImage(
-    this.bytes, {
-    required this.width,
-    required this.height,
-    this.scale = 1.0,
-  });
+  @override
+  State<RgbaImage> createState() => _RgbaImageState();
+}
 
-  Future<ui.Codec> _loadAsync(
-    RgbaImage key,
-    DecoderCallback decode,
-  ) async {
-    assert(key == this);
+class _RgbaImageState extends State<RgbaImage> {
+  ui.Image? _image;
 
-    final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
-    final descriptor = ui.ImageDescriptor.raw(
-      buffer,
-      width: width,
-      height: height,
-      pixelFormat: ui.PixelFormat.rgba8888,
-    );
-    return await descriptor.instantiateCodec();
+  Future<void> _loadImage() async {
+    final imageCompleter = Completer<ui.Image>();
+
+    ui.decodeImageFromPixels(
+        widget.bytes, widget.width, widget.height, widget.format, (result) {
+      imageCompleter.complete(result);
+    });
+
+    _image = await imageCompleter.future;
+    setState(() {});
   }
 
   @override
-  Future<RgbaImage> obtainKey(ImageConfiguration configuration) {
-    return SynchronousFuture<RgbaImage>(this);
+  void initState() {
+    super.initState();
+
+    _loadImage();
   }
 
   @override
-  bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType) return false;
-    return other is RgbaImage && other.bytes == bytes && other.scale == scale;
+  Widget build(BuildContext context) {
+    if (_image != null) {
+      return RawImage(
+        image: _image,
+      );
+    }
+
+    return const SizedBox();
   }
 
   @override
-  int get hashCode => Object.hash(bytes.hashCode, scale);
-
-  @override
-  String toString() =>
-      '${objectRuntimeType(this, 'RgbaImage')}(${describeIdentity(bytes)}, scale: $scale)';
-
-  @override
-  ImageStreamCompleter load(RgbaImage key, DecoderCallback decode) {
-    return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode),
-      scale: key.scale,
-      debugLabel: 'RgbaImage(${describeIdentity(key.bytes)})',
-    );
+  void dispose() {
+    _image?.dispose();
+    super.dispose();
   }
 }

--- a/example/lib/components/rgba_image.dart
+++ b/example/lib/components/rgba_image.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class RgbaImage extends StatefulWidget {
   const RgbaImage({

--- a/example/lib/examples/advanced/screen_sharing/screen_sharing.dart
+++ b/example/lib/examples/advanced/screen_sharing/screen_sharing.dart
@@ -8,6 +8,7 @@ import 'package:agora_rtc_engine_example/components/remote_video_views_widget.da
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:ui' as ui;
 
 /// ScreenSharing Example
 class ScreenSharing extends StatefulWidget {
@@ -528,25 +529,28 @@ class _ScreenShareDesktopState extends State<ScreenShareDesktop>
 
   Widget _createDropdownButton() {
     if (_screenCaptureSourceInfos.isEmpty) return Container();
+    ui.PixelFormat format = ui.PixelFormat.rgba8888;
+    if (defaultTargetPlatform == TargetPlatform.windows) {
+      // The native sdk return the bgra format on Windows.
+      format = ui.PixelFormat.bgra8888;
+    }
     return DropdownButton<ScreenCaptureSourceInfo>(
         items: _screenCaptureSourceInfos.map((info) {
           Widget image;
           if (info.iconImage!.width! != 0 && info.iconImage!.height! != 0) {
-            image = Image(
-              image: RgbaImage(
-                info.iconImage!.buffer!,
-                width: info.iconImage!.width!,
-                height: info.iconImage!.height!,
-              ),
+            image = RgbaImage(
+              bytes: info.iconImage!.buffer!,
+              width: info.iconImage!.width!,
+              height: info.iconImage!.height!,
+              format: format,
             );
           } else if (info.thumbImage!.width! != 0 &&
               info.thumbImage!.height! != 0) {
-            image = Image(
-              image: RgbaImage(
-                info.thumbImage!.buffer!,
-                width: info.thumbImage!.width!,
-                height: info.thumbImage!.height!,
-              ),
+            image = RgbaImage(
+              bytes: info.thumbImage!.buffer!,
+              width: info.thumbImage!.width!,
+              height: info.thumbImage!.height!,
+              format: format,
             );
           } else {
             image = const SizedBox(


### PR DESCRIPTION
The `DecorderCallback` was deprecated after v2.13.0-1.0.pre, and removed after 3.16.x
```dart
@Deprecated(
  'Use ImageDecoderCallback with ImageProvider.loadImage instead. '
  'This feature was deprecated after v2.13.0-1.0.pre.',
)
typedef DecoderCallback = Future<ui.Codec> Function(Uint8List buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling});
```

But we need to compatible with the Flutter SDK 2.10.x, so we need to avoid directly using the `ImageProvider`
