### PR TITLE
fix: Suppress R8 missing class com.google.devtools.*.ThrowableExtension for AGP 8.x

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -3,3 +3,5 @@
 -keep class org.jetbrains.** { *; }
 
 -keep class io.agora.**{*;}
+# Supress ERROR: R8: Missing class com.google.devtools.build.android.desugar.runtime.ThrowableExtension
+-dontwarn com.google.devtools.build.android.desugar.runtime.ThrowableExtension

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -3,5 +3,5 @@
 -keep class org.jetbrains.** { *; }
 
 -keep class io.agora.**{*;}
-# Supress ERROR: R8: Missing class com.google.devtools.build.android.desugar.runtime.ThrowableExtension
+# Suppress ERROR: R8: Missing class com.google.devtools.build.android.desugar.runtime.ThrowableExtension
 -dontwarn com.google.devtools.build.android.desugar.runtime.ThrowableExtension


### PR DESCRIPTION
Suppress `ERROR: R8: Missing class com.google.devtools.build.android.desugar.runtime.ThrowableExtension` when running with AGP 8.x

The Android Native SDK has caught this error internally, so we're safe to suppress this error.

Fix failed job https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/11359234733/job/31595029855?pr=2049