### PR TITLE
[ci] Fix CI failed caused by using an unsupported NodeJS version (#2070)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           ref: ${{ inputs.release_branch }}
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install release-it
         run: |
           npm install -g release-it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install release-it
         run: |
           npm install -g release-it

--- a/.github/workflows/release_special_version.yml
+++ b/.github/workflows/release_special_version.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install release-it
         run: |
           npm install -g release-it


### PR DESCRIPTION
See
https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/pull/111