### PR TITLE
Upgrade iris_method_channel: ^2.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel: 2.1.1
+  iris_method_channel: ^2.2.0
   js: '>=0.6.3'
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Upgrade iris_method_channel to version ^2.2.0 to ensure compatibility with the 2.x.