### PR TITLE
feat: upgrade native sdk dependencies 20240607

### DIFF
--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -2,7 +2,7 @@ Iris:
 https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Android_Video_20240509_1139.zip
 https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_iOS_Video_20240509_1139.zip
 https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Mac_Video_20240509_1139.zip
-https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Windows_Video_20240509_1139.zip
+https://download.agora.io/sdk/release/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152.zip
 implementation 'io.agora.rtc:iris-rtc:4.2.6.10-build.1'
 pod 'AgoraIrisRTC_iOS', '4.2.6.10-build.1'
 pod 'AgoraIrisRTC_macOS', '4.2.6.10-build.1'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -3,4 +3,4 @@ set -e
 export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Android_Video_20240509_1139.zip"
 export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_iOS_Video_20240509_1139.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Mac_Video_20240509_1139.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Windows_Video_20240509_1139.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.6.10-build.1_DCG_Windows_Video_20240509_1139.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.6.10-build.1_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.2.142-build.1_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native sdk dependencies 20240607
native sdk dependencies:
```

```

iris dependencies:
```
Iris: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.2.142-build.1/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152.zip Symbol: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/IRIS_RELEASE/4.2.2.142-build.1/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152_symbols.zip CDN: https://download.agora.io/sdk/release/iris_4.2.2.142-build.1_DCG_Windows_Video_20240329_1152.zip
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.