### PR TITLE
[test_shard] Fix some tests failed after upgrading the Flutter SDK 3.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ third_party/
 .ccls-cache/
 
 test_shard/**/scripts/iris_web_version.js
+test_shard/**/web/iris_web_version.js

--- a/ci/run_flutter_integration_test.sh
+++ b/ci/run_flutter_integration_test.sh
@@ -3,13 +3,19 @@
 set -e
 set -x
 
-MY_PATH=$(dirname "$0")
+MY_PATH=$(realpath $(dirname "$0"))
+PROJECT_ROOT=$(realpath ${MY_PATH}/..)
 PLATFORM=$1 # android/ios/macos/windows/web
 
 if [[ ${PLATFORM} == "web" ]];then
-    pushd ${MY_PATH}/../test_shard/fake_test_app
+    pushd ${PROJECT_ROOT}/test_shard/fake_test_app
+
+    IRIS_WEB_VERSION_PATH=${PROJECT_ROOT}/scripts/iris_web_version.js
+    rm -rf web/iris_web_version.js
+    cp -RP ${IRIS_WEB_VERSION_PATH} web/
 
     echo "Run integration test on web"
+    echo "If you want to run integration test on your local machine, please follow the https://docs.flutter.dev/testing/integration-tests#test-in-a-web-browser to setup first."
 
     flutter packages get
 

--- a/ci/run_rendering_test.sh
+++ b/ci/run_rendering_test.sh
@@ -3,14 +3,20 @@
 set -e
 set -x
 
-MY_PATH=$(dirname "$0")
+MY_PATH=$(realpath $(dirname "$0"))
+PROJECT_ROOT=$(realpath ${MY_PATH}/..)
 PLATFORM=$1 # android/ios/macos/windows/web
 
-pushd ${MY_PATH}/../test_shard/rendering_test
+pushd ${PROJECT_ROOT}/test_shard/rendering_test
 
 flutter packages get
 
 if [[ ${PLATFORM} == "web" ]];then
+
+    IRIS_WEB_VERSION_PATH=${PROJECT_ROOT}/scripts/iris_web_version.js
+    rm -rf web/iris_web_version.js
+    cp -RP ${IRIS_WEB_VERSION_PATH} web/
+
     echo "Run rendering test on web"
 
     flutter drive \

--- a/test_shard/fake_test_app/lib/main.dart
+++ b/test_shard/fake_test_app/lib/main.dart
@@ -139,8 +139,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              '$_counter'
             ),
           ],
         ),

--- a/test_shard/fake_test_app/pubspec.yaml
+++ b/test_shard/fake_test_app/pubspec.yaml
@@ -69,9 +69,7 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  assets:
-    # Add the `../../scripts/iris_web_version.js` to the assets, so we can use it in the `web/index.html` file.
-    - ../../scripts/iris_web_version.js
+  # assets:
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/test_shard/fake_test_app/web/index.html
+++ b/test_shard/fake_test_app/web/index.html
@@ -43,7 +43,7 @@
 <body>
   <!-- We add `../../scripts/iris_web_version.js` into the assets in `pubspec.yaml`, 
     the flutter run/build command will copy it to the `../scripts/iris_web_version.js` -->
-  <script type="text/javascript" src="../scripts/iris_web_version.js"></script>
+  <script type="text/javascript" src="./iris_web_version.js"></script>
   <script>
     window.addEventListener('load', function(ev) {
       // Download main.dart.js

--- a/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
+++ b/test_shard/integration_test_app/integration_test/testcases/fake_agora_video_view_testcases.dart
@@ -130,7 +130,7 @@ class FakeMethodChannelController {
       methodCallQueue.add(message);
 
       if (message.method == 'createTextureRender') {
-        final t = textrueId++;
+        final t = ++textrueId;
         final channelId = 'agora_rtc_engine/texture_render_$t';
         final c = MethodChannel(channelId);
         testDefaultBinaryMessenger.setMockMethodCallHandler(c, (message) async {
@@ -144,6 +144,8 @@ class FakeMethodChannelController {
               const MethodCall('onSizeChanged', {'width': 50, 'height': 50}));
         });
         return t;
+      } else if (message.method == 'destroyTextureRender') {
+        return true;
       }
 
       return 0;
@@ -165,12 +167,6 @@ class FakeMethodChannelController {
     textrueId = 0;
   }
 
-  void dispose() {
-    for (final c in mockedMethodChannels) {
-      testDefaultBinaryMessenger.setMockMethodCallHandler(c, null);
-    }
-    reset();
-  }
 
   void triggerPlatformMessage(String channelId, MethodCall methodCall) async {
     const StandardMethodCodec codec = StandardMethodCodec();
@@ -576,8 +572,8 @@ void testCases() {
                 }
                 return found;
               }), findsOneWidget);
-              // The first textureId is 0
-              expect(textureId == 0, isTrue);
+              // The first textureId is 1
+              expect(textureId == 1, isTrue);
             }
 
             fakeMethodChannelController.reset();
@@ -601,7 +597,6 @@ void testCases() {
               expect(disposeTextureRenderTextureId != -1, isTrue);
             }
 
-            fakeMethodChannelController.dispose();
           },
         );
 
@@ -652,8 +647,8 @@ void testCases() {
                 }
                 return found;
               }), findsOneWidget);
-              // The first textureId is 0
-              expect(textureId == 0, isTrue);
+              // The first textureId is 1
+              expect(textureId == 1, isTrue);
             }
 
             videoViewCreatedCompleter = Completer<void>();
@@ -698,11 +693,10 @@ void testCases() {
                 }
                 return found;
               }), findsOneWidget);
-              // The first textureId is 0
-              expect(textureId == 0, isTrue);
+              // The first textureId is 1
+              expect(textureId == 1, isTrue);
             }
 
-            fakeMethodChannelController.dispose();
           },
         );
 
@@ -822,10 +816,10 @@ void testCases() {
                   }
                   return found;
                 }), findsNWidgets(2));
-                // The first textureId is 0
-                expect(textureIds[0] == 0, isTrue);
-                // The second textureId is 0
-                expect(textureIds[1] == 1, isTrue);
+                // The first textureId is 1
+                expect(textureIds[0] == 1, isTrue);
+                // The second textureId is 1
+                expect(textureIds[1] == 2, isTrue);
               }
             }
 
@@ -893,14 +887,13 @@ void testCases() {
                   }
                   return found;
                 }), findsNWidgets(2));
-                // The third textureId is 2
-                expect(textureIds[0] == 2, isTrue);
+                // The third textureId is 3
+                expect(textureIds[0] == 3, isTrue);
                 // The fourth textureId is 3
-                expect(textureIds[1] == 3, isTrue);
+                expect(textureIds[1] == 4, isTrue);
               }
             }
 
-            fakeMethodChannelController.dispose();
 
             await tester.pumpWidget(Container());
             await tester.pumpAndSettle(const Duration(milliseconds: 5000));

--- a/test_shard/integration_test_app/lib/fake_remote_user_main.dart
+++ b/test_shard/integration_test_app/lib/fake_remote_user_main.dart
@@ -132,8 +132,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              '$_counter'
             ),
           ],
         ),

--- a/test_shard/integration_test_app/lib/main.dart
+++ b/test_shard/integration_test_app/lib/main.dart
@@ -145,8 +145,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              '$_counter'
             ),
           ],
         ),

--- a/test_shard/rendering_test/lib/main.dart
+++ b/test_shard/rendering_test/lib/main.dart
@@ -99,8 +99,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              '$_counter'
             ),
           ],
         ),

--- a/test_shard/rendering_test/pubspec.yaml
+++ b/test_shard/rendering_test/pubspec.yaml
@@ -71,8 +71,6 @@ flutter:
   assets:
     - assets/agoravideoview_rendering_test_solid_spilt.png
     - assets/agoravideoview_rendering_test_solid_spilt_small.png
-    # Add the `../../scripts/iris_web_version.js` to the assets, so we can use it in the `web/index.html` file.
-    - ../../scripts/iris_web_version.js
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/test_shard/rendering_test/web/index.html
+++ b/test_shard/rendering_test/web/index.html
@@ -42,7 +42,7 @@
 <body>
   <!-- We add `../../scripts/iris_web_version.js` into the assets in `pubspec.yaml`, 
   the flutter run/build command will copy it to the `../scripts/iris_web_version.js` -->
-  <script type="text/javascript" src="../scripts/iris_web_version.js"></script>
+  <script type="text/javascript" src="./iris_web_version.js"></script>
   <script>
     window.addEventListener('load', function(ev) {
       // Download main.dart.js


### PR DESCRIPTION
Some tests failed after upgrading the Flutter SDK 3.22, see https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/9177683376/job/25235867951?pr=1774

- Remove the use of `Theme.of(context).textTheme.headline4`.
- We previously added the `iris_web_version.js` as assets, and let the Flutter SDK copy the `iris_web_version.js` to the web folder, which does not work on Windows with Flutter SDK 3.22. We now copy the `iris_web_version.js` before running the test explicitly.
- The method channel call of `destroyTextureRender ` does not be mocked
- Remove the `FakeMethodChannelController.dispose`, which may reset the mock `MethodChannelCallHandler` too early, which caused an error on Windows(We checked the texture id can not be 0 on Windows).

