### PR TITLE
feat: upgrade native sdk dependencies 20240115

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,10 +57,9 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.6.3-build.1'
+    api 'io.agora.rtc:iris-rtc:4.2.6.4-build.1'
     api 'io.agora.rtc:agora-special-full:4.2.6.4'
     api 'io.agora.rtc:full-screen-sharing:4.2.6.4'
-    api 'io.agora.rtc:agora-special-voice:4.2.6.4'
   }
 }
 

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,9 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.3-build.1'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.4-build.1'
   s.dependency 'AgoraRtcEngine_Special_iOS', '4.2.6.4'
-  s.dependency 'AgoraAudio_Special_iOS', '4.2.6.4'
   end
   
   s.platform = :ios, '9.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -22,7 +22,7 @@ A new flutter plugin project.
     s.vendored_frameworks = 'libs/*.framework'
   else
   s.dependency 'AgoraRtcEngine_Special_macOS', '4.2.6.4'
-  s.dependency 'AgoraIrisRTC_macOS', '4.2.6.3-build.1'
+  s.dependency 'AgoraIrisRTC_macOS', '4.2.6.4-build.1'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Android_Video_20231227_0710.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_iOS_Video_20231227_0710.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Mac_Video_20231227_0710.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Windows_Video_20231227_0710.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Android_Video_20240115_1044.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_iOS_Video_20240115_1044.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Mac_Video_20240115_1044.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Windows_Video_20240115_1044.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.6.3-build.1_DCG_Windows_Video_20231227_0710.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.6.3-build.1_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Windows_Video_20240115_1044.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.6.4-build.1_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native sdk dependencies 20240115
native sdk dependencies:
```
【三方库链接】 【cdn】 https://download.agora.io/sdk/release/Agora_Native_SDK_for_iOS_rel.v4.2.6.4_39018_FULL_20240110_2218_289931.zip  【cocoapods】 pod 'AgoraRtcEngine_Special_iOS', '4.2.6.4'    【CDN】  https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_rel.v4.2.6.4_18647_FULL_20240110_0115_289793.zip  【COCOAPODS】  pod 'AgoraRtcEngine_Special_macOS', '4.2.6.4'    【CDN】  https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_rel.v4.2.6.4_23440_FULL_20240110_0054_289792.zip https://download.agora.io/sdk/release/Agora_Native_SDK_for_Android_rel.v4.2.6.4_56596_FULL_20240110_0059_289790.zip 【maven】 implementation 'io.agora.rtc:full-screen-sharing:4.2.6.4' implementation 'io.agora.rtc:agora-special-full:4.2.6.4'
```

iris dependencies:
```
打包助手 1-15 10:51 Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/ios/iris_4.2.6.4-build.1_DCG_iOS_Video_20240115_1044.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/ios/iris_4.2.6.4-build.1_DCG_iOS_Video_20240115_1044_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_iOS_Video_20240115_1044.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.6.4-build.1'  打包助手 1-15 10:54 Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/mac/iris_4.2.6.4-build.1_DCG_Mac_Video_20240115_1044.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/mac/iris_4.2.6.4-build.1_DCG_Mac_Video_20240115_1044_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Mac_Video_20240115_1044.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.2.6.4-build.1'  打包助手 1-15 10:56 Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/windows/iris_4.2.6.4-build.1_DCG_Windows_Video_20240115_1044.zip Private: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/windows/iris_4.2.6.4-build.1_DCG_Windows_Video_20240115_1044_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Windows_Video_20240115_1044.zip  打包助手 1-15 10:57 Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/android/iris_4.2.6.4-build.1_DCG_Android_Video_20240115_1044.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240115/android/iris_4.2.6.4-build.1_DCG_Android_Video_20240115_1044_private.zip CDN: https://download.agora.io/sdk/release/iris_4.2.6.4-build.1_DCG_Android_Video_20240115_1044.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.6.4-build.1'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.