### PR TITLE
fix: [texture rendering] Fix texture id lost when widget is updated

### DIFF
--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -212,7 +212,7 @@ class _AgoraRtcRenderPlatformViewState extends State<AgoraRtcRenderPlatformView>
 class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   _VideoViewControllerInternal(this._controller);
 
-  final VideoViewControllerBase _controller;
+  final VideoViewControllerBaseMixin _controller;
 
   @override
   VideoCanvas get canvas => _controller.canvas;
@@ -233,6 +233,37 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
 
   @override
   RtcEngine get rtcEngine => _controller.rtcEngine;
+
+  @override
+  bool get shouldHandlerRenderMode => _controller.shouldHandlerRenderMode;
+
+  @override
+  void addInitializedCompletedListener(VoidCallback listener) =>
+      _controller.addInitializedCompletedListener(listener);
+
+  @override
+  void removeInitializedCompletedListener(VoidCallback listener) =>
+      _controller.removeInitializedCompletedListener(listener);
+
+  @override
+  Future<void> dispose() => _controller.dispose();
+
+  @override
+  Future<void> disposeRenderInternal() => _controller.disposeRenderInternal();
+
+  @override
+  Future<int> createTextureRender(
+    int uid,
+    String channelId,
+    int videoSourceType,
+    int videoViewSetupMode,
+  ) =>
+      _controller.createTextureRender(
+          uid, channelId, videoSourceType, videoViewSetupMode);
+
+  @override
+  Future<void> setupView(int nativeViewPtr) =>
+      _controller.setupView(nativeViewPtr);
 }
 
 class AgoraRtcRenderTexture extends StatefulWidget {
@@ -256,7 +287,7 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
 
   VoidCallback? _listener;
 
-  _VideoViewControllerInternal? _controllerInternal;
+  VideoViewControllerBaseMixin? _controllerInternal;
 
   @override
   void initState() {
@@ -267,7 +298,8 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
 
   Future<void> _initialize() async {
     final sourceController = widget.controller;
-    _controllerInternal = _VideoViewControllerInternal(sourceController);
+    _controllerInternal = _VideoViewControllerInternal(
+        sourceController as VideoViewControllerBaseMixin);
 
     if (!_controllerInternal!.isInitialzed) {
       _listener ??= () {

--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -214,6 +214,8 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
 
   final VideoViewControllerBaseMixin _controller;
 
+  int _textureId = kTextureNotInit;
+
   @override
   VideoCanvas get canvas => _controller.canvas;
 
@@ -238,6 +240,9 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   bool get shouldHandlerRenderMode => _controller.shouldHandlerRenderMode;
 
   @override
+  int getTextureId() => _textureId;
+
+  @override
   void addInitializedCompletedListener(VoidCallback listener) =>
       _controller.addInitializedCompletedListener(listener);
 
@@ -260,6 +265,13 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   ) =>
       _controller.createTextureRender(
           uid, channelId, videoSourceType, videoViewSetupMode);
+
+  @override
+  Future<void> initializeRender() async {
+    await _controller.initializeRender();
+    // Renew the texture id
+    _textureId = _controller.getTextureId();
+  }
 
   @override
   Future<void> setupView(int nativeViewPtr) =>

--- a/test_shard/integration_test_app/android/build.gradle
+++ b/test_shard/integration_test_app/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
@@ -119,6 +119,69 @@ class FakeGlobalVideoViewController {
   }
 }
 
+class FakeMethodChannelController {
+  FakeMethodChannelController(this.rtcEngine, this.testDefaultBinaryMessenger) {
+    const videoViewControllerChannel =
+        MethodChannel('agora_rtc_ng/video_view_controller');
+    mockedMethodChannels.add(videoViewControllerChannel);
+    testDefaultBinaryMessenger
+        .setMockMethodCallHandler(videoViewControllerChannel, ((message) async {
+      methodCallQueue.add(message);
+
+      if (message.method == 'createTextureRender') {
+        final t = textrueId++;
+        final channelId = 'agora_rtc_engine/texture_render_$t';
+        final c = MethodChannel(channelId);
+        testDefaultBinaryMessenger.setMockMethodCallHandler(c, (message) async {
+          return 0;
+        });
+
+        mockedMethodChannels.add(c);
+        // Need a delay to ensure the channel `agora_rtc_engine/texture_render_xx` is registered.
+        Future.delayed(const Duration(milliseconds: 100), () {
+          triggerPlatformMessage(channelId,
+              const MethodCall('onSizeChanged', {'width': 50, 'height': 50}));
+        });
+        return t;
+      }
+
+      return 0;
+    }));
+  }
+
+  final RtcEngine rtcEngine;
+
+  final TestDefaultBinaryMessenger testDefaultBinaryMessenger;
+
+  final List<MethodCall> methodCallQueue = [];
+
+  final List<MethodChannel> mockedMethodChannels = [];
+
+  int textrueId = 0;
+
+  void reset() {
+    methodCallQueue.clear();
+    textrueId = 0;
+  }
+
+  void dispose() {
+    for (final c in mockedMethodChannels) {
+      testDefaultBinaryMessenger.setMockMethodCallHandler(c, null);
+    }
+    reset();
+  }
+
+  void triggerPlatformMessage(String channelId, MethodCall methodCall) async {
+    const StandardMethodCodec codec = StandardMethodCodec();
+    final ByteData data = codec.encodeMethodCall(methodCall);
+    await testDefaultBinaryMessenger.handlePlatformMessage(
+      channelId,
+      data,
+      (ByteData? data) {},
+    );
+  }
+}
+
 void testCases() {
   group('Test with FakeIrisMethodChannel', () {
     final FakeIrisMethodChannel irisMethodChannel =
@@ -440,262 +503,400 @@ void testCases() {
       skip: !(Platform.isAndroid || Platform.isIOS),
     );
 
-    // TODO(littlegnal): The texture rendering test case are crash, since it need to call the
-    // real `IrisMethodChannel` implementation, but not just implement a fake `GlobalVideoViewController`.
-    // Need figure it out how to re-enable these test cases it the future.
-    //
-    // group(
-    //   'Texture Rendering',
-    //   () {
-    //     testWidgets(
-    //       'Show local AgoraVideoView after RtcEngine.initialize',
-    //       (WidgetTester tester) async {
-    //         late FakeGlobalVideoViewController fakeGlobalVideoViewController;
+    group(
+      'Texture Rendering',
+      () {
+        testWidgets(
+          'Show local AgoraVideoView after RtcEngine.initialize',
+          (WidgetTester tester) async {
+            late FakeMethodChannelController fakeMethodChannelController;
+            fakeMethodChannelController = FakeMethodChannelController(
+              rtcEngine,
+              tester.binding.defaultBinaryMessenger,
+            );
 
-    //         final videoViewCreatedCompleter = Completer<void>();
+            final videoViewCreatedCompleter = Completer<void>();
 
-    //         print('1111');
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return SizedBox(
+                  height: 100,
+                  width: 100,
+                  child: AgoraVideoView(
+                    controller: VideoViewController(
+                      rtcEngine: engine,
+                      canvas: const VideoCanvas(uid: 0),
+                      useFlutterTexture: true,
+                    ),
+                    onAgoraVideoViewCreated: (viewId) {
+                      if (!videoViewCreatedCompleter.isCompleted) {
+                        videoViewCreatedCompleter.complete(null);
+                      }
+                    },
+                  ),
+                );
+              },
+            ));
 
-    //         await tester.pumpWidget(_RenderViewWidget(
-    //           rtcEngine: rtcEngine,
-    //           onRtcEngineInitialized: () {
-    //             fakeGlobalVideoViewController = FakeGlobalVideoViewController(
-    //               rtcEngine,
-    //               tester.binding.defaultBinaryMessenger,
-    //             );
-    //           },
-    //           builder: (context, engine) {
-    //             return SizedBox(
-    //               height: 100,
-    //               width: 100,
-    //               child: AgoraVideoView(
-    //                 controller: VideoViewController(
-    //                   rtcEngine: engine,
-    //                   canvas: const VideoCanvas(uid: 0),
-    //                   useFlutterTexture: true,
-    //                 ),
-    //                 onAgoraVideoViewCreated: (viewId) {
-    //                   if (!videoViewCreatedCompleter.isCompleted) {
-    //                     videoViewCreatedCompleter.complete(null);
-    //                   }
-    //                 },
-    //               ),
-    //             );
-    //           },
-    //         ));
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            await videoViewCreatedCompleter.future;
 
-    //         await videoViewCreatedCompleter.future;
+            {
+              final createTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'createTextureRender')
+                  .toList();
 
-    //         print('videoViewCreatedCompleter.future completed');
+              final createTextureRenderArg = Map<String, Object>.from(
+                  createTextureRenderCalls[0].arguments);
 
-    //         {
-    //           final createTextureRenderCalls = fakeGlobalVideoViewController
-    //               .methodCallQueue
-    //               .where((e) => e.method == 'createTextureRender')
-    //               .toList();
+              expect(createTextureRenderArg['uid'] == 0, isTrue);
 
-    //           final createTextureRenderArg = Map<String, Object>.from(
-    //               createTextureRenderCalls[0].arguments);
+              int textureId = -1;
+              expect(find.byWidgetPredicate((widget) {
+                final found = widget is Texture;
+                if (found) {
+                  textureId = (widget as Texture).textureId;
+                }
+                return found;
+              }), findsOneWidget);
+              // The first textureId is 0
+              expect(textureId == 0, isTrue);
+            }
 
-    //           expect(createTextureRenderArg['uid'] == 0, isTrue);
-    //         }
+            fakeMethodChannelController.reset();
 
-    //         fakeGlobalVideoViewController.reset();
+            await tester.pumpWidget(Container());
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    //         await tester.pumpWidget(Container());
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // Delay 5 seconds to ensure that previous Widget.dipose call completed.
+            await Future.delayed(const Duration(seconds: 5));
 
-    //         // Delay 5 seconds to ensure that previous Widget.dipose call completed.
-    //         await Future.delayed(const Duration(seconds: 5));
+            {
+              final disposeTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'destroyTextureRender')
+                  .toList();
 
-    //         {
-    //           final disposeTextureRenderCalls = fakeGlobalVideoViewController
-    //               .methodCallQueue
-    //               .where((e) => e.method == 'destroyTextureRender')
-    //               .toList();
+              // texture id
+              final disposeTextureRenderTextureId =
+                  disposeTextureRenderCalls[0].arguments as int;
 
-    //           // texture id
-    //           final disposeTextureRenderTextureId =
-    //               disposeTextureRenderCalls[0].arguments as int;
+              expect(disposeTextureRenderTextureId != -1, isTrue);
+            }
 
-    //           expect(disposeTextureRenderTextureId != 0, isTrue);
-    //         }
+            fakeMethodChannelController.dispose();
+          },
+        );
 
-    //         fakeGlobalVideoViewController.dispose();
-    //       },
-    //     );
+        testWidgets(
+          'Show local AgoraVideoView after udpate the widget multiple times',
+          (WidgetTester tester) async {
+            final fakeMethodChannelController = FakeMethodChannelController(
+              rtcEngine,
+              tester.binding.defaultBinaryMessenger,
+            );
 
-    //     testWidgets(
-    //       'Switch local/remote AgoraVideoView with RtcConnection',
-    //       (WidgetTester tester) async {
-    //         // This case run this following steps:
-    //         // 1. Show a local `AgoraVideoView`.
-    //         // 2. Show local and remote `AgoraVideoView`, this step will trigger the `State.didUpdateWidget`.
-    //         // 3. Switch the local and remote `AgoraVideoView`.
+            Completer<void> videoViewCreatedCompleter = Completer<void>();
 
-    //         late FakeGlobalVideoViewController fakeGlobalVideoViewController;
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return SizedBox(
+                  height: 100,
+                  width: 100,
+                  child: AgoraVideoView(
+                    controller: VideoViewController(
+                      rtcEngine: engine,
+                      canvas: const VideoCanvas(uid: 0),
+                      useFlutterTexture: true,
+                    ),
+                    onAgoraVideoViewCreated: (viewId) {
+                      if (!videoViewCreatedCompleter.isCompleted) {
+                        videoViewCreatedCompleter.complete(null);
+                      }
+                    },
+                  ),
+                );
+              },
+            ));
 
-    //         await tester.pumpWidget(_RenderViewWidget(
-    //           rtcEngine: rtcEngine,
-    //           onRtcEngineInitialized: () {
-    //             fakeGlobalVideoViewController = FakeGlobalVideoViewController(
-    //               rtcEngine,
-    //               tester.binding.defaultBinaryMessenger,
-    //             );
-    //           },
-    //           builder: (context, engine) {
-    //             return Column(
-    //               children: [
-    //                 SizedBox(
-    //                   height: 100,
-    //                   width: 100,
-    //                   child: AgoraVideoView(
-    //                     controller: VideoViewController(
-    //                       rtcEngine: engine,
-    //                       canvas: const VideoCanvas(uid: 0),
-    //                       useFlutterTexture: true,
-    //                     ),
-    //                   ),
-    //                 )
-    //               ],
-    //             );
-    //           },
-    //         ));
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            await videoViewCreatedCompleter.future;
 
-    //         // Check `GlobalVideoViewController.createTextureRender` calls
-    //         {
-    //           final createTextureRenderCalls = fakeGlobalVideoViewController
-    //               .methodCallQueue
-    //               .where((e) => e.method == 'createTextureRender')
-    //               .toList();
+            {
+              int textureId = -1;
+              expect(find.byWidgetPredicate((widget) {
+                final found = widget is Texture;
+                if (found) {
+                  textureId = (widget as Texture).textureId;
+                }
+                return found;
+              }), findsOneWidget);
+              // The first textureId is 0
+              expect(textureId == 0, isTrue);
+            }
 
-    //           final createTextureRenderArg = Map<String, Object>.from(
-    //               createTextureRenderCalls[0].arguments);
+            videoViewCreatedCompleter = Completer<void>();
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return SizedBox(
+                  height: 100,
+                  width: 100,
+                  child: AgoraVideoView(
+                    controller: VideoViewController(
+                      rtcEngine: engine,
+                      canvas: const VideoCanvas(uid: 0),
+                      useFlutterTexture: true,
+                    ),
+                    onAgoraVideoViewCreated: (viewId) {
+                      if (!videoViewCreatedCompleter.isCompleted) {
+                        videoViewCreatedCompleter.complete(null);
+                      }
+                    },
+                  ),
+                );
+              },
+            ));
 
-    //           expect(createTextureRenderArg['uid'] == 0, isTrue);
-    //         }
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    //         // Clear the methodCall records
-    //         fakeGlobalVideoViewController.reset();
+            {
+              final createTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'createTextureRender')
+                  .toList();
+              expect(createTextureRenderCalls.length == 1, isTrue);
 
-    //         // This step will call `didUpdateWidget`
-    //         await tester.pumpWidget(_RenderViewWidget(
-    //           rtcEngine: rtcEngine,
-    //           builder: (context, engine) {
-    //             return Column(
-    //               children: [
-    //                 SizedBox(
-    //                   height: 100,
-    //                   width: 100,
-    //                   child: AgoraVideoView(
-    //                     controller: VideoViewController(
-    //                       rtcEngine: engine,
-    //                       canvas: const VideoCanvas(uid: 0),
-    //                       useFlutterTexture: true,
-    //                     ),
-    //                   ),
-    //                 ),
-    //                 SizedBox(
-    //                   height: 100,
-    //                   width: 100,
-    //                   child: AgoraVideoView(
-    //                     controller: VideoViewController.remote(
-    //                       rtcEngine: engine,
-    //                       canvas: const VideoCanvas(uid: 1000),
-    //                       connection: const RtcConnection(
-    //                         channelId: 'switch_video_view',
-    //                         localUid: 1000,
-    //                       ),
-    //                       useFlutterTexture: true,
-    //                     ),
-    //                   ),
-    //                 )
-    //               ],
-    //             );
-    //           },
-    //         ));
+              int textureId = -1;
+              expect(find.byWidgetPredicate((widget) {
+                final found = widget is Texture;
+                if (found) {
+                  textureId = (widget as Texture).textureId;
+                }
+                return found;
+              }), findsOneWidget);
+              // The first textureId is 0
+              expect(textureId == 0, isTrue);
+            }
 
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-    //         // pumpAndSettle again to ensure the `AgoraVideoView` shown
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            fakeMethodChannelController.dispose();
+          },
+        );
 
-    //         // Check `GlobalVideoViewController.createTextureRender` calls for remote `AgoraVideoView`
-    //         {
-    //           final createTextureRenderCalls = fakeGlobalVideoViewController
-    //               .methodCallQueue
-    //               .where((e) => e.method == 'createTextureRender')
-    //               .toList();
+        testWidgets(
+          'Switch local/remote AgoraVideoView with RtcConnection',
+          (WidgetTester tester) async {
+            // This case run this following steps:
+            // 1. Show a local `AgoraVideoView`.
+            // 2. Show local and remote `AgoraVideoView`, this step will trigger the `State.didUpdateWidget`.
+            // 3. Switch the local and remote `AgoraVideoView`.
 
-    //           final createTextureRenderArg = Map<String, Object>.from(
-    //               createTextureRenderCalls[0].arguments);
+            final fakeMethodChannelController = FakeMethodChannelController(
+              rtcEngine,
+              tester.binding.defaultBinaryMessenger,
+            );
 
-    //           expect(createTextureRenderArg['uid'] != 0, isTrue);
-    //         }
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                          useFlutterTexture: true,
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
 
-    //         // Clear the methodCall records
-    //         fakeGlobalVideoViewController.reset();
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    //         await tester.pumpWidget(_RenderViewWidget(
-    //           rtcEngine: rtcEngine,
-    //           builder: (context, engine) {
-    //             return Column(
-    //               children: [
-    //                 SizedBox(
-    //                   height: 100,
-    //                   width: 100,
-    //                   child: AgoraVideoView(
-    //                     controller: VideoViewController.remote(
-    //                       rtcEngine: engine,
-    //                       canvas: const VideoCanvas(uid: 1000),
-    //                       connection: const RtcConnection(
-    //                         channelId: 'switch_video_view',
-    //                         localUid: 1000,
-    //                       ),
-    //                       useFlutterTexture: true,
-    //                     ),
-    //                   ),
-    //                 ),
-    //                 SizedBox(
-    //                   height: 100,
-    //                   width: 100,
-    //                   child: AgoraVideoView(
-    //                     controller: VideoViewController(
-    //                       rtcEngine: engine,
-    //                       canvas: const VideoCanvas(uid: 0),
-    //                       useFlutterTexture: true,
-    //                     ),
-    //                   ),
-    //                 )
-    //               ],
-    //             );
-    //           },
-    //         ));
+            // Check `GlobalVideoViewController.createTextureRender` calls
+            {
+              final createTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'createTextureRender')
+                  .toList();
 
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+              final createTextureRenderArg = Map<String, Object>.from(
+                  createTextureRenderCalls[0].arguments);
 
-    //         // When switch the local and remote `AgoraVideoView`, which will trigger the
-    //         // `State.didUpdateWidget`, so there're no method call records here.
-    //         expect(
-    //             fakeGlobalVideoViewController.methodCallQueue.isEmpty, isTrue);
+              expect(createTextureRenderArg['uid'] == 0, isTrue);
+            }
 
-    //         fakeGlobalVideoViewController.dispose();
+            // This step will call `didUpdateWidget`
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                          useFlutterTexture: true,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController.remote(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 1000),
+                          connection: const RtcConnection(
+                            channelId: 'switch_video_view',
+                            localUid: 1000,
+                          ),
+                          useFlutterTexture: true,
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
 
-    //         await tester.pumpWidget(Container());
-    //         await tester.pumpAndSettle(const Duration(milliseconds: 5000));
-    //         await Future.delayed(const Duration(seconds: 5));
-    //       },
-    //     );
-    //   },
-    //   skip: Platform.isAndroid,
-    // );
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            // pumpAndSettle again to ensure the `AgoraVideoView` shown
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            // Check `GlobalVideoViewController.createTextureRender` calls for remote `AgoraVideoView`
+            {
+              final createTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'createTextureRender')
+                  .toList();
+
+              expect(createTextureRenderCalls.length == 2, isTrue);
+
+              final createTextureRenderArg = Map<String, Object>.from(
+                  createTextureRenderCalls[1].arguments);
+
+              expect(createTextureRenderArg['uid'] != 0, isTrue);
+
+              {
+                List<int> textureIds = [];
+                expect(find.byWidgetPredicate((widget) {
+                  final found = widget is Texture;
+                  if (found) {
+                    // textureId = (widget as Texture).textureId;
+                    textureIds.add((widget as Texture).textureId);
+                  }
+                  return found;
+                }), findsNWidgets(2));
+                // The first textureId is 0
+                expect(textureIds[0] == 0, isTrue);
+                // The second textureId is 0
+                expect(textureIds[1] == 1, isTrue);
+              }
+            }
+
+            await tester.pumpWidget(_RenderViewWidget(
+              rtcEngine: rtcEngine,
+              builder: (context, engine) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController.remote(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 1000),
+                          connection: const RtcConnection(
+                            channelId: 'switch_video_view',
+                            localUid: 1000,
+                          ),
+                          useFlutterTexture: true,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 100,
+                      width: 100,
+                      child: AgoraVideoView(
+                        controller: VideoViewController(
+                          rtcEngine: engine,
+                          canvas: const VideoCanvas(uid: 0),
+                          useFlutterTexture: true,
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ));
+
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+            {
+              final createTextureRenderCalls = fakeMethodChannelController
+                  .methodCallQueue
+                  .where((e) => e.method == 'createTextureRender')
+                  .toList();
+
+              // After `didUpdateWidget` called, the texture renderer will be re-created,
+              // so there're another 2 times' `createTextureRender` are called.
+              // So the value of `createTextureRenderCalls.length` is 4
+              expect(createTextureRenderCalls.length == 4, isTrue);
+
+              final createTextureRenderArg = Map<String, Object>.from(
+                  createTextureRenderCalls[2].arguments);
+
+              expect(createTextureRenderArg['uid'] != 0, isTrue);
+
+              {
+                List<int> textureIds = [];
+                expect(find.byWidgetPredicate((widget) {
+                  final found = widget is Texture;
+                  if (found) {
+                    // textureId = (widget as Texture).textureId;
+                    textureIds.add((widget as Texture).textureId);
+                  }
+                  return found;
+                }), findsNWidgets(2));
+                // The third textureId is 2
+                expect(textureIds[0] == 2, isTrue);
+                // The fourth textureId is 3
+                expect(textureIds[1] == 3, isTrue);
+              }
+            }
+
+            fakeMethodChannelController.dispose();
+
+            await tester.pumpWidget(Container());
+            await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+            await Future.delayed(const Duration(seconds: 5));
+          },
+        );
+      },
+    );
 
     testWidgets(
       'dispose AgoraVideoView not crash before setupLocalVideo/setupRemoteVideo[Ex] call is completed',


### PR DESCRIPTION
We get the texture id from the `VideoViewController` that is passed by the user directly, which will be reset if the widget is updated, so we need to maintain it internally.