### PR TITLE
feat: upgrade native sdk dependencies 20240415

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download the `iris_web`(see the link below) artifact and include it as a `<scrip
 </body>
 </html>
 ```
-Download: https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.6.0.js
+Download: https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.7.0-pre.js
 
 **For Testing Purposes**
 
@@ -101,7 +101,7 @@ You can directly depend on the Agora CDN for testing purposes:
 ...
 <body>
   ...
-  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.6.0.js"></script>
+  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.7.0-pre.js"></script>
 </body>
 </html>
 ```

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -100,6 +100,6 @@
       loadMainDartJs();
     }
   </script>
-  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.6.0.js"></script>
+  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.7.0-pre.js"></script>
 </body>
 </html>

--- a/scripts/iris_web_version.js
+++ b/scripts/iris_web_version.js
@@ -1,7 +1,7 @@
 // Share the iris web url to all the tests
 
 // This url should be same as the url inside the `example/web/index.html`
-const irisWebUrl = 'https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.6.0.js';
+const irisWebUrl = 'https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.7.0-pre.js';
 const irisWebFakeUrl = 'https://download.agora.io/sdk/release/iris-web-rtc-fake_n430_w4200_0.7.0-pre.js';
 
 (function() {


### PR DESCRIPTION
Update native sdk dependencies 20240415
native sdk dependencies:
```

```

iris dependencies:
```
CDN: https://download.agora.io/sdk/release/iris-web-rtc_n430_w4200_0.7.0-pre.js
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.