### PR TITLE
Allow newer `flutter_lints` versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: '>=1.0.0'
   build_runner: ^2.1.7
   json_serializable: ^6.1.1
   ffigen: ^4.1.2


### PR DESCRIPTION
This PR fixes #1657 by tweaking the `pubspec.yaml` file.

Once this change is implemented, developers who use this plugin won't be prevented from using new linting features.