### PR TITLE
feat: upgrade native sdk dependencies 20241125

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download the `iris_web`(see the link below) artifact and include it as a `<scrip
 </body>
 </html>
 ```
-Download: https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.0.js
+Download: https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js
 
 **For Testing Purposes**
 
@@ -101,7 +101,7 @@ You can directly depend on the Agora CDN for testing purposes:
 ...
 <body>
   ...
-  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.0.js"></script>
+  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js"></script>
 </body>
 </html>
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   if (isDev(project)) {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.5.0-dev.13'
-    api 'io.agora.rtc:agora-full-preview:4.5.0-dev.13'
-    api 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.13'
+    api 'io.agora.rtc:iris-rtc:4.5.0-dev.15'
+    api 'io.agora.rtc:agora-full-preview:4.5.0-dev.15'
+    api 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.15'
   }
 }
 

--- a/android/src/main/cpp/third_party/include/agora_rtc/rte_base/c/c_rte.h
+++ b/android/src/main/cpp/third_party/include/agora_rtc/rte_base/c/c_rte.h
@@ -93,7 +93,7 @@ AGORA_RTE_API_C void RteConfigGetJsonParameter(RteConfig *config,
                                               RteError *err);
 
 AGORA_RTE_API_C Rte RteCreate(RteInitialConfig *config, RteError *err);
-AGORA_RTE_API_C void RteDestroy(Rte *self, RteError *err);
+AGORA_RTE_API_C bool RteDestroy(Rte *self, RteError *err);
 
 AGORA_RTE_API_C bool RteInitMediaEngine(Rte *self,
                                        void (*cb)(Rte *self, void *cb_data,

--- a/android/src/main/cpp/third_party/include/agora_rtc/rte_base/rte_cpp_rte.h
+++ b/android/src/main/cpp/third_party/include/agora_rtc/rte_base/rte_cpp_rte.h
@@ -269,7 +269,7 @@ class Rte {
    * @param config Rte object initialization configuration object.
    */
   explicit Rte(InitialConfig *config = nullptr): c_rte(::RteCreate(config != nullptr ? &config->c_rte_init_cfg : nullptr, nullptr)) {}
-  ~Rte(){RteDestroy(&c_rte, nullptr);};
+  ~Rte(){Destroy();};
 
   /**
    * Construct a new Rte object.
@@ -373,6 +373,20 @@ class Rte {
    */
   bool SetConfigs(Config *config, Error *err = nullptr){
     return RteSetConfigs(&c_rte, config != nullptr ? config->get_underlying_impl(): nullptr, err != nullptr ? err->get_underlying_impl() : nullptr);
+  }
+
+  /**
+   * Destroy the Rte object. The operation will release all resources used by the Rte object.
+   * @since v4.4.0
+   * @param err Possible return values for ErrorCode:
+   *  - kRteOk: Success
+   *  - kRteErrorInvalidOperation: The corresponding internal Rte object has been destroyed or is invalid.
+   * @return bool Returns the result of destroying the Rte object.
+   *  - true: Successfully destroyed.
+   *  - false: Failed to destroy.
+   */
+  bool Destroy(Error *err = nullptr){
+    return RteDestroy(&c_rte, err != nullptr ? err->get_underlying_impl() : nullptr);
   }
 
  private:

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -100,6 +100,6 @@
       loadMainDartJs();
     }
   </script>
-  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.0.js"></script>
+  <script src="https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js"></script>
 </body>
 </html>

--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,18 +1,18 @@
 Iris:
-https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Android_Video_16K_20241121_0622_696.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_iOS_Video_20241121_0622_570.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Mac_Video_20241121_0622_530.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Android_Video_16K_20241125_1201_699.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_iOS_Video_20241125_1201_573.zip
+https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Mac_Video_20241125_1201_533.zip
 https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Windows_Video_20241121_0622_573.zip
-implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.13'
-pod 'AgoraIrisRTC_iOS', '4.5.0-dev.13'
-pod 'AgoraIrisRTC_macOS', '4.5.0-dev.13'
+implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.15'
+pod 'AgoraIrisRTC_iOS', '4.5.0-dev.15'
+pod 'AgoraIrisRTC_macOS', '4.5.0-dev.15'
 
 Native:
 <NATIVE_CDN_URL_ANDROID>
 <NATIVE_CDN_URL_IOS>
 <NATIVE_CDN_URL_MACOS>
 <NATIVE_CDN_URL_WINDOWS>
-implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.13'
-implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.13'
-pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.13'
-pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.13'
+implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.15'
+implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.15'
+pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.15'
+pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.15'

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.13'
-  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.13'
+  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.15'
+  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.15'
   end
   
   s.platform = :ios, '9.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -21,8 +21,8 @@ A new flutter plugin project.
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework', 'libs/*.framework'
   else
-  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.13'
-  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-dev.13'
+  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.15'
+  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-dev.15'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Android_Video_16K_20241121_0622_696.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_iOS_Video_20241121_0622_570.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Mac_Video_20241121_0622_530.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Android_Video_16K_20241125_1201_699.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_iOS_Video_20241125_1201_573.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Mac_Video_20241125_1201_533.zip"
 export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Windows_Video_20241121_0622_573.zip"

--- a/scripts/iris_web_version.js
+++ b/scripts/iris_web_version.js
@@ -1,8 +1,8 @@
 // Share the iris web url to all the tests
 
 // This url should be same as the url inside the `example/web/index.html`
-const irisWebUrl = 'https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.0.js';
-const irisWebFakeUrl = 'https://download.agora.io/sdk/release/iris-web-rtc-fake_n440_w4220_0.8.0.js';
+const irisWebUrl = 'https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js';
+const irisWebFakeUrl = 'https://download.agora.io/sdk/release/iris-web-rtc-fake_n440_w4220_0.8.4.js';
 
 (function() {
     var scriptLoaded = false;


### PR DESCRIPTION
Update native dependencies 20241125
native dependencies:
```
CDN: https://download.agora.io/sdk/release/iris-web-rtc-fake_n440_w4220_0.8.4.js CDN: https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js CDN: https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Mac_Video_20241125_1201_533.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.5.0-dev.15' https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Windows_Video_Standalone_20241125_1202_576.zip implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.15' https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Android_Video_16K_20241125_1201_699.zip pod 'AgoraIrisRTC_iOS', '4.5.0-dev.15' https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_iOS_Video_20241125_1201_573.zip pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.15' pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.15' implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.15' implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.15' CDN: https://download.agora.io/sdk/release/AgoraRtcEngine_windows_Preview_4.5.0-dev.15.zip
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.