### PR TITLE
fix: Prevent multiple initializations of internal resources when `RtcEngine.initialize` is called simultaneously

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,9 +15,10 @@ dependencies:
     sdk: flutter
   json_annotation: ^4.4.0
   ffi: '>=1.1.2'
-  async: ^2.8.2
+  async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel: 2.1.0
+  iris_method_channel:
+    path: /Users/admin/codes/iris_method_channel_flutter
   js: '>=0.6.3'
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel:
-    git:
-      url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
-      ref: littlegnal/isolate-spawn-once
+  iris_method_channel: 2.1.1
   js: '>=0.6.3'
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   async: '>=2.8.2'
   meta: ^1.7.0
   iris_method_channel:
-    path: /Users/admin/codes/iris_method_channel_flutter
+    git:
+      url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
+      ref: littlegnal/isolate-spawn-once
   js: '>=0.6.3'
 dev_dependencies:
   flutter_test:

--- a/test_shard/integration_test_app/integration_test/fake/fake_iris_method_channel.dart
+++ b/test_shard/integration_test_app/integration_test/fake/fake_iris_method_channel.dart
@@ -60,6 +60,7 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
   @override
   Future<InitilizationResult?> initilize(
       List<InitilizationArgProvider> args) async {
+    methodCallQueue.add(const IrisMethodCall('initilize', '{}'));
     if (_config.isFakeInitilize) {
       return null;
     }
@@ -93,6 +94,7 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
 
   @override
   int getApiEngineHandle() {
+    methodCallQueue.add(const IrisMethodCall('getApiEngineHandle', '{}'));
     if (_config.isFakeGetNativeHandle) {
       return 100;
     }
@@ -101,6 +103,7 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
 
   @override
   VoidCallback addHotRestartListener(HotRestartListener listener) {
+    methodCallQueue.add(const IrisMethodCall('addHotRestartListener', '{}'));
     if (_config.isFakeAddHotRestartListener) {
       return () {};
     }
@@ -110,6 +113,7 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
 
   @override
   void removeHotRestartListener(HotRestartListener listener) {
+    methodCallQueue.add(const IrisMethodCall('removeHotRestartListener', '{}'));
     if (_config.isFakeRemoveHotRestartListener) {
       return;
     }
@@ -119,6 +123,7 @@ class FakeIrisMethodChannel extends IrisMethodChannel {
 
   @override
   Future<void> dispose() async {
+    methodCallQueue.add(const IrisMethodCall('dispose', '{}'));
     if (_config.isFakeDispose) {
       return;
     }

--- a/test_shard/integration_test_app/integration_test/fake_apis_call_integration_test.dart
+++ b/test_shard/integration_test_app/integration_test/fake_apis_call_integration_test.dart
@@ -1,9 +1,11 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'testcases/mediarecorder_fake_test_testcases.dart' as fake_mediarecorder;
+import 'testcases/rtcengine_fake_test_testcases.dart' as fake_rtcengine;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   fake_mediarecorder.testCases();
+  fake_rtcengine.testCases();
 }

--- a/test_shard/integration_test_app/integration_test/testcases/mediarecorder_fake_test_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/mediarecorder_fake_test_testcases.dart
@@ -55,7 +55,7 @@ void testCases() {
         MediaRecorderFakeIrisMethodChannel(
             IrisApiEngineNativeBindingDelegateProvider());
     final RtcEngine rtcEngine =
-        RtcEngineImpl.create(irisMethodChannel: irisMethodChannel);
+        RtcEngineImpl.createForTesting(irisMethodChannel: irisMethodChannel);
 
     setUp(() {
       irisMethodChannel.reset();
@@ -121,6 +121,7 @@ void testCases() {
             const MediaRecorderConfiguration(storagePath: 'path'));
         await recorder?.stopRecording();
         await rtcEngine.destroyMediaRecorder(recorder!);
+        await rtcEngine.release();
 
         expect(
             _isCallOnce(

--- a/test_shard/integration_test_app/integration_test/testcases/rtcengine_fake_test_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/rtcengine_fake_test_testcases.dart
@@ -1,0 +1,145 @@
+import 'package:agora_rtc_engine/agora_rtc_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:agora_rtc_engine/src/impl/platform/io/native_iris_api_engine_binding_delegate.dart';
+import '../fake/fake_iris_method_channel.dart';
+import 'package:agora_rtc_engine/src/impl/agora_rtc_engine_impl.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
+import 'dart:io';
+
+void testCases() {
+  group('RtcEngine.initialize', () {
+    final FakeIrisMethodChannel irisMethodChannel =
+        FakeIrisMethodChannel(IrisApiEngineNativeBindingDelegateProvider());
+    final RtcEngine rtcEngine =
+        RtcEngineImpl.createForTesting(irisMethodChannel: irisMethodChannel);
+
+    setUp(() {
+      irisMethodChannel.reset();
+    });
+
+    testWidgets(
+      'only initialize once',
+      (WidgetTester tester) async {
+        String engineAppId = const String.fromEnvironment('TEST_APP_ID',
+            defaultValue: '<YOUR_APP_ID>');
+
+        Directory appDocDir = await getApplicationDocumentsDirectory();
+        String logPath = path.join(appDocDir.path, 'test_log.txt');
+
+        await rtcEngine.initialize(RtcEngineContext(
+          appId: engineAppId,
+          areaCode: AreaCode.areaCodeGlob.value(),
+          logConfig: LogConfig(filePath: logPath),
+        ));
+        await rtcEngine.initialize(RtcEngineContext(
+          appId: engineAppId,
+          areaCode: AreaCode.areaCodeGlob.value(),
+          logConfig: LogConfig(filePath: logPath),
+        ));
+        await rtcEngine.initialize(RtcEngineContext(
+          appId: engineAppId,
+          areaCode: AreaCode.areaCodeGlob.value(),
+          logConfig: LogConfig(filePath: logPath),
+        ));
+        final calls = irisMethodChannel.methodCallQueue
+            .where((e) => e.funcName == 'initilize')
+            .toList();
+        expect(calls.length == 1, true);
+
+        await rtcEngine.release();
+      },
+    );
+
+    testWidgets(
+      'only initialize once when called simultaneously',
+      (WidgetTester tester) async {
+        String engineAppId = const String.fromEnvironment('TEST_APP_ID',
+            defaultValue: '<YOUR_APP_ID>');
+
+        Directory appDocDir = await getApplicationDocumentsDirectory();
+        String logPath = path.join(appDocDir.path, 'test_log.txt');
+
+        for (int i = 0; i < 5; ++i) {
+          rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+        }
+        // Wait for the 5 times calls of `irisMethodChannel.initilize` are completed.
+        await Future.delayed(const Duration(milliseconds: 1000));
+
+        final calls = irisMethodChannel.methodCallQueue
+            .where((e) => e.funcName == 'initilize')
+            .toList();
+        expect(calls.length == 1, true);
+
+        await rtcEngine.release();
+      },
+    );
+
+    testWidgets(
+      're-initialize once after release',
+      (WidgetTester tester) async {
+        String engineAppId = const String.fromEnvironment('TEST_APP_ID',
+            defaultValue: '<YOUR_APP_ID>');
+
+        Directory appDocDir = await getApplicationDocumentsDirectory();
+        String logPath = path.join(appDocDir.path, 'test_log.txt');
+        {
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+
+          final calls = irisMethodChannel.methodCallQueue
+              .where((e) => e.funcName == 'initilize')
+              .toList();
+          expect(calls.length == 1, true);
+
+          await rtcEngine.release();
+        }
+
+        irisMethodChannel.reset();
+
+        {
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+          await rtcEngine.initialize(RtcEngineContext(
+            appId: engineAppId,
+            areaCode: AreaCode.areaCodeGlob.value(),
+            logConfig: LogConfig(filePath: logPath),
+          ));
+
+          final calls = irisMethodChannel.methodCallQueue
+              .where((e) => e.funcName == 'initilize')
+              .toList();
+          expect(calls.length == 1, true);
+        }
+
+        await rtcEngine.release();
+      },
+    );
+  });
+}


### PR DESCRIPTION
A case like:
```dart
for (int i = 0; i < 5; ++i) {
  rtcEngine.initialize(RtcEngineContext(
    appId: engineAppId,
    areaCode: AreaCode.areaCodeGlob.value(),
    logConfig: LogConfig(filePath: logPath),
  ));
}
```
This causes `irisMethodChannel.initilize(args)`, and `_initializeInternal(context)` called multiple times, which causes unexpected behaviors.

`iris_method_channel` fix: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/pull/98