### PR TITLE
feat: upgrade native sdk dependencies 20240815

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   if (isDev(project)) {
     implementation fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.2.6.142-build.1'
+    api 'io.agora.rtc:iris-rtc:4.2.6.16-build.1'
     api 'io.agora.rtc:agora-special-voice:4.2.6.16.MINI.AUDIO'
   }
 }

--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,11 +1,11 @@
 Iris:
-https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Android_Video_20240815_0148.zip
+https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip
 https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_iOS_Video_20240815_0148.zip
-https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Mac_Video_20240815_0148.zip
-https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Windows_Video_20240815_0148.zip
-implementation 'io.agora.rtc:iris-rtc:4.2.6.142-build.1'
+https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip
+https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip
+implementation 'io.agora.rtc:iris-rtc:4.2.6.16-build.1'
 pod 'AgoraIrisRTC_iOS', '4.2.6.142-build.1'
-pod 'AgoraIrisRTC_macOS', '4.2.6.142-build.1'
+pod 'AgoraIrisRTC_macOS', '4.2.6.16-build.1'
 
 Native:
 https://download.agora.io/sdk/release/Agora_Native_SDK_for_Android_rel.v4.2.6.10_59623_FULL_20240423_1956_300131.zip

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -22,7 +22,7 @@ A new flutter plugin project.
     s.vendored_frameworks = 'libs/*.framework'
   else
   s.dependency 'AgoraRtcEngine_Special_macOS', '4.2.6.15'
-  s.dependency 'AgoraIrisRTC_macOS', '4.2.6.142-build.1'
+  s.dependency 'AgoraIrisRTC_macOS', '4.2.6.16-build.1'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Android_Video_20240815_0148.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip"
 export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_iOS_Video_20240815_0148.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Mac_Video_20240815_0148.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Windows_Video_20240815_0148.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_Windows_Video_20240815_0148.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.6.142-build.1_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.2.6.16-build.1_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native sdk dependencies 20240815
native sdk dependencies:
```

```

iris dependencies:
```
打包助手 8-15 11:51 Iris Android: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/android/iris_4.2.6.16-build.1_DCG_Android_Video_Standalone_20240815_1139.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/android/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/android/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139_private.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_Standalone_20240815_1139.zip https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.2.6.16-build.1'  打包助手 8-15 11:52 Iris Windows: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/windows/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/windows/iris_4.2.6.16-build.1_DCG_Windows_Video_Standalone_20240815_1139.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/windows/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139_private.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_Standalone_20240815_1139.zip  打包助手 8-15 11:52 Iris macOS: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/mac/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/mac/iris_4.2.6.16-build.1_DCG_Mac_Video_Standalone_20240815_1139.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/mac/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139_private.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_Standalone_20240815_1139.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.2.6.16-build.1'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.