### PR TITLE
[ci] Fix some ci issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         version: ["2.10.5", "3.x"]
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 120
     env:
       TEST_APP_ID: ${{ secrets.MY_APP_ID }}
@@ -114,9 +114,9 @@ jobs:
         with:
           flutter-version: ${{ matrix.version }}
           cache: true
-      - uses: futureware-tech/simulator-action@v1
+      - uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 13 Pro Max'
+          model: 'iPhone 14 Pro Max'
       - run: bash ci/run_flutter_integration_test_ios.sh
 
   integration_test_macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,6 +384,12 @@ jobs:
           model: 'iPhone 14 Pro Max'
       - run: bash ci/rendering_test_ios.sh
 
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: debug-golden-files-ios
+          path: test_shard/rendering_test/screenshot/*.debug.png
+
   rendering_test_macos:
     name: Run Flutter macOS Rendering Tests
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["2.10.5", "3.16"]
     runs-on: macos-12
     timeout-minutes: 120
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,12 +379,9 @@ jobs:
             --apple-package-name=io.agora.agoraRtcEngineExample \
             --flutter-package-name=agora_rtc_engine \
             --iris-ios-cdn-url=${IRIS_CDN_URL_IOS}
-      - name: Create ios simulator
-        run: |
-          xcrun simctl list
-          # We generate the screenshots base on the simulator "iPhone 13 Pro Max", so we set the SimDeviceType to iPhone 13 Pro Max.
-          # If you need to change the SimDeviceType, you may need to re-generate the screenshots first.
-          xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-13-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-16-4 | xargs xcrun simctl boot
+      - uses: futureware-tech/simulator-action@v3
+        with:
+          model: 'iPhone 13 Pro Max'
       - run: bash ci/rendering_test_ios.sh
 
   rendering_test_macos:
@@ -486,7 +483,9 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ['3.x']
+        # TODO(littlegnal): Temporily pin the Flutter SDK version to 3.16, since the rendering on web not work correct after 3.16, 
+        # see https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/7958003510/job/21721962323?pr=1572
+        version: ['3.16']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,7 @@ jobs:
             --iris-ios-cdn-url=${IRIS_CDN_URL_IOS}
       - uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 13 Pro Max'
+          model: 'iPhone 14 Pro Max'
       - run: bash ci/rendering_test_ios.sh
 
   rendering_test_macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         version: ["2.10.5", "3.x"]
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 120
     env:
       TEST_APP_ID: ${{ secrets.MY_APP_ID }}
@@ -347,7 +347,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["3.x"]
+        version: ["3.16"]
     runs-on: macos-13 # Rendering test on ios simulator need macos 13+
     timeout-minutes: 60
     env:

--- a/ci/run_flutter_integration_test_ios.sh
+++ b/ci/run_flutter_integration_test_ios.sh
@@ -17,7 +17,15 @@ pushd ${MY_PATH}/../test_shard/fake_test_app
 
 flutter packages get
 
-flutter test integration_test
+# flutter test integration_test
+
+# It's a little tricky that you should run integration test one by one on flutter macOS/Windows
+for filename in integration_test/*.dart; do
+    if [[ "$filename" == *.generated.dart  ]]; then
+        continue
+    fi
+    flutter test $filename
+done
 
 popd
 
@@ -25,6 +33,15 @@ pushd ${MY_PATH}/../test_shard/integration_test_app
 
 flutter packages get
 
-flutter test integration_test --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+# flutter test integration_test --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+
+# It's a little tricky that you should run integration test one by one on flutter macOS/Windows
+for filename in integration_test/*.dart; do
+    if [[ "$filename" == *.generated.dart  ]]; then
+        continue
+    fi
+    flutter test $filename --dart-define=TEST_APP_ID="${TEST_APP_ID}"
+done
+
 
 popd

--- a/ci/run_flutter_integration_test_ios.sh
+++ b/ci/run_flutter_integration_test_ios.sh
@@ -17,15 +17,7 @@ pushd ${MY_PATH}/../test_shard/fake_test_app
 
 flutter packages get
 
-# flutter test integration_test
-
-# It's a little tricky that you should run integration test one by one on flutter macOS/Windows
-for filename in integration_test/*.dart; do
-    if [[ "$filename" == *.generated.dart  ]]; then
-        continue
-    fi
-    flutter test $filename
-done
+flutter test integration_test
 
 popd
 
@@ -33,15 +25,6 @@ pushd ${MY_PATH}/../test_shard/integration_test_app
 
 flutter packages get
 
-# flutter test integration_test --dart-define=TEST_APP_ID="${TEST_APP_ID}"
-
-# It's a little tricky that you should run integration test one by one on flutter macOS/Windows
-for filename in integration_test/*.dart; do
-    if [[ "$filename" == *.generated.dart  ]]; then
-        continue
-    fi
-    flutter test $filename --dart-define=TEST_APP_ID="${TEST_APP_ID}"
-done
-
+flutter test integration_test --dart-define=TEST_APP_ID="${TEST_APP_ID}"
 
 popd


### PR DESCRIPTION
Fix some ci issues that block the https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/pull/1572
- iOS simulator not be created in the rendering test, it is most likely there's no "iPhone 13 Pro Max" in the `macos-12` runner anymore.
- The rendering test for the web failed with Flutter SDK 3.19, will fix it later.