### PR TITLE
feat: upgrade native sdk dependencies 20240103

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.6.231-build.1'
+    api 'io.agora.rtc:iris-rtc:4.2.6.231-build.2'
     api 'io.agora.rtc:agora-special-full:4.2.6.231'
     api 'io.agora.rtc:full-screen-sharing:4.2.6.231'
   }

--- a/android/src/main/cpp/third_party/include/iris/iris_base.h
+++ b/android/src/main/cpp/third_party/include/iris/iris_base.h
@@ -32,7 +32,6 @@ typedef enum IrisAppType {
 } IrisAppType;
 
 typedef enum IrisLogLevel {
-  levelTrace = 0,
   levelDebug = 1,
   levelInfo = 2,
   levelWarn = 3,

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.231-build.1'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.231-build.2'
   s.dependency 'AgoraRtcEngine_Special_iOS', '4.2.6.231'
   end
   

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.231-build.1_DCG_Android_Video_20240102_0653.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.231-build.1_DCG_iOS_Video_20240102_0655.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.231-build.2_DCG_Android_Video_20240103_0209.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.231-build.2_DCG_iOS_Video_20240103_0211.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Mac_Video_20231227_0710.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Windows_Video_20231227_0710.zip"


### PR DESCRIPTION
Update native sdk dependencies 20240103
native sdk dependencies:
```

```

iris dependencies:
```
Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2.6.231/20240103/android/iris_4.2.6.231-build.2_DCG_Android_Video_20240103_0209.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2.6.231/20240103/android/iris_4.2.6.231-build.2_DCG_Android_Video_20240103_0209_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.231-build.2_DCG_Android_Video_20240103_0209.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.6.231-build.2'  Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2.6.231/20240103/ios/iris_4.2.6.231-build.2_DCG_iOS_Video_20240103_0211.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2.6.231/20240103/ios/iris_4.2.6.231-build.2_DCG_iOS_Video_20240103_0211_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.231-build.2_DCG_iOS_Video_20240103_0211.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.6.231-build.2'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.