### PR TITLE
feat: Bump minimum supported Flutter SDK >= 3.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -119,7 +119,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.16"]
+        version: ["3.7.0", "3.16"]
     runs-on: macos-12
     timeout-minutes: 120
     env:
@@ -140,7 +140,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: macos-12
     timeout-minutes: 120
     env:
@@ -185,7 +185,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: windows-2019
     timeout-minutes: 120
     env:
@@ -239,7 +239,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -259,7 +259,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
@@ -280,7 +280,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -325,7 +325,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["2.10.5", "3.x"]
+        version: ["3.7.0", "3.x"]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the agora_rtc_engine plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test_shard/fake_test_app/pubspec.yaml
+++ b/test_shard/fake_test_app/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=2.19.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test_shard/integration_test_app/pubspec.yaml
+++ b/test_shard/integration_test_app/pubspec.yaml
@@ -18,7 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: '>=2.19.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/test_shard/iris_tester/pubspec.yaml
+++ b/test_shard/iris_tester/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=2.19.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   flutter:

--- a/test_shard/rendering_test/pubspec.yaml
+++ b/test_shard/rendering_test/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=2.19.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
We need this change(https://github.com/flutter/engine/commit/90815e5f75dee1c20ce6d61d5161157513d90b84), which was released in Flutter SDK 3.7.0 to fix a crash on Windows(https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/pull/1999)

This PR is preparing for the fix.