### PR TITLE
fix: Fix MediaEngineImpl.unregisterAudioFrameObserver not unregister eventhandler internally

### DIFF
--- a/lib/src/impl/agora_media_engine_impl_override.dart
+++ b/lib/src/impl/agora_media_engine_impl_override.dart
@@ -70,7 +70,7 @@ class MediaEngineImpl extends media_engine_impl_binding.MediaEngineImpl
     final eventHandlerWrapper = AudioFrameObserverWrapper(observer);
     final param = createParams({});
 
-    await irisMethodChannel.registerEventHandler(
+    await irisMethodChannel.unregisterEventHandler(
         ScopedEvent(
             scopedKey: _mediaEngineScopedKey,
             registerName: 'MediaEngine_registerAudioFrameObserver',


### PR DESCRIPTION
Wrong call `irisMethodChannel.registerEventHandler` inside `MediaEngineImpl.unregisterAudioFrameObserver`, it should be `irisMethodChannel.unregisterEventHandler`