### PR TITLE
Fix can not parse 64-bits int from JSON

### DIFF
--- a/lib/src/impl/json_converters.dart
+++ b/lib/src/impl/json_converters.dart
@@ -51,3 +51,44 @@ class _VideoFrameMetaInfoInternalJson {
   /// @nodoc
   Map<String, dynamic> toJson() => _$VideoFrameMetaInfoInternalJsonToJson(this);
 }
+
+int _intPtrStr2Int(String value) {
+  // In 64-bits system, the c++ int ptr value (unsigned long 64) can be 2^64 - 1,
+  // which may greater than the dart int max value (2^63 - 1), so we can not decode
+  // the json with big int c++ int ptr value and parse it directly.
+  //
+  // After dart sdk 2.0 support parse hexadecimal in unsigned int64 range.
+  // https://github.com/dart-lang/language/blob/ee1135e0c22391cee17bf3ee262d6a04582d25de/archive/newsletter/20170929.md#semantics
+  //
+  // So we retrive the c++ int ptr value from the json string directly, and
+  // parse an int from hexadecimal here.
+  BigInt valueBI = BigInt.parse(value);
+  return int.tryParse('0x${valueBI.toRadixString(16)}') ?? 0;
+}
+
+/// Parse a c++ int ptr value from the json key `<key>_str`
+Object? readIntPtr(Map json, String key) {
+  final newKey = '${key}_str';
+  // Default to 0.
+  int returnValue = 0;
+  if (json.containsKey(newKey)) {
+    final value = json[newKey];
+    assert(value is String);
+    returnValue = _intPtrStr2Int(value);
+  }
+
+  return returnValue;
+}
+
+/// Same as `readIntPtr`, but for list of int ptr.
+Object? readIntPtrList(Map json, String key) {
+  final newKey = '${key}_str';
+  List<int> returnValue = [];
+  if (json.containsKey(newKey)) {
+    final value = json[newKey];
+    assert(value is List);
+    returnValue = List.from(value.map((e) => _intPtrStr2Int(e)));
+  }
+
+  return returnValue;
+}

--- a/lib/src/impl/json_converters.dart
+++ b/lib/src/impl/json_converters.dart
@@ -69,26 +69,23 @@ int _intPtrStr2Int(String value) {
 /// Parse a c++ int ptr value from the json key `<key>_str`
 Object? readIntPtr(Map json, String key) {
   final newKey = '${key}_str';
-  // Default to 0.
-  int returnValue = 0;
   if (json.containsKey(newKey)) {
     final value = json[newKey];
     assert(value is String);
-    returnValue = _intPtrStr2Int(value);
+    return _intPtrStr2Int(value);
   }
 
-  return returnValue;
+  return json[key];
 }
 
 /// Same as `readIntPtr`, but for list of int ptr.
 Object? readIntPtrList(Map json, String key) {
   final newKey = '${key}_str';
-  List<int> returnValue = [];
   if (json.containsKey(newKey)) {
     final value = json[newKey];
     assert(value is List);
-    returnValue = List.from(value.map((e) => _intPtrStr2Int(e)));
+    return List.from(value.map((e) => _intPtrStr2Int(e)));
   }
 
-  return returnValue;
+  return json[key];
 }

--- a/test/json_converters_test.dart
+++ b/test/json_converters_test.dart
@@ -24,8 +24,8 @@ void main() {
 }
 ''';
       final res = readIntPtr(jsonDecode(json), 'key');
-      // Shoud return 0
-      expect(res, 0);
+      // 18446744073709551615 become 18446744073709552000.0 after `jsonDecode`
+      expect(res, 18446744073709552000.0);
     });
 
     test(
@@ -61,8 +61,8 @@ void main() {
 }
 ''';
       final res = readIntPtrList(jsonDecode(json), 'key');
-      // Shoud return []
-      expect(res, []);
+      // 18446744073709551615 become 18446744073709552000.0 after `jsonDecode`
+      expect(res, [18446744073709552000.0, 18446744073709552000.0]);
     });
 
     test(

--- a/test/json_converters_test.dart
+++ b/test/json_converters_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:agora_rtc_engine/src/impl/json_converters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('readIntPtr', () {
+    test('can parse int ptr from key pattern <key>_str', () async {
+      const json = '''
+{
+  "key": 18446744073709551615,
+  "key_str": "18446744073709551615"
+}
+''';
+      final res = readIntPtr(jsonDecode(json), 'key');
+      // 18446744073709551615 is -1 in c++
+      expect(res, -1);
+    });
+
+    test('can parse int ptr if no key pattern <key>_str', () async {
+      const json = '''
+{
+  "key": 18446744073709551615
+}
+''';
+      final res = readIntPtr(jsonDecode(json), 'key');
+      // Shoud return 0
+      expect(res, 0);
+    });
+
+    test(
+        'throw assertion error if value of key pattern <key>_str is not type of String',
+        () async {
+      const json = '''
+{
+  "key": 18446744073709551615,
+  "key_str": 18446744073709551615
+}
+''';
+      expect(() => readIntPtr(jsonDecode(json), 'key'), throwsAssertionError);
+    });
+  });
+
+  group('readIntPtrList', () {
+    test('can parse int ptr list from key pattern <key>_str', () async {
+      const json = '''
+{
+  "key": [18446744073709551615, 18446744073709551615],
+  "key_str": ["18446744073709551615", "18446744073709551615"]
+}
+''';
+      final res = readIntPtrList(jsonDecode(json), 'key');
+      // 18446744073709551615 is -1 in c++
+      expect(res, const [-1, -1]);
+    });
+
+    test('can parse int ptr list if no key pattern <key>_str', () async {
+      const json = '''
+{
+  "key": [18446744073709551615, 18446744073709551615]
+}
+''';
+      final res = readIntPtrList(jsonDecode(json), 'key');
+      // Shoud return []
+      expect(res, []);
+    });
+
+    test(
+        'throw assertion error if value of key pattern <key>_str is not type of List',
+        () async {
+      const json = '''
+{
+  "key": [18446744073709551615, 18446744073709551615],
+  "key_str": 18446744073709551615
+}
+''';
+      expect(
+          () => readIntPtrList(jsonDecode(json), 'key'), throwsAssertionError);
+    });
+  });
+}


### PR DESCRIPTION
The native side will return a 64-bits int ptr value, most of it is `view_t`, `void *`, which will cause the dart `jsonDecode` error, so we passed the int ptr value through the string, and parse it to the int value.

This change is not yet supported on iris 4.3.x, so we do not apply any code changes at this time.