### PR TITLE
[example] Do not show local video stats

### DIFF
--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -160,20 +160,16 @@ class _State extends State<JoinChannelVideo> {
       displayContentBuilder: (context, isLayoutHorizontal) {
         return Stack(
           children: [
-            StatsMonitoringWidget(
-              rtcEngine: _engine,
-              uid: 0,
-              child: AgoraVideoView(
-                controller: VideoViewController(
-                  rtcEngine: _engine,
-                  canvas: const VideoCanvas(uid: 0),
-                  useFlutterTexture: _isUseFlutterTexture,
-                  useAndroidSurfaceView: _isUseAndroidSurfaceView,
-                ),
-                onAgoraVideoViewCreated: (viewId) {
-                  _engine.startPreview();
-                },
+            AgoraVideoView(
+              controller: VideoViewController(
+                rtcEngine: _engine,
+                canvas: const VideoCanvas(uid: 0),
+                useFlutterTexture: _isUseFlutterTexture,
+                useAndroidSurfaceView: _isUseAndroidSurfaceView,
               ),
+              onAgoraVideoViewCreated: (viewId) {
+                _engine.startPreview();
+              },
             ),
             Align(
               alignment: Alignment.topLeft,


### PR DESCRIPTION
Do not show local video stats at this time, since there's a bug of `onLocalVideoStats`.