### PR TITLE
fix: Fix some callbacks not fired

### DIFF
--- a/lib/src/agora_rtc_engine.dart
+++ b/lib/src/agora_rtc_engine.dart
@@ -1877,7 +1877,7 @@ class RtcEngineEventHandler {
   ///
   /// * [connection] The connection information. See RtcConnection.
   /// * [elapsed] Time elapsed (ms) from the local user calling joinChannel until this callback is triggered.
-  final void Function(VideoSourceType source, int elapsed)?
+  final void Function(RtcConnection connection, int elapsed)?
       onFirstLocalVideoFramePublished;
 
   /// Occurs when the first remote video frame is received and decoded.
@@ -2038,7 +2038,7 @@ class RtcEngineEventHandler {
   ///
   /// * [connection] The connection information. See RtcConnection.
   /// * [stats] The statistics of the local video stream. See LocalVideoStats.
-  final void Function(VideoSourceType source, LocalVideoStats stats)?
+  final void Function(RtcConnection connection, LocalVideoStats stats)?
       onLocalVideoStats;
 
   /// Reports the statistics of the video stream sent by each remote users.

--- a/lib/src/binding/agora_rtc_engine_event_impl.dart
+++ b/lib/src/binding/agora_rtc_engine_event_impl.dart
@@ -400,7 +400,7 @@ class RtcEngineEventHandlerWrapper implements EventLoopEventHandler {
             source, width, height, elapsed);
         return true;
 
-      case 'onFirstLocalVideoFramePublished_2ad83d8':
+      case 'onFirstLocalVideoFramePublished_263e4cd':
         if (rtcEngineEventHandler.onFirstLocalVideoFramePublished == null) {
           return true;
         }
@@ -409,13 +409,14 @@ class RtcEngineEventHandlerWrapper implements EventLoopEventHandler {
             RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson.fromJson(
                 jsonMap);
         paramJson = paramJson.fillBuffers(buffers);
-        VideoSourceType? source = paramJson.source;
+        RtcConnection? connection = paramJson.connection;
         int? elapsed = paramJson.elapsed;
-        if (source == null || elapsed == null) {
+        if (connection == null || elapsed == null) {
           return true;
         }
-
-        rtcEngineEventHandler.onFirstLocalVideoFramePublished!(source, elapsed);
+        connection = connection.fillBuffers(buffers);
+        rtcEngineEventHandler.onFirstLocalVideoFramePublished!(
+            connection, elapsed);
         return true;
 
       case 'onFirstRemoteVideoDecoded_a68170a':
@@ -704,7 +705,7 @@ class RtcEngineEventHandlerWrapper implements EventLoopEventHandler {
         rtcEngineEventHandler.onLocalAudioStats!(connection, stats);
         return true;
 
-      case 'onLocalVideoStats_baa96c8':
+      case 'onLocalVideoStats_3ac0eb4':
         if (rtcEngineEventHandler.onLocalVideoStats == null) {
           return true;
         }
@@ -712,13 +713,14 @@ class RtcEngineEventHandlerWrapper implements EventLoopEventHandler {
         RtcEngineEventHandlerOnLocalVideoStatsJson paramJson =
             RtcEngineEventHandlerOnLocalVideoStatsJson.fromJson(jsonMap);
         paramJson = paramJson.fillBuffers(buffers);
-        VideoSourceType? source = paramJson.source;
+        RtcConnection? connection = paramJson.connection;
         LocalVideoStats? stats = paramJson.stats;
-        if (source == null || stats == null) {
+        if (connection == null || stats == null) {
           return true;
         }
+        connection = connection.fillBuffers(buffers);
         stats = stats.fillBuffers(buffers);
-        rtcEngineEventHandler.onLocalVideoStats!(source, stats);
+        rtcEngineEventHandler.onLocalVideoStats!(connection, stats);
         return true;
 
       case 'onRemoteVideoStats_2f43a70':

--- a/lib/src/binding/event_handler_param_json.dart
+++ b/lib/src/binding/event_handler_param_json.dart
@@ -2106,10 +2106,10 @@ extension RtcEngineEventHandlerOnFirstLocalVideoFrameJsonBufferExt
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson {
   const RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson(
-      {this.source, this.elapsed});
+      {this.connection, this.elapsed});
 
-  @JsonKey(name: 'source')
-  final VideoSourceType? source;
+  @JsonKey(name: 'connection')
+  final RtcConnection? connection;
 
   @JsonKey(name: 'elapsed')
   final int? elapsed;
@@ -2668,10 +2668,11 @@ extension RtcEngineEventHandlerOnLocalAudioStatsJsonBufferExt
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class RtcEngineEventHandlerOnLocalVideoStatsJson {
-  const RtcEngineEventHandlerOnLocalVideoStatsJson({this.source, this.stats});
+  const RtcEngineEventHandlerOnLocalVideoStatsJson(
+      {this.connection, this.stats});
 
-  @JsonKey(name: 'source')
-  final VideoSourceType? source;
+  @JsonKey(name: 'connection')
+  final RtcConnection? connection;
 
   @JsonKey(name: 'stats')
   final LocalVideoStats? stats;

--- a/lib/src/binding/event_handler_param_json.g.dart
+++ b/lib/src/binding/event_handler_param_json.g.dart
@@ -1803,7 +1803,10 @@ RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson
     _$RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonFromJson(
             Map<String, dynamic> json) =>
         RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson(
-          source: $enumDecodeNullable(_$VideoSourceTypeEnumMap, json['source']),
+          connection: json['connection'] == null
+              ? null
+              : RtcConnection.fromJson(
+                  json['connection'] as Map<String, dynamic>),
           elapsed: (json['elapsed'] as num?)?.toInt(),
         );
 
@@ -1818,7 +1821,7 @@ Map<String, dynamic>
     }
   }
 
-  writeNotNull('source', _$VideoSourceTypeEnumMap[instance.source]);
+  writeNotNull('connection', instance.connection?.toJson());
   writeNotNull('elapsed', instance.elapsed);
   return val;
 }
@@ -2310,7 +2313,10 @@ RtcEngineEventHandlerOnLocalVideoStatsJson
     _$RtcEngineEventHandlerOnLocalVideoStatsJsonFromJson(
             Map<String, dynamic> json) =>
         RtcEngineEventHandlerOnLocalVideoStatsJson(
-          source: $enumDecodeNullable(_$VideoSourceTypeEnumMap, json['source']),
+          connection: json['connection'] == null
+              ? null
+              : RtcConnection.fromJson(
+                  json['connection'] as Map<String, dynamic>),
           stats: json['stats'] == null
               ? null
               : LocalVideoStats.fromJson(json['stats'] as Map<String, dynamic>),
@@ -2326,7 +2332,7 @@ Map<String, dynamic> _$RtcEngineEventHandlerOnLocalVideoStatsJsonToJson(
     }
   }
 
-  writeNotNull('source', _$VideoSourceTypeEnumMap[instance.source]);
+  writeNotNull('connection', instance.connection?.toJson());
   writeNotNull('stats', instance.stats?.toJson());
   return val;
 }

--- a/test_shard/fake_test_app/integration_test/generated/event_ids_mapping_gen.dart
+++ b/test_shard/fake_test_app/integration_test/generated/event_ids_mapping_gen.dart
@@ -178,7 +178,7 @@ const eventIdsMapping = {
     "RtcEngineEventHandler_onFirstLocalVideoFrame_ebdfd19"
   ],
   "RtcEngineEventHandler_onFirstLocalVideoFramePublished": [
-    "RtcEngineEventHandler_onFirstLocalVideoFramePublished_2ad83d8"
+    "RtcEngineEventHandler_onFirstLocalVideoFramePublished_263e4cd"
   ],
   "RtcEngineEventHandler_onFirstRemoteVideoDecoded": [
     "RtcEngineEventHandler_onFirstRemoteVideoDecoded_a68170a"
@@ -223,7 +223,7 @@ const eventIdsMapping = {
     "RtcEngineEventHandler_onLocalAudioStats_5657f05"
   ],
   "RtcEngineEventHandler_onLocalVideoStats": [
-    "RtcEngineEventHandler_onLocalVideoStats_baa96c8"
+    "RtcEngineEventHandler_onLocalVideoStats_3ac0eb4"
   ],
   "RtcEngineEventHandler_onRemoteVideoStats": [
     "RtcEngineEventHandler_onRemoteVideoStats_2f43a70"

--- a/test_shard/fake_test_app/integration_test/generated/rtcengine_fake_test.generated.dart
+++ b/test_shard/fake_test_app/integration_test/generated/rtcengine_fake_test.generated.dart
@@ -8009,7 +8009,7 @@ void rtcEngineSmokeTestCases() {
           onFirstLocalVideoFrame:
               (VideoSourceType source, int width, int height, int elapsed) {},
           onFirstLocalVideoFramePublished:
-              (VideoSourceType source, int elapsed) {},
+              (RtcConnection connection, int elapsed) {},
           onFirstRemoteVideoDecoded: (RtcConnection connection, int remoteUid,
               int width, int height, int elapsed) {},
           onVideoSizeChanged: (RtcConnection connection,
@@ -8045,7 +8045,8 @@ void rtcEngineSmokeTestCases() {
               (RtcConnection connection, RemoteAudioStats stats) {},
           onLocalAudioStats:
               (RtcConnection connection, LocalAudioStats stats) {},
-          onLocalVideoStats: (VideoSourceType source, LocalVideoStats stats) {},
+          onLocalVideoStats:
+              (RtcConnection connection, LocalVideoStats stats) {},
           onRemoteVideoStats:
               (RtcConnection connection, RemoteVideoStats stats) {},
           onCameraReady: () {},
@@ -8225,7 +8226,7 @@ void rtcEngineSmokeTestCases() {
           onFirstLocalVideoFrame:
               (VideoSourceType source, int width, int height, int elapsed) {},
           onFirstLocalVideoFramePublished:
-              (VideoSourceType source, int elapsed) {},
+              (RtcConnection connection, int elapsed) {},
           onFirstRemoteVideoDecoded: (RtcConnection connection, int remoteUid,
               int width, int height, int elapsed) {},
           onVideoSizeChanged: (RtcConnection connection,
@@ -8261,7 +8262,8 @@ void rtcEngineSmokeTestCases() {
               (RtcConnection connection, RemoteAudioStats stats) {},
           onLocalAudioStats:
               (RtcConnection connection, LocalAudioStats stats) {},
-          onLocalVideoStats: (VideoSourceType source, LocalVideoStats stats) {},
+          onLocalVideoStats:
+              (RtcConnection connection, LocalVideoStats stats) {},
           onRemoteVideoStats:
               (RtcConnection connection, RemoteVideoStats stats) {},
           onCameraReady: () {},

--- a/test_shard/fake_test_app/integration_test/generated/rtcengine_rtcengineeventhandler_testcases.generated.dart
+++ b/test_shard/fake_test_app/integration_test/generated/rtcengine_rtcengineeventhandler_testcases.generated.dart
@@ -1502,7 +1502,8 @@ void generatedTestCases(ValueGetter<IrisTester> irisTester) {
 
       final onFirstLocalVideoFramePublishedCompleter = Completer<bool>();
       final theRtcEngineEventHandler = RtcEngineEventHandler(
-        onFirstLocalVideoFramePublished: (VideoSourceType source, int elapsed) {
+        onFirstLocalVideoFramePublished:
+            (RtcConnection connection, int elapsed) {
           onFirstLocalVideoFramePublishedCompleter.complete(true);
         },
       );
@@ -1515,11 +1516,16 @@ void generatedTestCases(ValueGetter<IrisTester> irisTester) {
       await Future.delayed(const Duration(milliseconds: 500));
 
       {
-        VideoSourceType source = VideoSourceType.videoSourceCameraPrimary;
+        String connectionChannelId = "hello";
+        int connectionLocalUid = 5;
+        RtcConnection connection = RtcConnection(
+          channelId: connectionChannelId,
+          localUid: connectionLocalUid,
+        );
         int elapsed = 5;
 
         final eventJson = {
-          'source': source.value(),
+          'connection': connection.toJson(),
           'elapsed': elapsed,
         };
 
@@ -2652,7 +2658,7 @@ void generatedTestCases(ValueGetter<IrisTester> irisTester) {
 
       final onLocalVideoStatsCompleter = Completer<bool>();
       final theRtcEngineEventHandler = RtcEngineEventHandler(
-        onLocalVideoStats: (VideoSourceType source, LocalVideoStats stats) {
+        onLocalVideoStats: (RtcConnection connection, LocalVideoStats stats) {
           onLocalVideoStatsCompleter.complete(true);
         },
       );
@@ -2665,7 +2671,12 @@ void generatedTestCases(ValueGetter<IrisTester> irisTester) {
       await Future.delayed(const Duration(milliseconds: 500));
 
       {
-        VideoSourceType source = VideoSourceType.videoSourceCameraPrimary;
+        String connectionChannelId = "hello";
+        int connectionLocalUid = 5;
+        RtcConnection connection = RtcConnection(
+          channelId: connectionChannelId,
+          localUid: connectionLocalUid,
+        );
         QualityAdaptIndication statsQualityAdaptIndication =
             QualityAdaptIndication.adaptNone;
         VideoCodecType statsCodecType = VideoCodecType.videoCodecNone;
@@ -2718,7 +2729,7 @@ void generatedTestCases(ValueGetter<IrisTester> irisTester) {
         );
 
         final eventJson = {
-          'source': source.value(),
+          'connection': connection.toJson(),
           'stats': stats.toJson(),
         };
 

--- a/tool/terra/configs/cud_node_parser.config.ts
+++ b/tool/terra/configs/cud_node_parser.config.ts
@@ -40,23 +40,9 @@ const deleteNodes = [
     parent_name: "IRtcEngineEventHandlerEx",
   },
   {
-    // onFirstLocalVideoFramePublished
-    __TYPE: CXXTYPE.MemberFunction,
-    name: "onFirstLocalVideoFramePublished",
-    namespaces: ["agora", "rtc"],
-    parent_name: "IRtcEngineEventHandlerEx",
-  },
-  {
     // onLocalVideoStateChanged
     __TYPE: CXXTYPE.MemberFunction,
     name: "onLocalVideoStateChanged",
-    namespaces: ["agora", "rtc"],
-    parent_name: "IRtcEngineEventHandlerEx",
-  },
-  {
-    // onLocalVideoStats
-    __TYPE: CXXTYPE.MemberFunction,
-    name: "onLocalVideoStats",
     namespaces: ["agora", "rtc"],
     parent_name: "IRtcEngineEventHandlerEx",
   },


### PR DESCRIPTION
Fix `onFirstLocalVideoFramePublished` not fired, the one with `connection` is fired by Native SDK.
Fix `onLocalVideoStats` not fired, the one with `connection` is fired by Native SDK.