### PR TITLE
[example] Clean up video_raw_data

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -33,12 +33,6 @@ dependencies:
   permission_handler: ^10.2.0
   path_provider: ^2.0.8
 
-  video_raw_data:
-    git:
-      url: https://github.com/AgoraIO-Extensions/RawDataPluginSample.git
-      path: frameworks/flutter/video_raw_data
-      ref: 51dde78706a015743a993368f25a06df7960378e
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
After `agora_rtc_engine: 6.3.0`, we do not implement the `ProcessVideoRawData` example by using the `video_raw_data`.

Fix ci failed https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/8135311600/job/22231749168?pr=1585