### PR TITLE
[ci][code-gen.yaml] Fix version regex

### DIFF
--- a/tool/terra/build.sh
+++ b/tool/terra/build.sh
@@ -12,10 +12,10 @@ if [ -n "$NEW_VERSION" ]; then
   # Check the operating system type
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS
-    sed -i '' -E "s/rtc_[0-9]+\.[0-9]+\.[0-9]+/${NEW_VERSION}/g" $TERRA_MAIN_FILE
+    sed -i '' -E "s/rtc_[0-9]+\.[0-9]+(\.[0-9]+)*/${NEW_VERSION}/g" $TERRA_MAIN_FILE
   else
     # Linux and other Unix-like systems
-    sed -i -E "s/rtc_[0-9]+\.[0-9]+\.[0-9]+/${NEW_VERSION}/g" $TERRA_MAIN_FILE
+    sed -i -E "s/rtc_[0-9]+\.[0-9]+(\.[0-9]+)*/${NEW_VERSION}/g" $TERRA_MAIN_FILE
   fi
   echo "Updated version to ${NEW_VERSION} in $TERRA_MAIN_FILE"
 fi


### PR DESCRIPTION
The code only matches the 3-segment version, but the native SDK can be 2-segment or 4-segment.