### PR TITLE
[ci] Run android integration test and rendering test on ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         version: ["2.10.5", "3.x"]
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       TEST_APP_ID: ${{ secrets.MY_APP_ID }}
@@ -98,7 +98,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.version }}
-      - run: flutter config --enable-macos-desktop
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: run flutter android integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -233,7 +237,6 @@ jobs:
   build_android_ubuntu:
     name: Build Android on Ubuntu
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
-    needs: flutter_codestyle_check
     strategy:
       matrix:
         version: ["2.10.5", "3.x"]
@@ -336,11 +339,10 @@ jobs:
         run: flutter build web
         working-directory: example
 
-  # Run android rendering test in macos is more stable
   rendering_test_android:
     name: Run Flutter Android Rendering Tests
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       TEST_APP_ID: ${{ secrets.MY_APP_ID }}
@@ -378,7 +380,11 @@ jobs:
             --flutter-package-name=agora_rtc_engine \
             --iris-android-cdn-url=${IRIS_CDN_URL_ANDROID} \
             --iris-macos-cdn-url=${IRIS_CDN_URL_MACOS}
-      - run: flutter config --enable-macos-desktop
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: run flutter android integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
After hardware accelerated support on Ubuntu, we can move the integration test and rendering test to Ubuntu to reduce the test times.
https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/