### PR TITLE
fix: Fix a potential crash in AgoraVideoView when the app is force quit

### DIFF
--- a/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
@@ -232,5 +232,6 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
 
     public void dispose() {
         methodChannel.setMethodCallHandler(null);
+        disposeAllRenderers();
     }
 }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -251,7 +251,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					71BBA3B728AB50E2007B0DBC = {
@@ -488,7 +488,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -543,7 +543,7 @@
 				INFOPLIST_FILE = ScreenSharing/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -580,7 +580,7 @@
 				INFOPLIST_FILE = ScreenSharing/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -616,7 +616,7 @@
 				INFOPLIST_FILE = ScreenSharing/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenSharing;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -680,7 +680,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -729,7 +729,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/ios/Classes/AgoraRtcNgPlugin.m
+++ b/ios/Classes/AgoraRtcNgPlugin.m
@@ -8,6 +8,8 @@
 
 @property(nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
 
+- (void) dispose;
+
 @end
 
 @implementation AgoraRtcNgPlugin
@@ -55,6 +57,22 @@
         } else {
     result(FlutterMethodNotImplemented);
   }
+}
+
+- (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+    [self dispose];
+}
+
+- (void) dispose {
+    if (self.videoViewController) {
+        [self.videoViewController dispose];
+        self.videoViewController = NULL;
+    }
+}
+
+- (void)dealloc
+{
+    [self dispose];
 }
 
 @end

--- a/shared/darwin/TextureRenderer.mm
+++ b/shared/darwin/TextureRenderer.mm
@@ -64,7 +64,7 @@ public:
             }
             dispatch_semaphore_signal(renderer.lock);
             
-            if (renderer.isDirtyBuffer) {
+            if (renderer.textureRegistry && renderer.isDirtyBuffer) {
                 [renderer.textureRegistry textureFrameAvailable:renderer.textureId];
             }
         }
@@ -126,13 +126,19 @@ public:
 }
 
 - (void)dispose {
-    self.irisRtcRendering->RemoveVideoFrameObserverDelegate(self.delegateId);
+    if (self.irisRtcRendering) {
+        self.irisRtcRendering->RemoveVideoFrameObserverDelegate(self.delegateId);
+        self.irisRtcRendering = NULL;
+    }
     if (self.delegate) {
         delete self.delegate;
         self.delegate = NULL;
     }
-    [self.textureRegistry unregisterTexture:self.textureId];
-    if (self.isDirtyBuffer) {
+    if (self.textureRegistry) {
+        [self.textureRegistry unregisterTexture:self.textureId];
+        self.textureRegistry = NULL;
+    }
+    if (self.buffer_cache && self.isDirtyBuffer) {
       CVPixelBufferRelease(self.buffer_cache);
       self.buffer_cache = NULL;
     }

--- a/shared/darwin/VideoViewController.h
+++ b/shared/darwin/VideoViewController.h
@@ -28,6 +28,8 @@
 
 - (BOOL)destroyTextureRender:(int64_t)textureId;
 
+- (void)dispose;
+
 @end
 
 

--- a/shared/darwin/VideoViewController.mm
+++ b/shared/darwin/VideoViewController.mm
@@ -132,8 +132,6 @@
 @property(nonatomic) PlatformRenderPool* platformRenderPool;
 
 @property(nonatomic, strong) FlutterMethodChannel *methodChannel;
-
-- (void)dispose;
 @end
 
 @implementation VideoViewController


### PR DESCRIPTION
If an `AgoraVideoView` is displayed and a video frame callback is received while the app is quitting, there is a potential crash risk due to access to invalid resources(invalid adresses) in the callback. To prevent this, we should ensure that resources are properly cleaned up in the destructor.

This logic is already handled in the Windows implementation, so in this PR, we are updating it for Android, iOS, and macOS only.