### PR TITLE
feat: upgrade native sdk dependencies 20240929

### DIFF
--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,10 +1,10 @@
 Iris:
 https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Android_Video_16K_20240927_0549_660.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_iOS_Video_20240927_0552_535.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip
 https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Mac_Video_20240927_0549_505.zip
 https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Windows_Video_20240927_0549_544.zip
 implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.4'
-pod 'AgoraIrisRTC_iOS', '4.5.0-dev.4'
+pod 'AgoraIrisRTC_iOS', '4.5.0-dev.5'
 pod 'AgoraIrisRTC_macOS', '4.5.0-dev.4'
 
 Native:

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.4'
+  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.5'
   s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.4'
   end
   

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
 export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Android_Video_16K_20240927_0549_660.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_iOS_Video_20240927_0552_535.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip"
 export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Mac_Video_20240927_0549_505.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Windows_Video_20240927_0549_544.zip"


### PR DESCRIPTION
Update native dependencies 20240929
native dependencies:
```
Iris iOS: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20240929/ios/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20240929/ios/iris_4.5.0-dev.5_DCG_iOS_Video_Standalone_20240929_0602_538.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20240929/ios/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538_xdump.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20240929/ios/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538_private.zip  CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_Standalone_20240929_0602_538.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.5.0-dev.5'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.