### PR TITLE
feat: upgrade native sdk dependencies 20241203

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   if (isDev(project)) {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
-    api 'io.agora.rtc:iris-rtc:4.5.0-dev.15'
-    api 'io.agora.rtc:agora-full-preview:4.5.0-dev.15'
-    api 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.15'
+    api 'io.agora.rtc:iris-rtc:4.5.0-build.1'
+    api 'io.agora.rtc:agora-special-full:4.5.0.1'
+    api 'io.agora.rtc:full-screen-sharing:4.5.0.1'
   }
 }
 

--- a/internal/deps_summary.txt
+++ b/internal/deps_summary.txt
@@ -1,18 +1,18 @@
 Iris:
-https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Android_Video_16K_20241125_1201_699.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_iOS_Video_20241125_1201_573.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Mac_Video_20241125_1201_533.zip
-https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Windows_Video_20241121_0622_573.zip
-implementation 'io.agora.rtc:iris-rtc:4.5.0-dev.15'
-pod 'AgoraIrisRTC_iOS', '4.5.0-dev.15'
-pod 'AgoraIrisRTC_macOS', '4.5.0-dev.15'
+https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Android_Video_16K_20241203_0322_701.zip
+https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_iOS_Video_20241203_0325_575.zip
+https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Mac_Video_20241203_0322_534.zip
+https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Windows_Video_20241203_0322_577.zip
+implementation 'io.agora.rtc:iris-rtc:4.5.0-build.1'
+pod 'AgoraIrisRTC_iOS', '4.5.0-build.1'
+pod 'AgoraIrisRTC_macOS', '4.5.0-build.1'
 
 Native:
 <NATIVE_CDN_URL_ANDROID>
 <NATIVE_CDN_URL_IOS>
 <NATIVE_CDN_URL_MACOS>
 <NATIVE_CDN_URL_WINDOWS>
-implementation 'io.agora.rtc:agora-full-preview:4.5.0-dev.15'
-implementation 'io.agora.rtc:full-screen-sharing-special:4.5.0-dev.15'
-pod 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.15'
-pod 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.15'
+implementation 'io.agora.rtc:agora-special-full:4.5.0.1'
+implementation 'io.agora.rtc:full-screen-sharing:4.5.0.1'
+pod 'AgoraRtcEngine_iOS', '4.5.0'
+pod 'AgoraRtcEngine_macOS', '4.5.0'

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework'
   else
-  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-dev.15'
-  s.dependency 'AgoraRtcEngine_iOS_Preview', '4.5.0-dev.15'
+  s.dependency 'AgoraIrisRTC_iOS', '4.5.0-build.1'
+  s.dependency 'AgoraRtcEngine_iOS', '4.5.0'
   end
   
   s.platform = :ios, '9.0'

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -21,8 +21,8 @@ A new flutter plugin project.
     puts '[plugin_dev] Found .plugin_dev file, use vendored_frameworks instead.'
     s.vendored_frameworks = 'libs/*.xcframework', 'libs/*.framework'
   else
-  s.dependency 'AgoraRtcEngine_macOS_Preview', '4.5.0-dev.15'
-  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-dev.15'
+  s.dependency 'AgoraRtcEngine_macOS', '4.5.0'
+  s.dependency 'AgoraIrisRTC_macOS', '4.5.0-build.1'
   end
 
   s.platform = :osx, '10.11'

--- a/scripts/artifacts_version.sh
+++ b/scripts/artifacts_version.sh
@@ -1,6 +1,6 @@
 set -e
 
-export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Android_Video_16K_20241125_1201_699.zip"
-export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_iOS_Video_20241125_1201_573.zip"
-export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-dev.15_DCG_Mac_Video_20241125_1201_533.zip"
-export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Windows_Video_20241121_0622_573.zip"
+export IRIS_CDN_URL_ANDROID="https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Android_Video_16K_20241203_0322_701.zip"
+export IRIS_CDN_URL_IOS="https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_iOS_Video_20241203_0325_575.zip"
+export IRIS_CDN_URL_MACOS="https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Mac_Video_20241203_0322_534.zip"
+export IRIS_CDN_URL_WINDOWS="https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Windows_Video_20241203_0322_577.zip"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -12,8 +12,8 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "agora_rtc_engine_plugin")
 
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.5.0-dev.13_DCG_Windows_Video_20241121_0622_573.zip")
-set(IRIS_SDK_DOWNLOAD_NAME "iris_4.5.0-dev.13_DCG_Windows")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Windows_Video_20241203_0322_577.zip")
+set(IRIS_SDK_DOWNLOAD_NAME "iris_4.5.0-build.1_DCG_Windows")
 set(RTC_SDK_DOWNLOAD_NAME "Agora_Native_SDK_for_Windows_FULL")
 set(IRIS_SDK_VERSION "v3_6_2_fix.1")
 


### PR DESCRIPTION
Update native dependencies 20241203
native dependencies:
```
CDN: https://download.agora.io/sdk/release/iris-web-rtc-fake_n440_w4220_0.8.4.js CDN: https://download.agora.io/sdk/release/iris-web-rtc_n440_w4220_0.8.4.js https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Mac_Video_20241203_0322_534.zip https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Windows_Video_20241203_0322_577.zip Cocoapods: pod 'AgoraIrisRTC_macOS', '4.5.0-build.1' implementation 'io.agora.rtc:iris-rtc:4.5.0-build.1' https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_Android_Video_16K_20241203_0322_701.zip pod 'AgoraIrisRTC_iOS', '4.5.0-build.1' https://download.agora.io/sdk/release/iris_4.5.0-build.1_DCG_iOS_Video_20241203_0325_575.zip pod 'AgoraRtcEngine_iOS', '4.5.0' pod 'AgoraRtcEngine_macOS', '4.5.0' implementation 'io.agora.rtc:agora-special-full:4.5.0.1' implementation 'io.agora.rtc:full-screen-sharing:4.5.0.1' CDN: https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v4.5.0_FULL.zip https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v4.5.0_FULL.zip
```

> This pull request is trigger by bot, DO NOT MODIFY BY HAND.