### PR TITLE
feat: upgrade native sdk dependencies 20240815

### DIFF
--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,10 +1,10 @@
 Iris:
 https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip
-https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_iOS_Video_20240815_0148.zip
+https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_iOS_Video_20240815_1139.zip
 https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip
 https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip
 implementation 'io.agora.rtc:iris-rtc:4.2.6.16-build.1'
-pod 'AgoraIrisRTC_iOS', '4.2.6.142-build.1'
+pod 'AgoraIrisRTC_iOS', '4.2.6.16-build.1'
 pod 'AgoraIrisRTC_macOS', '4.2.6.16-build.1'
 
 Native:

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.142-build.1'
+  s.dependency 'AgoraIrisRTC_iOS', '4.2.6.16-build.1'
   s.dependency 'AgoraAudio_Special_iOS', '4.2.6.16.MINI.AUDIO'
   end
   

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
 export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Android_Video_20240815_1139.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.142-build.1_DCG_iOS_Video_20240815_0148.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_iOS_Video_20240815_1139.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Mac_Video_20240815_1139.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_Windows_Video_20240815_1139.zip"


### PR DESCRIPTION
Update native sdk dependencies 20240815
native sdk dependencies:
```

```

iris dependencies:
```
Iris iOS: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/ios/iris_4.2.6.16-build.1_DCG_iOS_Video_20240815_1139.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/ios/iris_4.2.6.16-build.1_DCG_iOS_Video_Standalone_20240815_1139.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.2/20240815/ios/iris_4.2.6.16-build.1_DCG_iOS_Video_20240815_1139_private.zip  CDN: https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_iOS_Video_20240815_1139.zip https://download.agora.io/sdk/release/iris_4.2.6.16-build.1_DCG_iOS_Video_Standalone_20240815_1139.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.2.6.16-build.1'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.