### PR TITLE
fix: AgoraVideoView crash when dispose after RtcEngine.release

### DIFF
--- a/android/src/main/cpp/iris_rtc_rendering_android.cc
+++ b/android/src/main/cpp/iris_rtc_rendering_android.cc
@@ -711,7 +711,7 @@ class NativeTextureRenderer final
     }
   }
 
-  ~NativeTextureRenderer() final { Dispose(); }
+  ~NativeTextureRenderer() final {}
 
   void OnVideoFrameReceived(const void *videoFrame,
                             const IrisRtcVideoFrameConfig &config,

--- a/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
@@ -56,6 +56,7 @@ class SimpleRef {
 class PlatformRenderPool {
 
     private final Map<Integer, SimpleRef> renders = new HashMap<>();
+
     SimpleRef createView(int platformViewId,
                          Context context,
                          AgoraPlatformViewFactory.PlatformViewProvider viewProvider) {
@@ -182,10 +183,8 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
             case "createTextureRender": {
                 final Map<?, ?> args = (Map<?, ?>) call.arguments;
 
-                @SuppressWarnings("ConstantConditions")
-                final long irisRtcRenderingHandle = getLong(args.get("irisRtcRenderingHandle"));
-                @SuppressWarnings("ConstantConditions")
-                final long uid = getLong(args.get("uid"));
+                @SuppressWarnings("ConstantConditions") final long irisRtcRenderingHandle = getLong(args.get("irisRtcRenderingHandle"));
+                @SuppressWarnings("ConstantConditions") final long uid = getLong(args.get("uid"));
                 final String channelId = (String) args.get("channelId");
                 final int videoSourceType = (int) args.get("videoSourceType");
                 final int videoViewSetupMode = (int) args.get("videoViewSetupMode");
@@ -205,11 +204,23 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
                 result.success(success);
                 break;
             }
+            case "dispose": {
+                disposeAllRenderers();
+                result.success(true);
+                break;
+            }
             case "updateTextureRenderData":
             default:
                 result.notImplemented();
                 break;
         }
+    }
+
+    private void disposeAllRenderers() {
+        for (final TextureRenderer textureRenderer : textureRendererMap.values()) {
+            textureRenderer.dispose();
+        }
+        textureRendererMap.clear();
     }
 
     /**

--- a/shared/darwin/VideoViewController.mm
+++ b/shared/darwin/VideoViewController.mm
@@ -132,6 +132,8 @@
 @property(nonatomic) PlatformRenderPool* platformRenderPool;
 
 @property(nonatomic, strong) FlutterMethodChannel *methodChannel;
+
+- (void)dispose;
 @end
 
 @implementation VideoViewController
@@ -186,6 +188,9 @@
       [self dePlatformRenderRef:platformViewId];
       
       result(@(YES));
+  } else if ([@"dispose" isEqualToString:call.method]) {
+      [self dispose];
+      result(@(YES));
   }
 }
 
@@ -229,6 +234,13 @@
       return YES;
     }
     return NO;
+}
+
+- (void)dispose {
+    for (TextureRender * textureRender in self.textureRenders.allValues) {
+        [textureRender dispose];
+    }
+    [self.textureRenders removeAllObjects];
 }
 
 @end

--- a/test_shard/integration_test_app/integration_test/fake/fake_iris_method_channel.dart
+++ b/test_shard/integration_test_app/integration_test/fake/fake_iris_method_channel.dart
@@ -10,6 +10,7 @@ class FakeIrisMethodChannelConfig {
     this.isFakeRemoveHotRestartListener = true,
     this.isFakeDispose = true,
     this.delayInvokeMethod = const {},
+    this.fakeInvokeMethods = const {},
   });
 
   final bool isFakeInitilize;
@@ -19,6 +20,7 @@ class FakeIrisMethodChannelConfig {
   final bool isFakeRemoveHotRestartListener;
   final bool isFakeDispose;
   final Map<String, int> delayInvokeMethod;
+  final Map<String, CallApiResult> fakeInvokeMethods;
 
   FakeIrisMethodChannelConfig copyWith({
     bool? isFakeInitilize,
@@ -28,6 +30,7 @@ class FakeIrisMethodChannelConfig {
     bool? isFakeRemoveHotRestartListener,
     bool? isFakeDispose,
     Map<String, int>? delayInvokeMethod,
+    Map<String, CallApiResult>? fakeInvokeMethods
   }) {
     return FakeIrisMethodChannelConfig(
       isFakeInitilize: isFakeInitilize ?? this.isFakeInitilize,
@@ -40,6 +43,7 @@ class FakeIrisMethodChannelConfig {
           isFakeRemoveHotRestartListener ?? this.isFakeRemoveHotRestartListener,
       isFakeDispose: isFakeDispose ?? this.isFakeDispose,
       delayInvokeMethod: delayInvokeMethod ?? this.delayInvokeMethod,
+      fakeInvokeMethods: fakeInvokeMethods ?? this.fakeInvokeMethods,
     );
   }
 }
@@ -77,6 +81,9 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
 
     if (_config.isFakeInvokeMethod) {
       await __maybeDelay();
+      if (_config.fakeInvokeMethods.containsKey(methodCall.funcName)) {
+        return _config.fakeInvokeMethods[methodCall.funcName]!;
+      }
       return CallApiResult(data: {'result': 0}, irisReturnCode: 0);
     }
 

--- a/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
@@ -11,6 +11,7 @@ import 'package:agora_rtc_engine/src/impl/agora_rtc_engine_impl.dart';
 import '../fake/fake_iris_method_channel.dart';
 import 'package:agora_rtc_engine/src/impl/platform/io/global_video_view_controller_platform_io.dart';
 import 'package:agora_rtc_engine/src/impl/platform/io/native_iris_api_engine_binding_delegate.dart';
+import 'package:iris_method_channel/iris_method_channel.dart';
 
 class _RenderViewWidget extends StatefulWidget {
   const _RenderViewWidget({
@@ -191,6 +192,11 @@ void testCases() {
 
     setUp(() {
       irisMethodChannel.reset();
+      irisMethodChannel.config =
+          FakeIrisMethodChannelConfig(fakeInvokeMethods: {
+        'CreateIrisRtcRendering': CallApiResult(
+            data: {'irisRtcRenderingHandle': 100}, irisReturnCode: 0)
+      });
     });
 
     group(

--- a/windows/include/agora_rtc_engine/video_view_controller.h
+++ b/windows/include/agora_rtc_engine/video_view_controller.h
@@ -34,6 +34,8 @@ private:
 
     bool DestroyTextureRender(int64_t textureId);
 
+    void Dispose();
+
 public:
     VideoViewController(flutter::TextureRegistrar *texture_registrar, flutter::BinaryMessenger *messenger_);
     virtual ~VideoViewController();

--- a/windows/video_view_controller.cc
+++ b/windows/video_view_controller.cc
@@ -126,6 +126,11 @@ void VideoViewController::HandleMethodCall(
 
     result->Success(flutter::EncodableValue(true));
   }
+  else if (method.compare("dispose") == 0)
+  {
+    Dispose();
+    result->Success(flutter::EncodableValue(true));
+  }
   else if (method.compare("updateTextureRenderData") == 0)
   {
   }
@@ -171,4 +176,13 @@ bool VideoViewController::DestroyTextureRender(int64_t textureId)
     return true;
   }
   return false;
+}
+
+void VideoViewController::Dispose()
+{
+  for (const auto &entry : renderers_)
+  {
+    entry.second->Dispose();
+  }
+  renderers_.clear();
 }


### PR DESCRIPTION
The `IrisRtcEngineRendering` handle becomes invalid after `RtcEngine.release`, which needs explicit clean-up of the texture renderers on the native side.

Fix https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/issues/1567