### PR TITLE
[texture rendering][macos/ios/windows] Update the frame position to POSITION_POST_CAPTURER | POSITION_PRE_RENDERER

### DIFF
--- a/shared/darwin/TextureRenderer.mm
+++ b/shared/darwin/TextureRenderer.mm
@@ -104,7 +104,7 @@ public:
 }
 
 - (void)updateData:(NSNumber *)uid channelId:(NSString *)channelId videoSourceType:(NSNumber *)videoSourceType videoViewSetupMode:(NSNumber *)videoViewSetupMode {
-    IrisRtcVideoFrameConfig config = EmptyIrisRtcVideoFrameConfig;
+    IrisRtcVideoFrameConfig config;
     config.video_frame_format = agora::media::base::VIDEO_PIXEL_FORMAT::VIDEO_CVPIXEL_NV12;
     config.uid = [uid unsignedIntValue];
     config.video_source_type = [videoSourceType intValue];
@@ -114,6 +114,7 @@ public:
       strcpy(config.channelId, "");
     }
     config.video_view_setup_mode = [videoViewSetupMode intValue];
+        config.observed_frame_position = agora::media::base::VIDEO_MODULE_POSITION::POSITION_POST_CAPTURER | agora::media::base::VIDEO_MODULE_POSITION::POSITION_PRE_RENDERER;
     
     self.delegateId = self.irisRtcRendering->AddVideoFrameObserverDelegate(config, self.delegate);
 }

--- a/windows/texture_render.cc
+++ b/windows/texture_render.cc
@@ -117,10 +117,11 @@ TextureRender::CopyPixelBuffer(size_t width, size_t height)
 
 void TextureRender::UpdateData(unsigned int uid, const std::string &channelId, unsigned int videoSourceType, unsigned int videoViewSetupMode)
 {
-    IrisRtcVideoFrameConfig config = EmptyIrisRtcVideoFrameConfig;
+    IrisRtcVideoFrameConfig config;
     config.uid = uid;
     config.video_source_type = videoSourceType;
     config.video_frame_format = agora::media::base::VIDEO_PIXEL_FORMAT::VIDEO_PIXEL_RGBA;
+    config.observed_frame_position = agora::media::base::VIDEO_MODULE_POSITION::POSITION_POST_CAPTURER | agora::media::base::VIDEO_MODULE_POSITION::POSITION_PRE_RENDERER;
     if (!channelId.empty())
     {
         strcpy_s(config.channelId, channelId.c_str());


### PR DESCRIPTION
[texture rendering][macos/ios/windows] Update the frame position to POSITION_POST_CAPTURER | POSITION_PRE_RENDERER for consistency with the Android changes introduced in version 4.3.2. Without this update, a bug will occur in version 4.4.0. This change also prepares for further adjustments in 4.4.0.