### PR TITLE
[testcase_gen] Pin paraphrase to tag: 0.1.0

### DIFF
--- a/tool/testcase_gen/pubspec.yaml
+++ b/tool/testcase_gen/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   paraphrase: 
     git:
       url: https://github.com/littleGnAl/paraphrase.git
-      ref: main
+      ref: 0.1.0
 
   args: ^2.3.1
 


### PR DESCRIPTION
The main branch will support the dart records features, which require the dart SDK >= 3.0.0, so we pin the `paraphrase` to avoid a break change.
https://github.com/littleGnAl/paraphrase/pull/1