### PR TITLE
Update iris_method_channel constraint to >= 2.2.2 for improved compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel: ^2.2.0
+  iris_method_channel: '>=2.2.0'
   js: '>=0.6.3'
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
See https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/pull/181