### PR TITLE
feat: upgrade native sdk dependencies 20240612

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,8 +58,8 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
     api 'io.agora.rtc:iris-rtc:4.2.6.10-build.1'
-    api 'io.agora.rtc:agora-special-full:4.2.6.12'
-    api 'io.agora.rtc:full-screen-sharing:4.2.6.12'
+    api 'io.agora.rtc:agora-special-full:4.2.6.240'
+    api 'io.agora.rtc:full-screen-sharing:4.2.6.240'
   }
 }
 

--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -12,7 +12,7 @@ https://download.agora.io/sdk/release/Agora_Native_SDK_for_Android_rel.v4.2.6.10
 https://download.agora.io/sdk/release/Agora_Native_SDK_for_iOS_rel.v4.2.6.10_41553_FULL_20240424_1218_300208.zip
 https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_rel.v4.2.6.10_20053_FULL_20240423_2008_300134.zip
 https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_rel.v4.2.6.10_24680_FULL_20240424_1808_300258.zip
-implementation 'io.agora.rtc:agora-special-full:4.2.6.12'
-implementation 'io.agora.rtc:full-screen-sharing:4.2.6.12'
-pod 'AgoraRtcEngine_Special_iOS', '4.2.6.12'
+implementation 'io.agora.rtc:agora-special-full:4.2.6.240'
+implementation 'io.agora.rtc:full-screen-sharing:4.2.6.240'
+pod 'AgoraRtcEngine_Special_iOS', '4.2.6.240'
 pod 'AgoraRtcEngine_Special_macOS', '4.2.6.10'

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.vendored_frameworks = 'libs/*.xcframework'
   else
   s.dependency 'AgoraIrisRTC_iOS', '4.2.6.10-build.1'
-  s.dependency 'AgoraRtcEngine_Special_iOS', '4.2.6.12'
+  s.dependency 'AgoraRtcEngine_Special_iOS', '4.2.6.240'
   end
   
   s.platform = :ios, '9.0'


### PR DESCRIPTION
Update native sdk dependencies 20240612
native sdk dependencies:
```
【maven】 implementation 'io.agora.rtc:agora-special-full:4.2.6.240'  implementation 'io.agora.rtc:full-screen-sharing:4.2.6.240'  【cocoapods】 pod 'AgoraRtcEngine_Special_iOS', '4.2.6.240'
```

iris dependencies:
```

```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.