### PR TITLE
Bump minimum kotlin version to 1.7.0

### DIFF
--- a/ci/run_flutter_integration_test_android.sh
+++ b/ci/run_flutter_integration_test_android.sh
@@ -19,6 +19,9 @@ flutter packages get
 
 flutter test integration_test --verbose
 
+# Remove the build directory to save disk space
+rm -rf build/
+
 popd
 
 pushd ${MY_PATH}/../test_shard/integration_test_app

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    // Min kotlin version for Flutter SDK 3.x
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()

--- a/test_shard/fake_test_app/android/build.gradle
+++ b/test_shard/fake_test_app/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()

--- a/test_shard/integration_test_app/android/app/build.gradle
+++ b/test_shard/integration_test_app/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/test_shard/integration_test_app/android/build.gradle
+++ b/test_shard/integration_test_app/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()

--- a/test_shard/iris_tester/android/build.gradle
+++ b/test_shard/iris_tester/android/build.gradle
@@ -2,7 +2,8 @@ group 'com.example.iris_tester'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()

--- a/test_shard/iris_tester/android/build.gradle
+++ b/test_shard/iris_tester/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/test_shard/iris_tester/example/android/build.gradle
+++ b/test_shard/iris_tester/example/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()

--- a/test_shard/rendering_test/android/build.gradle
+++ b/test_shard/rendering_test/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    // Min kotlin version for Flutter SDK 3.24
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
> Error: Your project's Kotlin version (1.6.10) is lower than Flutter's minimum supported version of 1.7.0. Please upgrade your Kotlin version. 
  Alternatively, use the flag "--android-skip-build-dependency-validation" to bypass this check.

Fix build failed with Flutter SDK 3.24, which needs minimum Kotlin version 1.7.0 

Failed job: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/10305485073/job/28526448084?pr=1943