### PR TITLE
feat: upgrade native sdk dependencies 20241015

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   if (isDev(project)) {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.5.0-dev.4'
-    api 'io.agora.rtc:agora-full-preview:4.5.0-dev.4'
-    api 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.4'
+    api 'io.agora.rtc:iris-rtc:4.5.0-dev.6'
+    api 'io.agora.rtc:agora-full-preview:4.5.0-dev.6'
+    api 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.6'
   }
 }
 

--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,18 +1,18 @@
 Iris:
-https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Android_Video_16K_20240927_0549_660.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Mac_Video_20240927_0549_505.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Windows_Video_20240927_0549_544.zip
-implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.4'
-pod 'AgoraIrisRTC_iOS', '4.5.0-dev.5'
-pod 'AgoraIrisRTC_macOS', '4.5.0-dev.4'
+https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550.zip
+implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.6'
+pod 'AgoraIrisRTC_iOS', '4.5.0-dev.6'
+pod 'AgoraIrisRTC_macOS', '4.5.0-dev.6'
 
 Native:
 <NATIVE_CDN_URL_ANDROID>
 <NATIVE_CDN_URL_IOS>
 <NATIVE_CDN_URL_MACOS>
 <NATIVE_CDN_URL_WINDOWS>
-implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.4'
-implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.4'
-pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.4'
-pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.4'
+implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.6'
+implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.6'
+pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.6'
+pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.6'

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.5'
-  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.4'
+  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.6'
+  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.6'
   end
   
   s.platform = :ios, '9.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -21,8 +21,8 @@ A new flutter plugin project.
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework', 'libs/*.framework'
   else
-  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.4'
-  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-dev.4'
+  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.6'
+  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-dev.6'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Android_Video_16K_20240927_0549_660.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.5_DCG_iOS_Video_20240929_0602_538.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Mac_Video_20240927_0549_505.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Windows_Video_20240927_0549_544.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.5.0-dev.4_DCG_Windows_Video_20240927_0549_544.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.5.0-dev.4_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.5.0-dev.6_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native dependencies 20241015
native dependencies:
```
打包助手 10-11 13:40 Iris macOS: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/mac/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/mac/iris_4.5.0-dev.6_DCG_Mac_Video_Standalone_20241011_0131_511.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/mac/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511_private.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/mac/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511_xdump.zip  CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Mac_Video_20241011_0131_511.zip https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Mac_Video_Standalone_20241011_0131_511.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.5.0-dev.6'  打包助手 10-11 13:42 Iris Android: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/android/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/android/iris_4.5.0-dev.6_DCG_Android_Video_Standalone_16K_20241011_0131_666.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/android/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666_private.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/android/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666_xdump.zip  CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Android_Video_16K_20241011_0131_666.zip https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Android_Video_Standalone_16K_20241011_0131_666.zip Maven: implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.6'  打包助手 10-11 13:43 Iris iOS: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/ios/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/ios/iris_4.5.0-dev.6_DCG_iOS_Video_Standalone_20241011_0134_542.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/ios/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542_private.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/ios/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542_xdump.zip  CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_iOS_Video_20241011_0134_542.zip https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_iOS_Video_Standalone_20241011_0134_542.zip Cocoapods: pod 'AgoraIrisRTC_iOS', '4.5.0-dev.6'  打包助手 10-11 13:43 Iris Windows: Artifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/windows/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/windows/iris_4.5.0-dev.6_DCG_Windows_Video_Standalone_20241011_0131_550.zip PrivateArtifactory: https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/windows/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550_private.zip https://artifactory-api.bj2.agoralab.co/artifactory/CSDC_repo/EP/4.5/20241011/windows/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550_xdump.zip  CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Windows_Video_20241011_0131_550.zip https://download.agora.io/sdk/release/iris_4.5.0-dev.6_DCG_Windows_Video_Standalone_20241011_0131_550.zip  打包助手 10-11 13:43 Packages: implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.6'  打包助手 10-11 13:43 Packages: implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.6'  打包助手 10-11 13:43 Packages: pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.6'  打包助手 10-11 13:43 Packages: pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.6'
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.