### PR TITLE
feat: upgrade native sdk dependencies 20240125

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   if (isDev(project)) {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.3.0-test.7'
+    api 'io.agora.rtc:iris-rtc:4.3.0-test.8'
     api 'io.agora.rtc:agora-full-preview:4.3.0-dev.21'
     api 'io.agora.rtc:full-screen-sharing-special:4.3.0-dev.21'
   }

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.3.0-test.7_DCG_Android_Video_20240125_0450.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.3.0-test.8_DCG_Android_Video_20240125_0619.zip"
 export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.3.0-test.7_DCG_iOS_Video_20240125_0450.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.3.0-test.7_DCG_Mac_Video_20240125_0450.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.3.0-test.7_DCG_Windows_Video_20240125_0450.zip"


### PR DESCRIPTION
Update native sdk dependencies 20240125
native sdk dependencies:
```

```

iris dependencies:
```
Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/littlegnal/20240125/android/iris_4.3.0-test.8_DCG_Android_Video_20240125_0619.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/littlegnal/20240125/android/iris_4.3.0-test.8_DCG_Android_Video_20240125_0619_private.zip CDN: https://download.agora.io/sdk/release/iris_4.3.0-test.8_DCG_Android_Video_20240125_0619.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.3.0-test.8'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.