### PR TITLE
⚡️ Make data classes serializable

### DIFF
--- a/lib/src/_serializable.dart
+++ b/lib/src/_serializable.dart
@@ -1,0 +1,6 @@
+abstract class AgoraSerializable {
+  Map<String, dynamic> toJson();
+
+  @override
+  String toString() => '$runtimeType({$toJson()})';
+}

--- a/lib/src/agora_base.dart
+++ b/lib/src/agora_base.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_base.g.dart';
 
@@ -970,7 +971,7 @@ extension DegradationPreferenceExt on DegradationPreference {
 
 /// The video dimension.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDimensions {
+class VideoDimensions implements AgoraSerializable {
   /// @nodoc
   const VideoDimensions({this.width, this.height});
 
@@ -987,6 +988,7 @@ class VideoDimensions {
       _$VideoDimensionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDimensionsToJson(this);
 }
 
@@ -1183,7 +1185,7 @@ extension TCcModeExt on TCcMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SenderOptions {
+class SenderOptions implements AgoraSerializable {
   /// @nodoc
   const SenderOptions({this.ccMode, this.codecType, this.targetBitrate});
 
@@ -1204,6 +1206,7 @@ class SenderOptions {
       _$SenderOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SenderOptionsToJson(this);
 }
 
@@ -1352,7 +1355,7 @@ extension WatermarkFitModeExt on WatermarkFitMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedAudioFrameAdvancedSettings {
+class EncodedAudioFrameAdvancedSettings implements AgoraSerializable {
   /// @nodoc
   const EncodedAudioFrameAdvancedSettings({this.speech, this.sendEvenIfEmpty});
 
@@ -1370,13 +1373,14 @@ class EncodedAudioFrameAdvancedSettings {
       _$EncodedAudioFrameAdvancedSettingsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$EncodedAudioFrameAdvancedSettingsToJson(this);
 }
 
 /// Audio information after encoding.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedAudioFrameInfo {
+class EncodedAudioFrameInfo implements AgoraSerializable {
   /// @nodoc
   const EncodedAudioFrameInfo(
       {this.codec,
@@ -1415,12 +1419,13 @@ class EncodedAudioFrameInfo {
       _$EncodedAudioFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncodedAudioFrameInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmDataInfo {
+class AudioPcmDataInfo implements AgoraSerializable {
   /// @nodoc
   const AudioPcmDataInfo(
       {this.samplesPerChannel,
@@ -1454,6 +1459,7 @@ class AudioPcmDataInfo {
       _$AudioPcmDataInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmDataInfoToJson(this);
 }
 
@@ -1533,7 +1539,7 @@ extension VideoStreamTypeExt on VideoStreamType {
 
 /// Video subscription options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoSubscriptionOptions {
+class VideoSubscriptionOptions implements AgoraSerializable {
   /// @nodoc
   const VideoSubscriptionOptions({this.type, this.encodedFrameOnly});
 
@@ -1550,6 +1556,7 @@ class VideoSubscriptionOptions {
       _$VideoSubscriptionOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoSubscriptionOptionsToJson(this);
 }
 
@@ -1576,7 +1583,7 @@ extension MaxUserAccountLengthTypeExt on MaxUserAccountLengthType {
 
 /// Information about externally encoded video frames.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedVideoFrameInfo {
+class EncodedVideoFrameInfo implements AgoraSerializable {
   /// @nodoc
   const EncodedVideoFrameInfo(
       {this.uid,
@@ -1645,6 +1652,7 @@ class EncodedVideoFrameInfo {
       _$EncodedVideoFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncodedVideoFrameInfoToJson(this);
 }
 
@@ -1708,7 +1716,7 @@ extension EncodingPreferenceExt on EncodingPreference {
 
 /// Advanced options for video encoding.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvanceOptions {
+class AdvanceOptions implements AgoraSerializable {
   /// @nodoc
   const AdvanceOptions(
       {this.encodingPreference, this.compressionPreference, this.encodeAlpha});
@@ -1730,6 +1738,7 @@ class AdvanceOptions {
       _$AdvanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvanceOptionsToJson(this);
 }
 
@@ -1898,7 +1907,7 @@ extension CodecCapMaskExt on CodecCapMask {
 
 /// The level of the codec capability.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CodecCapLevels {
+class CodecCapLevels implements AgoraSerializable {
   /// @nodoc
   const CodecCapLevels({this.hwDecodingLevel, this.swDecodingLevel});
 
@@ -1915,12 +1924,13 @@ class CodecCapLevels {
       _$CodecCapLevelsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CodecCapLevelsToJson(this);
 }
 
 /// The codec capability of the SDK.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CodecCapInfo {
+class CodecCapInfo implements AgoraSerializable {
   /// @nodoc
   const CodecCapInfo({this.codecType, this.codecCapMask, this.codecLevels});
 
@@ -1941,6 +1951,7 @@ class CodecCapInfo {
       _$CodecCapInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CodecCapInfoToJson(this);
 }
 
@@ -1948,7 +1959,7 @@ class CodecCapInfo {
 ///
 /// This enumeration class applies to Android and iOS only.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FocalLengthInfo {
+class FocalLengthInfo implements AgoraSerializable {
   /// @nodoc
   const FocalLengthInfo({this.cameraDirection, this.focalLengthType});
 
@@ -1965,12 +1976,13 @@ class FocalLengthInfo {
       _$FocalLengthInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$FocalLengthInfoToJson(this);
 }
 
 /// Video encoder configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoEncoderConfiguration {
+class VideoEncoderConfiguration implements AgoraSerializable {
   /// @nodoc
   const VideoEncoderConfiguration(
       {this.codecType,
@@ -2024,6 +2036,7 @@ class VideoEncoderConfiguration {
       _$VideoEncoderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoEncoderConfigurationToJson(this);
 }
 
@@ -2031,7 +2044,7 @@ class VideoEncoderConfiguration {
 ///
 /// The following table shows the SDK behaviors under different parameter settings:
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DataStreamConfig {
+class DataStreamConfig implements AgoraSerializable {
   /// @nodoc
   const DataStreamConfig({this.syncWithAudio, this.ordered});
 
@@ -2048,6 +2061,7 @@ class DataStreamConfig {
       _$DataStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DataStreamConfigToJson(this);
 }
 
@@ -2082,7 +2096,7 @@ extension SimulcastStreamModeExt on SimulcastStreamMode {
 
 /// The configuration of the low-quality video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SimulcastStreamConfig {
+class SimulcastStreamConfig implements AgoraSerializable {
   /// @nodoc
   const SimulcastStreamConfig({this.dimensions, this.kBitrate, this.framerate});
 
@@ -2103,12 +2117,13 @@ class SimulcastStreamConfig {
       _$SimulcastStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SimulcastStreamConfigToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SimulcastConfig {
+class SimulcastConfig implements AgoraSerializable {
   /// @nodoc
   const SimulcastConfig({this.configs});
 
@@ -2121,6 +2136,7 @@ class SimulcastConfig {
       _$SimulcastConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SimulcastConfigToJson(this);
 }
 
@@ -2175,7 +2191,7 @@ extension StreamLayerIndexExt on StreamLayerIndex {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class StreamLayerConfig {
+class StreamLayerConfig implements AgoraSerializable {
   /// @nodoc
   const StreamLayerConfig({this.dimensions, this.framerate, this.enable});
 
@@ -2196,12 +2212,13 @@ class StreamLayerConfig {
       _$StreamLayerConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$StreamLayerConfigToJson(this);
 }
 
 /// The location of the target area relative to the screen or window. If you do not set this parameter, the SDK selects the whole screen or window.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Rectangle {
+class Rectangle implements AgoraSerializable {
   /// @nodoc
   const Rectangle({this.x, this.y, this.width, this.height});
 
@@ -2226,6 +2243,7 @@ class Rectangle {
       _$RectangleFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RectangleToJson(this);
 }
 
@@ -2235,7 +2253,7 @@ class Rectangle {
 ///  (xRatio, yRatio) refers to the coordinates of the upper left corner of the watermark, which determines the distance from the upper left corner of the watermark to the upper left corner of the screen.
 ///  The widthRatio determines the width of the watermark.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WatermarkRatio {
+class WatermarkRatio implements AgoraSerializable {
   /// @nodoc
   const WatermarkRatio({this.xRatio, this.yRatio, this.widthRatio});
 
@@ -2256,12 +2274,13 @@ class WatermarkRatio {
       _$WatermarkRatioFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WatermarkRatioToJson(this);
 }
 
 /// Configurations of the watermark image.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WatermarkOptions {
+class WatermarkOptions implements AgoraSerializable {
   /// @nodoc
   const WatermarkOptions(
       {this.visibleInPreview,
@@ -2295,12 +2314,13 @@ class WatermarkOptions {
       _$WatermarkOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WatermarkOptionsToJson(this);
 }
 
 /// Statistics of a call session.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcStats {
+class RtcStats implements AgoraSerializable {
   /// @nodoc
   const RtcStats(
       {this.duration,
@@ -2477,6 +2497,7 @@ class RtcStats {
       _$RtcStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcStatsToJson(this);
 }
 
@@ -2561,7 +2582,7 @@ extension AudienceLatencyLevelTypeExt on AudienceLatencyLevelType {
 
 /// Setting of user role properties.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ClientRoleOptions {
+class ClientRoleOptions implements AgoraSerializable {
   /// @nodoc
   const ClientRoleOptions({this.audienceLatencyLevel});
 
@@ -2574,6 +2595,7 @@ class ClientRoleOptions {
       _$ClientRoleOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ClientRoleOptionsToJson(this);
 }
 
@@ -2763,7 +2785,7 @@ extension AudioScenarioTypeExt on AudioScenarioType {
 
 /// The format of the video frame.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFormat {
+class VideoFormat implements AgoraSerializable {
   /// @nodoc
   const VideoFormat({this.width, this.height, this.fps});
 
@@ -2784,6 +2806,7 @@ class VideoFormat {
       _$VideoFormatFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFormatToJson(this);
 }
 
@@ -3500,7 +3523,7 @@ extension RemoteUserStateExt on RemoteUserState {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoTrackInfo {
+class VideoTrackInfo implements AgoraSerializable {
   /// @nodoc
   const VideoTrackInfo(
       {this.isLocal,
@@ -3549,6 +3572,7 @@ class VideoTrackInfo {
       _$VideoTrackInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoTrackInfoToJson(this);
 }
 
@@ -3591,7 +3615,7 @@ extension RemoteVideoDownscaleLevelExt on RemoteVideoDownscaleLevel {
 
 /// The volume information of users.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioVolumeInfo {
+class AudioVolumeInfo implements AgoraSerializable {
   /// @nodoc
   const AudioVolumeInfo({this.uid, this.volume, this.vad, this.voicePitch});
 
@@ -3622,6 +3646,7 @@ class AudioVolumeInfo {
       _$AudioVolumeInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioVolumeInfoToJson(this);
 }
 
@@ -3629,7 +3654,7 @@ class AudioVolumeInfo {
 ///
 /// This class is for Android only.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DeviceInfo {
+class DeviceInfo implements AgoraSerializable {
   /// @nodoc
   const DeviceInfo({this.isLowLatencyAudioSupported});
 
@@ -3642,12 +3667,13 @@ class DeviceInfo {
       _$DeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DeviceInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Packet {
+class Packet implements AgoraSerializable {
   /// @nodoc
   const Packet({this.buffer, this.size});
 
@@ -3663,6 +3689,7 @@ class Packet {
   factory Packet.fromJson(Map<String, dynamic> json) => _$PacketFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PacketToJson(this);
 }
 
@@ -3780,7 +3807,7 @@ extension AudioCodecProfileTypeExt on AudioCodecProfileType {
 
 /// Local audio statistics.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalAudioStats {
+class LocalAudioStats implements AgoraSerializable {
   /// @nodoc
   const LocalAudioStats(
       {this.numChannels,
@@ -3834,6 +3861,7 @@ class LocalAudioStats {
       _$LocalAudioStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalAudioStatsToJson(this);
 }
 
@@ -4002,7 +4030,7 @@ extension RtmpStreamingEventExt on RtmpStreamingEvent {
 ///
 /// This class sets the properties of the watermark and background images in the live video.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcImage {
+class RtcImage implements AgoraSerializable {
   /// @nodoc
   const RtcImage(
       {this.url,
@@ -4048,6 +4076,7 @@ class RtcImage {
       _$RtcImageFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcImageToJson(this);
 }
 
@@ -4055,7 +4084,7 @@ class RtcImage {
 ///
 /// If you want to enable the advanced features of streaming with transcoding, contact.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LiveStreamAdvancedFeature {
+class LiveStreamAdvancedFeature implements AgoraSerializable {
   /// @nodoc
   const LiveStreamAdvancedFeature({this.featureName, this.opened});
 
@@ -4072,6 +4101,7 @@ class LiveStreamAdvancedFeature {
       _$LiveStreamAdvancedFeatureFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LiveStreamAdvancedFeatureToJson(this);
 }
 
@@ -4122,7 +4152,7 @@ extension ConnectionStateTypeExt on ConnectionStateType {
 
 /// Transcoding configurations of each host.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class TranscodingUser {
+class TranscodingUser implements AgoraSerializable {
   /// @nodoc
   const TranscodingUser(
       {this.uid,
@@ -4177,12 +4207,13 @@ class TranscodingUser {
       _$TranscodingUserFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$TranscodingUserToJson(this);
 }
 
 /// Transcoding configurations for Media Push.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LiveTranscoding {
+class LiveTranscoding implements AgoraSerializable {
   /// @nodoc
   const LiveTranscoding(
       {this.width,
@@ -4315,12 +4346,13 @@ class LiveTranscoding {
       _$LiveTranscodingFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LiveTranscodingToJson(this);
 }
 
 /// The video streams for local video mixing.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class TranscodingVideoStream {
+class TranscodingVideoStream implements AgoraSerializable {
   /// @nodoc
   const TranscodingVideoStream(
       {this.sourceType,
@@ -4386,12 +4418,13 @@ class TranscodingVideoStream {
       _$TranscodingVideoStreamFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$TranscodingVideoStreamToJson(this);
 }
 
 /// The configuration of the video mixing on the local client.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalTranscoderConfiguration {
+class LocalTranscoderConfiguration implements AgoraSerializable {
   /// @nodoc
   const LocalTranscoderConfiguration(
       {this.streamCount,
@@ -4420,6 +4453,7 @@ class LocalTranscoderConfiguration {
       _$LocalTranscoderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalTranscoderConfigurationToJson(this);
 }
 
@@ -4466,7 +4500,7 @@ extension VideoTranscoderErrorExt on VideoTranscoderError {
 
 /// The source of the audio streams that are mixed locally.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MixedAudioStream {
+class MixedAudioStream implements AgoraSerializable {
   /// @nodoc
   const MixedAudioStream(
       {this.sourceType, this.remoteUserUid, this.channelId, this.trackId});
@@ -4496,12 +4530,13 @@ class MixedAudioStream {
       _$MixedAudioStreamFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MixedAudioStreamToJson(this);
 }
 
 /// The configurations for mixing the lcoal audio.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalAudioMixerConfiguration {
+class LocalAudioMixerConfiguration implements AgoraSerializable {
   /// @nodoc
   const LocalAudioMixerConfiguration(
       {this.streamCount, this.audioInputStreams, this.syncWithLocalMic});
@@ -4523,12 +4558,13 @@ class LocalAudioMixerConfiguration {
       _$LocalAudioMixerConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalAudioMixerConfigurationToJson(this);
 }
 
 /// Configurations of the last-mile network test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeConfig {
+class LastmileProbeConfig implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeConfig(
       {this.probeUplink,
@@ -4557,6 +4593,7 @@ class LastmileProbeConfig {
       _$LastmileProbeConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeConfigToJson(this);
 }
 
@@ -4591,7 +4628,7 @@ extension LastmileProbeResultStateExt on LastmileProbeResultState {
 
 /// Results of the uplink or downlink last-mile network test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeOneWayResult {
+class LastmileProbeOneWayResult implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeOneWayResult(
       {this.packetLossRate, this.jitter, this.availableBandwidth});
@@ -4613,12 +4650,13 @@ class LastmileProbeOneWayResult {
       _$LastmileProbeOneWayResultFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeOneWayResultToJson(this);
 }
 
 /// Results of the uplink and downlink last-mile network tests.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeResult {
+class LastmileProbeResult implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeResult(
       {this.state, this.uplinkReport, this.downlinkReport, this.rtt});
@@ -4644,6 +4682,7 @@ class LastmileProbeResult {
       _$LastmileProbeResultFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeResultToJson(this);
 }
 
@@ -4869,7 +4908,7 @@ extension WlaccSuggestActionExt on WlaccSuggestAction {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WlAccStats {
+class WlAccStats implements AgoraSerializable {
   /// @nodoc
   const WlAccStats(
       {this.e2eDelayPercent, this.frozenRatioPercent, this.lossRatePercent});
@@ -4891,6 +4930,7 @@ class WlAccStats {
       _$WlAccStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WlAccStatsToJson(this);
 }
 
@@ -4974,7 +5014,7 @@ extension VideoViewSetupModeExt on VideoViewSetupMode {
 
 /// Attributes of the video canvas object.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoCanvas {
+class VideoCanvas implements AgoraSerializable {
   /// @nodoc
   const VideoCanvas(
       {this.uid,
@@ -5047,12 +5087,13 @@ class VideoCanvas {
       _$VideoCanvasFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoCanvasToJson(this);
 }
 
 /// Image enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class BeautyOptions {
+class BeautyOptions implements AgoraSerializable {
   /// @nodoc
   const BeautyOptions(
       {this.lighteningContrastLevel,
@@ -5086,6 +5127,7 @@ class BeautyOptions {
       _$BeautyOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$BeautyOptionsToJson(this);
 }
 
@@ -5120,7 +5162,7 @@ extension LighteningContrastLevelExt on LighteningContrastLevel {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FaceShapeAreaOptions {
+class FaceShapeAreaOptions implements AgoraSerializable {
   /// @nodoc
   const FaceShapeAreaOptions({this.shapeArea, this.shapeIntensity});
 
@@ -5137,6 +5179,7 @@ class FaceShapeAreaOptions {
       _$FaceShapeAreaOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$FaceShapeAreaOptionsToJson(this);
 }
 
@@ -5211,7 +5254,7 @@ extension FaceShapeAreaExt on FaceShapeArea {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FaceShapeBeautyOptions {
+class FaceShapeBeautyOptions implements AgoraSerializable {
   /// @nodoc
   const FaceShapeBeautyOptions({this.shapeStyle, this.styleIntensity});
 
@@ -5228,6 +5271,7 @@ class FaceShapeBeautyOptions {
       _$FaceShapeBeautyOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$FaceShapeBeautyOptionsToJson(this);
 }
 
@@ -5258,7 +5302,7 @@ extension FaceShapeBeautyStyleExt on FaceShapeBeautyStyle {
 
 /// Filter effect options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FilterEffectOptions {
+class FilterEffectOptions implements AgoraSerializable {
   /// @nodoc
   const FilterEffectOptions({this.path, this.strength});
 
@@ -5282,12 +5326,13 @@ class FilterEffectOptions {
       _$FilterEffectOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$FilterEffectOptionsToJson(this);
 }
 
 /// The low-light enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LowlightEnhanceOptions {
+class LowlightEnhanceOptions implements AgoraSerializable {
   /// @nodoc
   const LowlightEnhanceOptions({this.mode, this.level});
 
@@ -5304,6 +5349,7 @@ class LowlightEnhanceOptions {
       _$LowlightEnhanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LowlightEnhanceOptionsToJson(this);
 }
 
@@ -5359,7 +5405,7 @@ extension LowLightEnhanceLevelExt on LowLightEnhanceLevel {
 
 /// Video noise reduction options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDenoiserOptions {
+class VideoDenoiserOptions implements AgoraSerializable {
   /// @nodoc
   const VideoDenoiserOptions({this.mode, this.level});
 
@@ -5376,6 +5422,7 @@ class VideoDenoiserOptions {
       _$VideoDenoiserOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDenoiserOptionsToJson(this);
 }
 
@@ -5431,7 +5478,7 @@ extension VideoDenoiserLevelExt on VideoDenoiserLevel {
 
 /// The color enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ColorEnhanceOptions {
+class ColorEnhanceOptions implements AgoraSerializable {
   /// @nodoc
   const ColorEnhanceOptions({this.strengthLevel, this.skinProtectLevel});
 
@@ -5450,12 +5497,13 @@ class ColorEnhanceOptions {
       _$ColorEnhanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ColorEnhanceOptionsToJson(this);
 }
 
 /// The custom background.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VirtualBackgroundSource {
+class VirtualBackgroundSource implements AgoraSerializable {
   /// @nodoc
   const VirtualBackgroundSource(
       {this.backgroundSourceType, this.color, this.source, this.blurDegree});
@@ -5481,6 +5529,7 @@ class VirtualBackgroundSource {
       _$VirtualBackgroundSourceFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VirtualBackgroundSourceToJson(this);
 }
 
@@ -5552,7 +5601,7 @@ extension BackgroundBlurDegreeExt on BackgroundBlurDegree {
 
 /// Processing properties for background images.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SegmentationProperty {
+class SegmentationProperty implements AgoraSerializable {
   /// @nodoc
   const SegmentationProperty({this.modelType, this.greenCapacity});
 
@@ -5569,6 +5618,7 @@ class SegmentationProperty {
       _$SegmentationPropertyFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SegmentationPropertyToJson(this);
 }
 
@@ -5628,7 +5678,7 @@ extension AudioTrackTypeExt on AudioTrackType {
 
 /// The configuration of custom audio tracks.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioTrackConfig {
+class AudioTrackConfig implements AgoraSerializable {
   /// @nodoc
   const AudioTrackConfig(
       {this.enableLocalPlayback, this.enableAudioProcessing});
@@ -5646,6 +5696,7 @@ class AudioTrackConfig {
       _$AudioTrackConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioTrackConfigToJson(this);
 }
 
@@ -5998,7 +6049,7 @@ extension VoiceAiTunerTypeExt on VoiceAiTunerType {
 
 /// Screen sharing configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureParameters {
+class ScreenCaptureParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureParameters(
       {this.dimensions,
@@ -6065,6 +6116,7 @@ class ScreenCaptureParameters {
       _$ScreenCaptureParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureParametersToJson(this);
 }
 
@@ -6161,7 +6213,7 @@ extension AudioEncodedFrameObserverPositionExt
 
 /// Recording configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioRecordingConfiguration {
+class AudioRecordingConfiguration implements AgoraSerializable {
   /// @nodoc
   const AudioRecordingConfiguration(
       {this.filePath,
@@ -6208,12 +6260,13 @@ class AudioRecordingConfiguration {
       _$AudioRecordingConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioRecordingConfigurationToJson(this);
 }
 
 /// Observer settings for the encoded audio.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverConfig {
+class AudioEncodedFrameObserverConfig implements AgoraSerializable {
   /// @nodoc
   const AudioEncodedFrameObserverConfig({this.postionType, this.encodingType});
 
@@ -6230,6 +6283,7 @@ class AudioEncodedFrameObserverConfig {
       _$AudioEncodedFrameObserverConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverConfigToJson(this);
 }
@@ -6481,7 +6535,7 @@ extension ChannelMediaRelayStateExt on ChannelMediaRelayState {
 
 /// Channel media information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaInfo {
+class ChannelMediaInfo implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaInfo({this.uid, this.channelName, this.token});
 
@@ -6502,12 +6556,13 @@ class ChannelMediaInfo {
       _$ChannelMediaInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaInfoToJson(this);
 }
 
 /// Configuration of cross channel media relay.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaRelayConfiguration {
+class ChannelMediaRelayConfiguration implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaRelayConfiguration(
       {this.srcInfo, this.destInfos, this.destCount});
@@ -6533,12 +6588,13 @@ class ChannelMediaRelayConfiguration {
       _$ChannelMediaRelayConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaRelayConfigurationToJson(this);
 }
 
 /// The uplink network information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UplinkNetworkInfo {
+class UplinkNetworkInfo implements AgoraSerializable {
   /// @nodoc
   const UplinkNetworkInfo({this.videoEncoderTargetBitrateBps});
 
@@ -6551,12 +6607,13 @@ class UplinkNetworkInfo {
       _$UplinkNetworkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UplinkNetworkInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DownlinkNetworkInfo {
+class DownlinkNetworkInfo implements AgoraSerializable {
   /// @nodoc
   const DownlinkNetworkInfo(
       {this.lastmileBufferDelayTimeMs,
@@ -6590,12 +6647,13 @@ class DownlinkNetworkInfo {
       _$DownlinkNetworkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DownlinkNetworkInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PeerDownlinkInfo {
+class PeerDownlinkInfo implements AgoraSerializable {
   /// @nodoc
   const PeerDownlinkInfo(
       {this.userId,
@@ -6624,6 +6682,7 @@ class PeerDownlinkInfo {
       _$PeerDownlinkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PeerDownlinkInfoToJson(this);
 }
 
@@ -6684,7 +6743,7 @@ extension EncryptionModeExt on EncryptionMode {
 
 /// Built-in encryption configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncryptionConfig {
+class EncryptionConfig implements AgoraSerializable {
   /// @nodoc
   const EncryptionConfig(
       {this.encryptionMode,
@@ -6713,6 +6772,7 @@ class EncryptionConfig {
       _$EncryptionConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncryptionConfigToJson(this);
 }
 
@@ -6891,7 +6951,7 @@ extension StreamPublishStateExt on StreamPublishState {
 
 /// The configuration of the audio and video call loop test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EchoTestConfiguration {
+class EchoTestConfiguration implements AgoraSerializable {
   /// @nodoc
   const EchoTestConfiguration(
       {this.view,
@@ -6932,12 +6992,13 @@ class EchoTestConfiguration {
       _$EchoTestConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EchoTestConfigurationToJson(this);
 }
 
 /// The information of the user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UserInfo {
+class UserInfo implements AgoraSerializable {
   /// @nodoc
   const UserInfo({this.uid, this.userAccount});
 
@@ -6954,6 +7015,7 @@ class UserInfo {
       _$UserInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UserInfoToJson(this);
 }
 
@@ -7033,7 +7095,7 @@ extension ThreadPriorityTypeExt on ThreadPriorityType {
 
 /// The video configuration for the shared screen stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenVideoParameters {
+class ScreenVideoParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenVideoParameters(
       {this.dimensions, this.frameRate, this.bitrate, this.contentHint});
@@ -7059,6 +7121,7 @@ class ScreenVideoParameters {
       _$ScreenVideoParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenVideoParametersToJson(this);
 }
 
@@ -7066,7 +7129,7 @@ class ScreenVideoParameters {
 ///
 /// Only available where captureAudio is true.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenAudioParameters {
+class ScreenAudioParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenAudioParameters(
       {this.sampleRate, this.channels, this.captureSignalVolume});
@@ -7088,12 +7151,13 @@ class ScreenAudioParameters {
       _$ScreenAudioParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenAudioParametersToJson(this);
 }
 
 /// Screen sharing configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureParameters2 {
+class ScreenCaptureParameters2 implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureParameters2(
       {this.captureAudio,
@@ -7124,6 +7188,7 @@ class ScreenCaptureParameters2 {
       _$ScreenCaptureParameters2FromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureParameters2ToJson(this);
 }
 
@@ -7154,7 +7219,7 @@ extension MediaTraceEventExt on MediaTraceEvent {
 
 /// Indicators during video frame rendering progress.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoRenderingTracingInfo {
+class VideoRenderingTracingInfo implements AgoraSerializable {
   /// @nodoc
   const VideoRenderingTracingInfo(
       {this.elapsedTime,
@@ -7210,6 +7275,7 @@ class VideoRenderingTracingInfo {
       _$VideoRenderingTracingInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoRenderingTracingInfoToJson(this);
 }
 
@@ -7265,7 +7331,7 @@ extension LocalProxyModeExt on LocalProxyMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LogUploadServerInfo {
+class LogUploadServerInfo implements AgoraSerializable {
   /// @nodoc
   const LogUploadServerInfo(
       {this.serverDomain, this.serverPath, this.serverPort, this.serverHttps});
@@ -7291,12 +7357,13 @@ class LogUploadServerInfo {
       _$LogUploadServerInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LogUploadServerInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvancedConfigInfo {
+class AdvancedConfigInfo implements AgoraSerializable {
   /// @nodoc
   const AdvancedConfigInfo({this.logUploadServer});
 
@@ -7309,12 +7376,13 @@ class AdvancedConfigInfo {
       _$AdvancedConfigInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvancedConfigInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalAccessPointConfiguration {
+class LocalAccessPointConfiguration implements AgoraSerializable {
   /// @nodoc
   const LocalAccessPointConfiguration(
       {this.ipList,
@@ -7363,6 +7431,7 @@ class LocalAccessPointConfiguration {
       _$LocalAccessPointConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalAccessPointConfigurationToJson(this);
 }
 
@@ -7393,7 +7462,7 @@ extension RecorderStreamTypeExt on RecorderStreamType {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RecorderStreamInfo {
+class RecorderStreamInfo implements AgoraSerializable {
   /// @nodoc
   const RecorderStreamInfo({this.channelId, this.uid, this.type});
 
@@ -7414,12 +7483,13 @@ class RecorderStreamInfo {
       _$RecorderStreamInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RecorderStreamInfoToJson(this);
 }
 
 /// The spatial audio parameters.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SpatialAudioParams {
+class SpatialAudioParams implements AgoraSerializable {
   /// @nodoc
   const SpatialAudioParams(
       {this.speakerAzimuth,
@@ -7468,12 +7538,13 @@ class SpatialAudioParams {
       _$SpatialAudioParamsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SpatialAudioParamsToJson(this);
 }
 
 /// Layout information of a specific sub-video stream within the mixed stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoLayout {
+class VideoLayout implements AgoraSerializable {
   /// @nodoc
   const VideoLayout(
       {this.channelId,
@@ -7525,5 +7596,6 @@ class VideoLayout {
       _$VideoLayoutFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoLayoutToJson(this);
 }

--- a/lib/src/agora_log.dart
+++ b/lib/src/agora_log.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_log.g.dart';
 
@@ -102,7 +103,7 @@ const defaultLogSizeInKb = 2048;
 
 /// Configuration of Agora SDK log files.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LogConfig {
+class LogConfig implements AgoraSerializable {
   /// @nodoc
   const LogConfig({this.filePath, this.fileSizeInKB, this.level});
 
@@ -123,5 +124,6 @@ class LogConfig {
       _$LogConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LogConfigToJson(this);
 }

--- a/lib/src/agora_media_base.dart
+++ b/lib/src/agora_media_base.dart
@@ -1,4 +1,6 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
+
 part 'agora_media_base.g.dart';
 
 /// @nodoc
@@ -12,7 +14,7 @@ const dummyConnectionId = 4294967295;
 
 /// The context information of the extension.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ExtensionContext {
+class ExtensionContext implements AgoraSerializable {
   /// @nodoc
   const ExtensionContext(
       {this.isValid, this.uid, this.providerName, this.extensionName});
@@ -38,6 +40,7 @@ class ExtensionContext {
       _$ExtensionContextFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ExtensionContextToJson(this);
 }
 
@@ -271,7 +274,7 @@ extension BytesPerSampleExt on BytesPerSample {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioParameters {
+class AudioParameters implements AgoraSerializable {
   /// @nodoc
   const AudioParameters({this.sampleRate, this.channels, this.framesPerBuffer});
 
@@ -292,6 +295,7 @@ class AudioParameters {
       _$AudioParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioParametersToJson(this);
 }
 
@@ -461,7 +465,7 @@ extension ContentInspectTypeExt on ContentInspectType {
 
 /// ContentInspectModule A structure used to configure the frequency of video screenshot and upload.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ContentInspectModule {
+class ContentInspectModule implements AgoraSerializable {
   /// @nodoc
   const ContentInspectModule({this.type, this.interval});
 
@@ -478,12 +482,13 @@ class ContentInspectModule {
       _$ContentInspectModuleFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ContentInspectModuleToJson(this);
 }
 
 /// Screenshot and upload configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ContentInspectConfig {
+class ContentInspectConfig implements AgoraSerializable {
   /// @nodoc
   const ContentInspectConfig(
       {this.extraInfo, this.serverConfig, this.modules, this.moduleCount});
@@ -509,6 +514,7 @@ class ContentInspectConfig {
       _$ContentInspectConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ContentInspectConfigToJson(this);
 }
 
@@ -517,7 +523,7 @@ const kMaxCodecNameLength = 50;
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PacketOptions {
+class PacketOptions implements AgoraSerializable {
   /// @nodoc
   const PacketOptions({this.timestamp, this.audioLevelIndication});
 
@@ -534,12 +540,13 @@ class PacketOptions {
       _$PacketOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PacketOptionsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameInfo {
+class AudioEncodedFrameInfo implements AgoraSerializable {
   /// @nodoc
   const AudioEncodedFrameInfo({this.sendTs, this.codec});
 
@@ -556,12 +563,13 @@ class AudioEncodedFrameInfo {
       _$AudioEncodedFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioEncodedFrameInfoToJson(this);
 }
 
 /// The parameters of the audio frame in PCM format.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmFrame {
+class AudioPcmFrame implements AgoraSerializable {
   /// @nodoc
   const AudioPcmFrame(
       {this.captureTimestamp,
@@ -605,6 +613,7 @@ class AudioPcmFrame {
       _$AudioPcmFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmFrameToJson(this);
 }
 
@@ -805,7 +814,7 @@ extension MetaInfoKeyExt on MetaInfoKey {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ColorSpace {
+class ColorSpace implements AgoraSerializable {
   /// @nodoc
   const ColorSpace({this.primaries, this.transfer, this.matrix, this.range});
 
@@ -830,6 +839,7 @@ class ColorSpace {
       _$ColorSpaceFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ColorSpaceToJson(this);
 }
 
@@ -1091,7 +1101,7 @@ extension TransferIDExt on TransferID {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Hdr10MetadataInfo {
+class Hdr10MetadataInfo implements AgoraSerializable {
   /// @nodoc
   const Hdr10MetadataInfo(
       {this.redPrimaryX,
@@ -1160,6 +1170,7 @@ class Hdr10MetadataInfo {
       _$Hdr10MetadataInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$Hdr10MetadataInfoToJson(this);
 }
 
@@ -1202,7 +1213,7 @@ extension AlphaStitchModeExt on AlphaStitchMode {
 
 /// The external video frame.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ExternalVideoFrame {
+class ExternalVideoFrame implements AgoraSerializable {
   /// @nodoc
   const ExternalVideoFrame(
       {this.type,
@@ -1333,6 +1344,7 @@ class ExternalVideoFrame {
       _$ExternalVideoFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ExternalVideoFrameToJson(this);
 }
 
@@ -1394,7 +1406,7 @@ extension VideoBufferTypeExt on VideoBufferType {
 ///
 /// Note that the buffer provides a pointer to a pointer. This interface cannot modify the pointer of the buffer, but it can modify the content of the buffer.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrame {
+class VideoFrame implements AgoraSerializable {
   /// @nodoc
   const VideoFrame(
       {this.type,
@@ -1516,6 +1528,7 @@ class VideoFrame {
       _$VideoFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFrameToJson(this);
 }
 
@@ -1585,7 +1598,7 @@ extension VideoModulePositionExt on VideoModulePosition {
 
 /// The snapshot configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SnapshotConfig {
+class SnapshotConfig implements AgoraSerializable {
   /// @nodoc
   const SnapshotConfig({this.filePath, this.position});
 
@@ -1606,6 +1619,7 @@ class SnapshotConfig {
       _$SnapshotConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SnapshotConfigToJson(this);
 }
 
@@ -1698,7 +1712,7 @@ extension AudioFrameTypeExt on AudioFrameType {
 
 /// Raw audio data.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrame {
+class AudioFrame implements AgoraSerializable {
   /// @nodoc
   const AudioFrame(
       {this.type,
@@ -1764,6 +1778,7 @@ class AudioFrame {
       _$AudioFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioFrameToJson(this);
 }
 
@@ -1813,7 +1828,7 @@ extension AudioFramePositionExt on AudioFramePosition {
 /// The SDK calculates the sampling interval through the samplesPerCall, sampleRate, and channel parameters in AudioParams, and triggers the onRecordAudioFrame, onPlaybackAudioFrame, onMixedAudioFrame, and onEarMonitoringAudioFrame callbacks according to the sampling interval. Sample interval (sec) = samplePerCall /(sampleRate × channel).
 ///  Ensure that the sample interval ≥ 0.01 (s).
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioParams {
+class AudioParams implements AgoraSerializable {
   /// @nodoc
   const AudioParams(
       {this.sampleRate, this.channels, this.mode, this.samplesPerCall});
@@ -1846,6 +1861,7 @@ class AudioParams {
       _$AudioParamsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioParamsToJson(this);
 }
 
@@ -1886,7 +1902,7 @@ class AudioFrameObserver extends AudioFrameObserverBase {
 
 /// The audio spectrum data.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumData {
+class AudioSpectrumData implements AgoraSerializable {
   /// @nodoc
   const AudioSpectrumData({this.audioSpectrumData, this.dataLength});
 
@@ -1903,12 +1919,13 @@ class AudioSpectrumData {
       _$AudioSpectrumDataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioSpectrumDataToJson(this);
 }
 
 /// Audio spectrum information of the remote user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UserAudioSpectrumInfo {
+class UserAudioSpectrumInfo implements AgoraSerializable {
   /// @nodoc
   const UserAudioSpectrumInfo({this.uid, this.spectrumData});
 
@@ -1925,6 +1942,7 @@ class UserAudioSpectrumInfo {
       _$UserAudioSpectrumInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UserAudioSpectrumInfoToJson(this);
 }
 
@@ -2206,7 +2224,7 @@ extension RecorderReasonCodeExt on RecorderReasonCode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderConfiguration {
+class MediaRecorderConfiguration implements AgoraSerializable {
   /// @nodoc
   const MediaRecorderConfiguration(
       {this.storagePath,
@@ -2270,6 +2288,7 @@ class MediaRecorderConfiguration {
       _$MediaRecorderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MediaRecorderConfigurationToJson(this);
 }
 
@@ -2302,7 +2321,7 @@ class FaceInfoObserver {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RecorderInfo {
+class RecorderInfo implements AgoraSerializable {
   /// @nodoc
   const RecorderInfo({this.fileName, this.durationMs, this.fileSize});
 
@@ -2323,6 +2342,7 @@ class RecorderInfo {
       _$RecorderInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RecorderInfoToJson(this);
 }
 

--- a/lib/src/agora_media_player_types.dart
+++ b/lib/src/agora_media_player_types.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_media_player_types.g.dart';
 
@@ -323,7 +324,7 @@ extension PlayerPreloadEventExt on PlayerPreloadEvent {
 
 /// The detailed information of the media stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerStreamInfo {
+class PlayerStreamInfo implements AgoraSerializable {
   /// @nodoc
   const PlayerStreamInfo(
       {this.streamIndex,
@@ -397,12 +398,13 @@ class PlayerStreamInfo {
       _$PlayerStreamInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerStreamInfoToJson(this);
 }
 
 /// Information about the video bitrate of the media resource being played.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SrcInfo {
+class SrcInfo implements AgoraSerializable {
   /// @nodoc
   const SrcInfo({this.bitrateInKbps, this.name});
 
@@ -419,6 +421,7 @@ class SrcInfo {
       _$SrcInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SrcInfoToJson(this);
 }
 
@@ -449,7 +452,7 @@ extension MediaPlayerMetadataTypeExt on MediaPlayerMetadataType {
 
 /// Statistics about the media files being cached.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CacheStatistics {
+class CacheStatistics implements AgoraSerializable {
   /// @nodoc
   const CacheStatistics({this.fileSize, this.cacheSize, this.downloadSize});
 
@@ -470,12 +473,13 @@ class CacheStatistics {
       _$CacheStatisticsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CacheStatisticsToJson(this);
 }
 
 /// The information of the media file being played.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerPlaybackStats {
+class PlayerPlaybackStats implements AgoraSerializable {
   /// @nodoc
   const PlayerPlaybackStats(
       {this.videoFps,
@@ -504,12 +508,13 @@ class PlayerPlaybackStats {
       _$PlayerPlaybackStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerPlaybackStatsToJson(this);
 }
 
 /// Information related to the media player.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerUpdatedInfo {
+class PlayerUpdatedInfo implements AgoraSerializable {
   /// @nodoc
   const PlayerUpdatedInfo(
       {this.internalPlayerUuid,
@@ -553,12 +558,13 @@ class PlayerUpdatedInfo {
       _$PlayerUpdatedInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerUpdatedInfoToJson(this);
 }
 
 /// Information related to the media file to be played and the playback scenario configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaSource {
+class MediaSource implements AgoraSerializable {
   /// @nodoc
   const MediaSource(
       {this.url,
@@ -610,5 +616,6 @@ class MediaSource {
       _$MediaSourceFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MediaSourceToJson(this);
 }

--- a/lib/src/agora_media_streaming_source.dart
+++ b/lib/src/agora_media_streaming_source.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_media_streaming_source.g.dart';
 
@@ -153,7 +154,7 @@ extension StreamingSrcStateExt on StreamingSrcState {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class InputSeiData {
+class InputSeiData implements AgoraSerializable {
   /// @nodoc
   const InputSeiData(
       {this.type,
@@ -187,5 +188,6 @@ class InputSeiData {
       _$InputSeiDataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$InputSeiDataToJson(this);
 }

--- a/lib/src/agora_music_content_center.dart
+++ b/lib/src/agora_music_content_center.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_music_content_center.g.dart';
 
@@ -114,7 +115,7 @@ extension MusicContentCenterStateReasonExt on MusicContentCenterStateReason {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicChartInfo {
+class MusicChartInfo implements AgoraSerializable {
   /// @nodoc
   const MusicChartInfo({this.chartName, this.id});
 
@@ -131,6 +132,7 @@ class MusicChartInfo {
       _$MusicChartInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicChartInfoToJson(this);
 }
 
@@ -161,7 +163,7 @@ extension MusicCacheStatusTypeExt on MusicCacheStatusType {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicCacheInfo {
+class MusicCacheInfo implements AgoraSerializable {
   /// @nodoc
   const MusicCacheInfo({this.songCode, this.status});
 
@@ -178,6 +180,7 @@ class MusicCacheInfo {
       _$MusicCacheInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicCacheInfoToJson(this);
 }
 
@@ -192,7 +195,7 @@ abstract class MusicChartCollection {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MvProperty {
+class MvProperty implements AgoraSerializable {
   /// @nodoc
   const MvProperty({this.resolution, this.bandwidth});
 
@@ -209,12 +212,13 @@ class MvProperty {
       _$MvPropertyFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MvPropertyToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ClimaxSegment {
+class ClimaxSegment implements AgoraSerializable {
   /// @nodoc
   const ClimaxSegment({this.startTimeMs, this.endTimeMs});
 
@@ -231,12 +235,13 @@ class ClimaxSegment {
       _$ClimaxSegmentFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ClimaxSegmentToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Music {
+class Music implements AgoraSerializable {
   /// @nodoc
   const Music(
       {this.songCode,
@@ -314,6 +319,7 @@ class Music {
   factory Music.fromJson(Map<String, dynamic> json) => _$MusicFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicToJson(this);
 }
 
@@ -386,7 +392,7 @@ class MusicContentCenterEventHandler {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterConfiguration {
+class MusicContentCenterConfiguration implements AgoraSerializable {
   /// @nodoc
   const MusicContentCenterConfiguration(
       {this.appId, this.token, this.mccUid, this.maxCacheSize, this.mccDomain});
@@ -416,6 +422,7 @@ class MusicContentCenterConfiguration {
       _$MusicContentCenterConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterConfigurationToJson(this);
 }

--- a/lib/src/agora_rhythm_player.dart
+++ b/lib/src/agora_rhythm_player.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rhythm_player.g.dart';
 
@@ -77,7 +78,7 @@ extension RhythmPlayerReasonExt on RhythmPlayerReason {
 
 /// The metronome configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AgoraRhythmPlayerConfig {
+class AgoraRhythmPlayerConfig implements AgoraSerializable {
   /// @nodoc
   const AgoraRhythmPlayerConfig({this.beatsPerMeasure, this.beatsPerMinute});
 
@@ -94,5 +95,6 @@ class AgoraRhythmPlayerConfig {
       _$AgoraRhythmPlayerConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AgoraRhythmPlayerConfigToJson(this);
 }

--- a/lib/src/agora_rtc_engine.dart
+++ b/lib/src/agora_rtc_engine.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rtc_engine.g.dart';
 
@@ -367,7 +368,7 @@ extension PriorityTypeExt on PriorityType {
 
 /// The statistics of the local video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalVideoStats {
+class LocalVideoStats implements AgoraSerializable {
   /// @nodoc
   const LocalVideoStats(
       {this.uid,
@@ -498,12 +499,13 @@ class LocalVideoStats {
       _$LocalVideoStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalVideoStatsToJson(this);
 }
 
 /// Audio statistics of the remote user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteAudioStats {
+class RemoteAudioStats implements AgoraSerializable {
   /// @nodoc
   const RemoteAudioStats(
       {this.uid,
@@ -607,12 +609,13 @@ class RemoteAudioStats {
       _$RemoteAudioStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteAudioStatsToJson(this);
 }
 
 /// Statistics of the remote video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteVideoStats {
+class RemoteVideoStats implements AgoraSerializable {
   /// @nodoc
   const RemoteVideoStats(
       {this.uid,
@@ -716,12 +719,13 @@ class RemoteVideoStats {
       _$RemoteVideoStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteVideoStatsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoCompositingLayout {
+class VideoCompositingLayout implements AgoraSerializable {
   /// @nodoc
   const VideoCompositingLayout(
       {this.canvasWidth,
@@ -765,12 +769,13 @@ class VideoCompositingLayout {
       _$VideoCompositingLayoutFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoCompositingLayoutToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Region {
+class Region implements AgoraSerializable {
   /// @nodoc
   const Region(
       {this.uid,
@@ -818,12 +823,13 @@ class Region {
   factory Region.fromJson(Map<String, dynamic> json) => _$RegionFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RegionToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class InjectStreamConfig {
+class InjectStreamConfig implements AgoraSerializable {
   /// @nodoc
   const InjectStreamConfig(
       {this.width,
@@ -872,6 +878,7 @@ class InjectStreamConfig {
       _$InjectStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$InjectStreamConfigToJson(this);
 }
 
@@ -904,7 +911,7 @@ extension RtmpStreamLifeCycleTypeExt on RtmpStreamLifeCycleType {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PublisherConfiguration {
+class PublisherConfiguration implements AgoraSerializable {
   /// @nodoc
   const PublisherConfiguration(
       {this.width,
@@ -978,6 +985,7 @@ class PublisherConfiguration {
       _$PublisherConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PublisherConfigurationToJson(this);
 }
 
@@ -1037,7 +1045,7 @@ extension CloudProxyTypeExt on CloudProxyType {
 
 /// The camera capturer preference.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CameraCapturerConfiguration {
+class CameraCapturerConfiguration implements AgoraSerializable {
   /// @nodoc
   const CameraCapturerConfiguration(
       {this.cameraDirection,
@@ -1085,12 +1093,13 @@ class CameraCapturerConfiguration {
       _$CameraCapturerConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CameraCapturerConfigurationToJson(this);
 }
 
 /// The configuration of the captured screen.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureConfiguration {
+class ScreenCaptureConfiguration implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureConfiguration(
       {this.isCaptureWindow,
@@ -1129,12 +1138,13 @@ class ScreenCaptureConfiguration {
       _$ScreenCaptureConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureConfigurationToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SIZE {
+class SIZE implements AgoraSerializable {
   /// @nodoc
   const SIZE({this.width, this.height});
 
@@ -1150,6 +1160,7 @@ class SIZE {
   factory SIZE.fromJson(Map<String, dynamic> json) => _$SIZEFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SIZEToJson(this);
 }
 
@@ -1157,7 +1168,7 @@ class SIZE {
 ///
 /// The default image is in the ARGB format. If you need to use another format, you need to convert the image on your own.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ThumbImageBuffer {
+class ThumbImageBuffer implements AgoraSerializable {
   /// @nodoc
   const ThumbImageBuffer({this.buffer, this.length, this.width, this.height});
 
@@ -1182,6 +1193,7 @@ class ThumbImageBuffer {
       _$ThumbImageBufferFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ThumbImageBufferToJson(this);
 }
 
@@ -1220,7 +1232,7 @@ extension ScreenCaptureSourceTypeExt on ScreenCaptureSourceType {
 
 /// The information about the specified shareable window or screen.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureSourceInfo {
+class ScreenCaptureSourceInfo implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureSourceInfo(
       {this.type,
@@ -1289,12 +1301,13 @@ class ScreenCaptureSourceInfo {
       _$ScreenCaptureSourceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureSourceInfoToJson(this);
 }
 
 /// The advanced options for audio.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvancedAudioOptions {
+class AdvancedAudioOptions implements AgoraSerializable {
   /// @nodoc
   const AdvancedAudioOptions({this.audioProcessingChannels});
 
@@ -1307,12 +1320,13 @@ class AdvancedAudioOptions {
       _$AdvancedAudioOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvancedAudioOptionsToJson(this);
 }
 
 /// Image configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ImageTrackOptions {
+class ImageTrackOptions implements AgoraSerializable {
   /// @nodoc
   const ImageTrackOptions({this.imageUrl, this.fps, this.mirrorMode});
 
@@ -1333,6 +1347,7 @@ class ImageTrackOptions {
       _$ImageTrackOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ImageTrackOptionsToJson(this);
 }
 
@@ -1340,7 +1355,7 @@ class ImageTrackOptions {
 ///
 /// Agora supports publishing multiple audio streams and one video stream at the same time and in the same RtcConnection. For example, publishMicrophoneTrack, publishCustomAudioTrack, and publishMediaPlayerAudioTrack can be set as true at the same time, but only one of publishCameraTrack, publishScreenCaptureVideo, publishScreenTrack, publishCustomVideoTrack, or publishEncodedVideoTrack can be set as true. Agora recommends that you set member parameter values yourself according to your business scenario, otherwise the SDK will automatically assign values to member parameters.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaOptions {
+class ChannelMediaOptions implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaOptions(
       {this.publishCameraTrack,
@@ -1538,6 +1553,7 @@ class ChannelMediaOptions {
       _$ChannelMediaOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaOptionsToJson(this);
 }
 
@@ -1613,7 +1629,7 @@ extension FeatureTypeExt on FeatureType {
 
 /// The options for leaving a channel.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LeaveChannelOptions {
+class LeaveChannelOptions implements AgoraSerializable {
   /// @nodoc
   const LeaveChannelOptions(
       {this.stopAudioMixing, this.stopAllEffect, this.stopMicrophoneRecording});
@@ -1635,6 +1651,7 @@ class LeaveChannelOptions {
       _$LeaveChannelOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LeaveChannelOptionsToJson(this);
 }
 
@@ -2716,7 +2733,7 @@ abstract class VideoDeviceManager {
 
 /// Configurations for the RtcEngineContext instance.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineContext {
+class RtcEngineContext implements AgoraSerializable {
   /// @nodoc
   const RtcEngineContext(
       {this.appId,
@@ -2785,6 +2802,7 @@ class RtcEngineContext {
       _$RtcEngineContextFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineContextToJson(this);
 }
 
@@ -2857,7 +2875,7 @@ extension MaxMetadataSizeTypeExt on MaxMetadataSizeType {
 
 /// Media metadata.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Metadata {
+class Metadata implements AgoraSerializable {
   /// @nodoc
   const Metadata(
       {this.channelId, this.uid, this.size, this.buffer, this.timeStampMs});
@@ -2889,6 +2907,7 @@ class Metadata {
       _$MetadataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MetadataToJson(this);
 }
 
@@ -2972,7 +2991,7 @@ extension DirectCdnStreamingStateExt on DirectCdnStreamingState {
 
 /// The statistics of the current CDN streaming.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingStats {
+class DirectCdnStreamingStats implements AgoraSerializable {
   /// @nodoc
   const DirectCdnStreamingStats(
       {this.videoWidth,
@@ -3006,6 +3025,7 @@ class DirectCdnStreamingStats {
       _$DirectCdnStreamingStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DirectCdnStreamingStatsToJson(this);
 }
 
@@ -3039,7 +3059,7 @@ class DirectCdnStreamingEventHandler {
 
 /// The media setting options for the host.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingMediaOptions {
+class DirectCdnStreamingMediaOptions implements AgoraSerializable {
   /// @nodoc
   const DirectCdnStreamingMediaOptions(
       {this.publishCameraTrack,
@@ -3083,12 +3103,13 @@ class DirectCdnStreamingMediaOptions {
       _$DirectCdnStreamingMediaOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DirectCdnStreamingMediaOptionsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ExtensionInfo {
+class ExtensionInfo implements AgoraSerializable {
   /// @nodoc
   const ExtensionInfo(
       {this.mediaSourceType, this.remoteUid, this.channelId, this.localUid});
@@ -3114,6 +3135,7 @@ class ExtensionInfo {
       _$ExtensionInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ExtensionInfoToJson(this);
 }
 
@@ -6795,7 +6817,7 @@ extension VideoProfileTypeExt on VideoProfileType {
 
 /// SDK version information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SDKBuildInfo {
+class SDKBuildInfo implements AgoraSerializable {
   /// @nodoc
   const SDKBuildInfo({this.build, this.version});
 
@@ -6812,12 +6834,13 @@ class SDKBuildInfo {
       _$SDKBuildInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SDKBuildInfoToJson(this);
 }
 
 /// The VideoDeviceInfo class that contains the ID and device name of the video devices.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceInfo {
+class VideoDeviceInfo implements AgoraSerializable {
   /// @nodoc
   const VideoDeviceInfo({this.deviceId, this.deviceName});
 
@@ -6834,12 +6857,13 @@ class VideoDeviceInfo {
       _$VideoDeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDeviceInfoToJson(this);
 }
 
 /// The AudioDeviceInfo class that contains the ID, name and type of the audio devices.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceInfo {
+class AudioDeviceInfo implements AgoraSerializable {
   /// @nodoc
   const AudioDeviceInfo({this.deviceId, this.deviceTypeName, this.deviceName});
 
@@ -6860,5 +6884,6 @@ class AudioDeviceInfo {
       _$AudioDeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioDeviceInfoToJson(this);
 }

--- a/lib/src/agora_rtc_engine_ex.dart
+++ b/lib/src/agora_rtc_engine_ex.dart
@@ -1,9 +1,10 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rtc_engine_ex.g.dart';
 
 /// Contains connection information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcConnection {
+class RtcConnection implements AgoraSerializable {
   /// @nodoc
   const RtcConnection({this.channelId, this.localUid});
 
@@ -20,6 +21,7 @@ class RtcConnection {
       _$RtcConnectionFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcConnectionToJson(this);
 }
 

--- a/lib/src/agora_spatial_audio.dart
+++ b/lib/src/agora_spatial_audio.dart
@@ -1,9 +1,10 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_spatial_audio.g.dart';
 
 /// The spatial position of the remote user or the media player.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteVoicePositionInfo {
+class RemoteVoicePositionInfo implements AgoraSerializable {
   /// @nodoc
   const RemoteVoicePositionInfo({this.position, this.forward});
 
@@ -20,12 +21,13 @@ class RemoteVoicePositionInfo {
       _$RemoteVoicePositionInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteVoicePositionInfoToJson(this);
 }
 
 /// Sound insulation area settings.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SpatialAudioZone {
+class SpatialAudioZone implements AgoraSerializable {
   /// @nodoc
   const SpatialAudioZone(
       {this.zoneSetId,
@@ -83,6 +85,7 @@ class SpatialAudioZone {
       _$SpatialAudioZoneFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SpatialAudioZoneToJson(this);
 }
 

--- a/lib/src/binding/call_api_impl_params_json.dart
+++ b/lib/src/binding/call_api_impl_params_json.dart
@@ -2,11 +2,13 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, unused_import
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
+
 part 'call_api_impl_params_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetDurationJson {
+class MediaPlayerGetDurationJson implements AgoraSerializable {
   const MediaPlayerGetDurationJson(this.duration);
 
   @JsonKey(name: 'duration')
@@ -15,11 +17,12 @@ class MediaPlayerGetDurationJson {
   factory MediaPlayerGetDurationJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetDurationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetDurationJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPlayPositionJson {
+class MediaPlayerGetPlayPositionJson implements AgoraSerializable {
   const MediaPlayerGetPlayPositionJson(this.pos);
 
   @JsonKey(name: 'pos')
@@ -28,11 +31,12 @@ class MediaPlayerGetPlayPositionJson {
   factory MediaPlayerGetPlayPositionJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetPlayPositionJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetPlayPositionJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetStreamCountJson {
+class MediaPlayerGetStreamCountJson implements AgoraSerializable {
   const MediaPlayerGetStreamCountJson(this.count);
 
   @JsonKey(name: 'count')
@@ -41,11 +45,12 @@ class MediaPlayerGetStreamCountJson {
   factory MediaPlayerGetStreamCountJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetStreamCountJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetStreamCountJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetStreamInfoJson {
+class MediaPlayerGetStreamInfoJson implements AgoraSerializable {
   const MediaPlayerGetStreamInfoJson(this.info);
 
   @JsonKey(name: 'info')
@@ -54,11 +59,12 @@ class MediaPlayerGetStreamInfoJson {
   factory MediaPlayerGetStreamInfoJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetStreamInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetStreamInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetMuteJson {
+class MediaPlayerGetMuteJson implements AgoraSerializable {
   const MediaPlayerGetMuteJson(this.muted);
 
   @JsonKey(name: 'muted')
@@ -67,11 +73,12 @@ class MediaPlayerGetMuteJson {
   factory MediaPlayerGetMuteJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetMuteJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPlayoutVolumeJson {
+class MediaPlayerGetPlayoutVolumeJson implements AgoraSerializable {
   const MediaPlayerGetPlayoutVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -80,12 +87,13 @@ class MediaPlayerGetPlayoutVolumeJson {
   factory MediaPlayerGetPlayoutVolumeJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetPlayoutVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerGetPlayoutVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPublishSignalVolumeJson {
+class MediaPlayerGetPublishSignalVolumeJson implements AgoraSerializable {
   const MediaPlayerGetPublishSignalVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -95,12 +103,13 @@ class MediaPlayerGetPublishSignalVolumeJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerGetPublishSignalVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerGetPublishSignalVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerCacheManagerGetCacheDirJson {
+class MediaPlayerCacheManagerGetCacheDirJson implements AgoraSerializable {
   const MediaPlayerCacheManagerGetCacheDirJson(this.path);
 
   @JsonKey(name: 'path')
@@ -110,12 +119,13 @@ class MediaPlayerCacheManagerGetCacheDirJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerCacheManagerGetCacheDirJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerCacheManagerGetCacheDirJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetMusicChartsJson {
+class MusicContentCenterGetMusicChartsJson implements AgoraSerializable {
   const MusicContentCenterGetMusicChartsJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -125,12 +135,14 @@ class MusicContentCenterGetMusicChartsJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetMusicChartsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetMusicChartsJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetMusicCollectionByMusicChartIdJson {
+class MusicContentCenterGetMusicCollectionByMusicChartIdJson
+    implements AgoraSerializable {
   const MusicContentCenterGetMusicCollectionByMusicChartIdJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -140,12 +152,13 @@ class MusicContentCenterGetMusicCollectionByMusicChartIdJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetMusicCollectionByMusicChartIdJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetMusicCollectionByMusicChartIdJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterSearchMusicJson {
+class MusicContentCenterSearchMusicJson implements AgoraSerializable {
   const MusicContentCenterSearchMusicJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -155,12 +168,13 @@ class MusicContentCenterSearchMusicJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterSearchMusicJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterSearchMusicJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterPreloadJson {
+class MusicContentCenterPreloadJson implements AgoraSerializable {
   const MusicContentCenterPreloadJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -169,11 +183,12 @@ class MusicContentCenterPreloadJson {
   factory MusicContentCenterPreloadJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterPreloadJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MusicContentCenterPreloadJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetCachesJson {
+class MusicContentCenterGetCachesJson implements AgoraSerializable {
   const MusicContentCenterGetCachesJson(this.cacheInfo);
 
   @JsonKey(name: 'cacheInfo')
@@ -182,12 +197,13 @@ class MusicContentCenterGetCachesJson {
   factory MusicContentCenterGetCachesJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterGetCachesJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetCachesJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetLyricJson {
+class MusicContentCenterGetLyricJson implements AgoraSerializable {
   const MusicContentCenterGetLyricJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -196,11 +212,12 @@ class MusicContentCenterGetLyricJson {
   factory MusicContentCenterGetLyricJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterGetLyricJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MusicContentCenterGetLyricJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetSongSimpleInfoJson {
+class MusicContentCenterGetSongSimpleInfoJson implements AgoraSerializable {
   const MusicContentCenterGetSongSimpleInfoJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -210,12 +227,13 @@ class MusicContentCenterGetSongSimpleInfoJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetSongSimpleInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetSongSimpleInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetInternalSongCodeJson {
+class MusicContentCenterGetInternalSongCodeJson implements AgoraSerializable {
   const MusicContentCenterGetInternalSongCodeJson(this.internalSongCode);
 
   @JsonKey(name: 'internalSongCode')
@@ -225,12 +243,13 @@ class MusicContentCenterGetInternalSongCodeJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetInternalSongCodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetInternalSongCodeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceManagerGetDeviceJson {
+class VideoDeviceManagerGetDeviceJson implements AgoraSerializable {
   const VideoDeviceManagerGetDeviceJson(this.deviceIdUTF8);
 
   @JsonKey(name: 'deviceIdUTF8')
@@ -239,12 +258,13 @@ class VideoDeviceManagerGetDeviceJson {
   factory VideoDeviceManagerGetDeviceJson.fromJson(Map<String, dynamic> json) =>
       _$VideoDeviceManagerGetDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoDeviceManagerGetDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceManagerGetCapabilityJson {
+class VideoDeviceManagerGetCapabilityJson implements AgoraSerializable {
   const VideoDeviceManagerGetCapabilityJson(this.capability);
 
   @JsonKey(name: 'capability')
@@ -254,12 +274,13 @@ class VideoDeviceManagerGetCapabilityJson {
           Map<String, dynamic> json) =>
       _$VideoDeviceManagerGetCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoDeviceManagerGetCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineQueryCodecCapabilityJson {
+class RtcEngineQueryCodecCapabilityJson implements AgoraSerializable {
   const RtcEngineQueryCodecCapabilityJson(this.codecInfo);
 
   @JsonKey(name: 'codecInfo')
@@ -269,12 +290,13 @@ class RtcEngineQueryCodecCapabilityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineQueryCodecCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineQueryCodecCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetFaceShapeBeautyOptionsJson {
+class RtcEngineGetFaceShapeBeautyOptionsJson implements AgoraSerializable {
   const RtcEngineGetFaceShapeBeautyOptionsJson(this.options);
 
   @JsonKey(name: 'options')
@@ -284,12 +306,13 @@ class RtcEngineGetFaceShapeBeautyOptionsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetFaceShapeBeautyOptionsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetFaceShapeBeautyOptionsJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetFaceShapeAreaOptionsJson {
+class RtcEngineGetFaceShapeAreaOptionsJson implements AgoraSerializable {
   const RtcEngineGetFaceShapeAreaOptionsJson(this.options);
 
   @JsonKey(name: 'options')
@@ -299,12 +322,13 @@ class RtcEngineGetFaceShapeAreaOptionsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetFaceShapeAreaOptionsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetFaceShapeAreaOptionsJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineUploadLogFileJson {
+class RtcEngineUploadLogFileJson implements AgoraSerializable {
   const RtcEngineUploadLogFileJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -313,11 +337,12 @@ class RtcEngineUploadLogFileJson {
   factory RtcEngineUploadLogFileJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineUploadLogFileJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineUploadLogFileJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetExtensionPropertyJson {
+class RtcEngineGetExtensionPropertyJson implements AgoraSerializable {
   const RtcEngineGetExtensionPropertyJson(this.value);
 
   @JsonKey(name: 'value')
@@ -327,12 +352,13 @@ class RtcEngineGetExtensionPropertyJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetExtensionPropertyJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetExtensionPropertyJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetAudioDeviceInfoJson {
+class RtcEngineGetAudioDeviceInfoJson implements AgoraSerializable {
   const RtcEngineGetAudioDeviceInfoJson(this.deviceInfo);
 
   @JsonKey(name: 'deviceInfo')
@@ -341,12 +367,14 @@ class RtcEngineGetAudioDeviceInfoJson {
   factory RtcEngineGetAudioDeviceInfoJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetAudioDeviceInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetAudioDeviceInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineQueryCameraFocalLengthCapabilityJson {
+class RtcEngineQueryCameraFocalLengthCapabilityJson
+    implements AgoraSerializable {
   const RtcEngineQueryCameraFocalLengthCapabilityJson(this.focalLengthInfos);
 
   @JsonKey(name: 'focalLengthInfos')
@@ -356,12 +384,13 @@ class RtcEngineQueryCameraFocalLengthCapabilityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineQueryCameraFocalLengthCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineQueryCameraFocalLengthCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetCallIdJson {
+class RtcEngineGetCallIdJson implements AgoraSerializable {
   const RtcEngineGetCallIdJson(this.callId);
 
   @JsonKey(name: 'callId')
@@ -370,11 +399,12 @@ class RtcEngineGetCallIdJson {
   factory RtcEngineGetCallIdJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetCallIdJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineGetCallIdJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineCreateDataStreamJson {
+class RtcEngineCreateDataStreamJson implements AgoraSerializable {
   const RtcEngineCreateDataStreamJson(this.streamId);
 
   @JsonKey(name: 'streamId')
@@ -383,11 +413,12 @@ class RtcEngineCreateDataStreamJson {
   factory RtcEngineCreateDataStreamJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineCreateDataStreamJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineCreateDataStreamJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetUserInfoByUserAccountJson {
+class RtcEngineGetUserInfoByUserAccountJson implements AgoraSerializable {
   const RtcEngineGetUserInfoByUserAccountJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -397,12 +428,13 @@ class RtcEngineGetUserInfoByUserAccountJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetUserInfoByUserAccountJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetUserInfoByUserAccountJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetUserInfoByUidJson {
+class RtcEngineGetUserInfoByUidJson implements AgoraSerializable {
   const RtcEngineGetUserInfoByUidJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -411,11 +443,12 @@ class RtcEngineGetUserInfoByUidJson {
   factory RtcEngineGetUserInfoByUidJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetUserInfoByUidJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineGetUserInfoByUidJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineQueryHDRCapabilityJson {
+class RtcEngineQueryHDRCapabilityJson implements AgoraSerializable {
   const RtcEngineQueryHDRCapabilityJson(this.capability);
 
   @JsonKey(name: 'capability')
@@ -424,12 +457,13 @@ class RtcEngineQueryHDRCapabilityJson {
   factory RtcEngineQueryHDRCapabilityJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineQueryHDRCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineQueryHDRCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExCreateDataStreamExJson {
+class RtcEngineExCreateDataStreamExJson implements AgoraSerializable {
   const RtcEngineExCreateDataStreamExJson(this.streamId);
 
   @JsonKey(name: 'streamId')
@@ -439,12 +473,13 @@ class RtcEngineExCreateDataStreamExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExCreateDataStreamExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExCreateDataStreamExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetUserInfoByUserAccountExJson {
+class RtcEngineExGetUserInfoByUserAccountExJson implements AgoraSerializable {
   const RtcEngineExGetUserInfoByUserAccountExJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -454,12 +489,13 @@ class RtcEngineExGetUserInfoByUserAccountExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExGetUserInfoByUserAccountExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExGetUserInfoByUserAccountExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetUserInfoByUidExJson {
+class RtcEngineExGetUserInfoByUidExJson implements AgoraSerializable {
   const RtcEngineExGetUserInfoByUidExJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -469,12 +505,13 @@ class RtcEngineExGetUserInfoByUidExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExGetUserInfoByUidExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExGetUserInfoByUidExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetCallIdExJson {
+class RtcEngineExGetCallIdExJson implements AgoraSerializable {
   const RtcEngineExGetCallIdExJson(this.callId);
 
   @JsonKey(name: 'callId')
@@ -483,11 +520,12 @@ class RtcEngineExGetCallIdExJson {
   factory RtcEngineExGetCallIdExJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineExGetCallIdExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineExGetCallIdExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceJson {
+class AudioDeviceManagerGetPlaybackDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -497,12 +535,14 @@ class AudioDeviceManagerGetPlaybackDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceVolumeJson {
+class AudioDeviceManagerGetPlaybackDeviceVolumeJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -512,12 +552,13 @@ class AudioDeviceManagerGetPlaybackDeviceVolumeJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceJson {
+class AudioDeviceManagerGetRecordingDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -527,12 +568,14 @@ class AudioDeviceManagerGetRecordingDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceVolumeJson {
+class AudioDeviceManagerGetRecordingDeviceVolumeJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -542,12 +585,13 @@ class AudioDeviceManagerGetRecordingDeviceVolumeJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetLoopbackDeviceJson {
+class AudioDeviceManagerGetLoopbackDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetLoopbackDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -557,12 +601,13 @@ class AudioDeviceManagerGetLoopbackDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetLoopbackDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetLoopbackDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceMuteJson {
+class AudioDeviceManagerGetPlaybackDeviceMuteJson implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceMuteJson(this.mute);
 
   @JsonKey(name: 'mute')
@@ -572,12 +617,14 @@ class AudioDeviceManagerGetPlaybackDeviceMuteJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceMuteJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceMuteJson {
+class AudioDeviceManagerGetRecordingDeviceMuteJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceMuteJson(this.mute);
 
   @JsonKey(name: 'mute')
@@ -587,6 +634,7 @@ class AudioDeviceManagerGetRecordingDeviceMuteJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceMuteJsonToJson(this);
 }

--- a/lib/src/binding/event_handler_param_json.dart
+++ b/lib/src/binding/event_handler_param_json.dart
@@ -2,11 +2,14 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, unused_import, prefer_is_empty
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
+
 part 'event_handler_param_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -23,6 +26,7 @@ class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonToJson(this);
 }
@@ -52,7 +56,8 @@ extension AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -69,6 +74,7 @@ class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonToJson(this);
 }
@@ -98,7 +104,8 @@ extension AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -115,6 +122,7 @@ class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonToJson(this);
 }
@@ -144,7 +152,7 @@ extension AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmFrameSinkOnFrameJson {
+class AudioPcmFrameSinkOnFrameJson implements AgoraSerializable {
   const AudioPcmFrameSinkOnFrameJson({this.frame});
 
   @JsonKey(name: 'frame')
@@ -153,6 +161,7 @@ class AudioPcmFrameSinkOnFrameJson {
   factory AudioPcmFrameSinkOnFrameJson.fromJson(Map<String, dynamic> json) =>
       _$AudioPcmFrameSinkOnFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmFrameSinkOnFrameJsonToJson(this);
 }
 
@@ -170,7 +179,8 @@ extension AudioPcmFrameSinkOnFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnRecordAudioFrameJson {
+class AudioFrameObserverBaseOnRecordAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnRecordAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -184,6 +194,7 @@ class AudioFrameObserverBaseOnRecordAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnRecordAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnRecordAudioFrameJsonToJson(this);
 }
@@ -203,7 +214,8 @@ extension AudioFrameObserverBaseOnRecordAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnPlaybackAudioFrameJson {
+class AudioFrameObserverBaseOnPlaybackAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnPlaybackAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -217,6 +229,7 @@ class AudioFrameObserverBaseOnPlaybackAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnPlaybackAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnPlaybackAudioFrameJsonToJson(this);
 }
@@ -236,7 +249,7 @@ extension AudioFrameObserverBaseOnPlaybackAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnMixedAudioFrameJson {
+class AudioFrameObserverBaseOnMixedAudioFrameJson implements AgoraSerializable {
   const AudioFrameObserverBaseOnMixedAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -250,6 +263,7 @@ class AudioFrameObserverBaseOnMixedAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnMixedAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnMixedAudioFrameJsonToJson(this);
 }
@@ -269,7 +283,8 @@ extension AudioFrameObserverBaseOnMixedAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson {
+class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnEarMonitoringAudioFrameJson({this.audioFrame});
 
   @JsonKey(name: 'audioFrame')
@@ -279,6 +294,7 @@ class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonToJson(this);
 }
@@ -298,7 +314,8 @@ extension AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson {
+class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson
+    implements AgoraSerializable {
   const AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson(
       {this.channelId, this.uid, this.audioFrame});
 
@@ -315,6 +332,7 @@ class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonToJson(this);
 }
@@ -334,7 +352,8 @@ extension AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumObserverOnLocalAudioSpectrumJson {
+class AudioSpectrumObserverOnLocalAudioSpectrumJson
+    implements AgoraSerializable {
   const AudioSpectrumObserverOnLocalAudioSpectrumJson({this.data});
 
   @JsonKey(name: 'data')
@@ -344,6 +363,7 @@ class AudioSpectrumObserverOnLocalAudioSpectrumJson {
           Map<String, dynamic> json) =>
       _$AudioSpectrumObserverOnLocalAudioSpectrumJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioSpectrumObserverOnLocalAudioSpectrumJsonToJson(this);
 }
@@ -363,7 +383,8 @@ extension AudioSpectrumObserverOnLocalAudioSpectrumJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumObserverOnRemoteAudioSpectrumJson {
+class AudioSpectrumObserverOnRemoteAudioSpectrumJson
+    implements AgoraSerializable {
   const AudioSpectrumObserverOnRemoteAudioSpectrumJson(
       {this.spectrums, this.spectrumNumber});
 
@@ -377,6 +398,7 @@ class AudioSpectrumObserverOnRemoteAudioSpectrumJson {
           Map<String, dynamic> json) =>
       _$AudioSpectrumObserverOnRemoteAudioSpectrumJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioSpectrumObserverOnRemoteAudioSpectrumJsonToJson(this);
 }
@@ -396,7 +418,8 @@ extension AudioSpectrumObserverOnRemoteAudioSpectrumJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson {
+class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson
+    implements AgoraSerializable {
   const VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson(
       {this.uid, this.imageBuffer, this.length, this.videoEncodedFrameInfo});
 
@@ -416,6 +439,7 @@ class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson {
           Map<String, dynamic> json) =>
       _$VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonToJson(this);
 }
@@ -446,7 +470,7 @@ extension VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnCaptureVideoFrameJson {
+class VideoFrameObserverOnCaptureVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnCaptureVideoFrameJson(
       {this.sourceType, this.videoFrame});
 
@@ -460,6 +484,7 @@ class VideoFrameObserverOnCaptureVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnCaptureVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnCaptureVideoFrameJsonToJson(this);
 }
@@ -479,7 +504,7 @@ extension VideoFrameObserverOnCaptureVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnPreEncodeVideoFrameJson {
+class VideoFrameObserverOnPreEncodeVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnPreEncodeVideoFrameJson(
       {this.sourceType, this.videoFrame});
 
@@ -493,6 +518,7 @@ class VideoFrameObserverOnPreEncodeVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnPreEncodeVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnPreEncodeVideoFrameJsonToJson(this);
 }
@@ -512,7 +538,8 @@ extension VideoFrameObserverOnPreEncodeVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnMediaPlayerVideoFrameJson {
+class VideoFrameObserverOnMediaPlayerVideoFrameJson
+    implements AgoraSerializable {
   const VideoFrameObserverOnMediaPlayerVideoFrameJson(
       {this.videoFrame, this.mediaPlayerId});
 
@@ -526,6 +553,7 @@ class VideoFrameObserverOnMediaPlayerVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnMediaPlayerVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnMediaPlayerVideoFrameJsonToJson(this);
 }
@@ -545,7 +573,7 @@ extension VideoFrameObserverOnMediaPlayerVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnRenderVideoFrameJson {
+class VideoFrameObserverOnRenderVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnRenderVideoFrameJson(
       {this.channelId, this.remoteUid, this.videoFrame});
 
@@ -562,6 +590,7 @@ class VideoFrameObserverOnRenderVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnRenderVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnRenderVideoFrameJsonToJson(this);
 }
@@ -581,7 +610,8 @@ extension VideoFrameObserverOnRenderVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnTranscodedVideoFrameJson {
+class VideoFrameObserverOnTranscodedVideoFrameJson
+    implements AgoraSerializable {
   const VideoFrameObserverOnTranscodedVideoFrameJson({this.videoFrame});
 
   @JsonKey(name: 'videoFrame')
@@ -591,6 +621,7 @@ class VideoFrameObserverOnTranscodedVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnTranscodedVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnTranscodedVideoFrameJsonToJson(this);
 }
@@ -610,7 +641,7 @@ extension VideoFrameObserverOnTranscodedVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FaceInfoObserverOnFaceInfoJson {
+class FaceInfoObserverOnFaceInfoJson implements AgoraSerializable {
   const FaceInfoObserverOnFaceInfoJson({this.outFaceInfo});
 
   @JsonKey(name: 'outFaceInfo')
@@ -619,6 +650,7 @@ class FaceInfoObserverOnFaceInfoJson {
   factory FaceInfoObserverOnFaceInfoJson.fromJson(Map<String, dynamic> json) =>
       _$FaceInfoObserverOnFaceInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$FaceInfoObserverOnFaceInfoJsonToJson(this);
 }
 
@@ -636,7 +668,8 @@ extension FaceInfoObserverOnFaceInfoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderObserverOnRecorderStateChangedJson {
+class MediaRecorderObserverOnRecorderStateChangedJson
+    implements AgoraSerializable {
   const MediaRecorderObserverOnRecorderStateChangedJson(
       {this.channelId, this.uid, this.state, this.reason});
 
@@ -656,6 +689,7 @@ class MediaRecorderObserverOnRecorderStateChangedJson {
           Map<String, dynamic> json) =>
       _$MediaRecorderObserverOnRecorderStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaRecorderObserverOnRecorderStateChangedJsonToJson(this);
 }
@@ -675,7 +709,8 @@ extension MediaRecorderObserverOnRecorderStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderObserverOnRecorderInfoUpdatedJson {
+class MediaRecorderObserverOnRecorderInfoUpdatedJson
+    implements AgoraSerializable {
   const MediaRecorderObserverOnRecorderInfoUpdatedJson(
       {this.channelId, this.uid, this.info});
 
@@ -692,6 +727,7 @@ class MediaRecorderObserverOnRecorderInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaRecorderObserverOnRecorderInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaRecorderObserverOnRecorderInfoUpdatedJsonToJson(this);
 }
@@ -711,7 +747,7 @@ extension MediaRecorderObserverOnRecorderInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnEnableTranscodeJson {
+class H265TranscoderObserverOnEnableTranscodeJson implements AgoraSerializable {
   const H265TranscoderObserverOnEnableTranscodeJson({this.result});
 
   @JsonKey(name: 'result')
@@ -721,6 +757,7 @@ class H265TranscoderObserverOnEnableTranscodeJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnEnableTranscodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnEnableTranscodeJsonToJson(this);
 }
@@ -740,7 +777,7 @@ extension H265TranscoderObserverOnEnableTranscodeJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnQueryChannelJson {
+class H265TranscoderObserverOnQueryChannelJson implements AgoraSerializable {
   const H265TranscoderObserverOnQueryChannelJson(
       {this.result, this.originChannel, this.transcodeChannel});
 
@@ -757,6 +794,7 @@ class H265TranscoderObserverOnQueryChannelJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnQueryChannelJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnQueryChannelJsonToJson(this);
 }
@@ -776,7 +814,8 @@ extension H265TranscoderObserverOnQueryChannelJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnTriggerTranscodeJson {
+class H265TranscoderObserverOnTriggerTranscodeJson
+    implements AgoraSerializable {
   const H265TranscoderObserverOnTriggerTranscodeJson({this.result});
 
   @JsonKey(name: 'result')
@@ -786,6 +825,7 @@ class H265TranscoderObserverOnTriggerTranscodeJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnTriggerTranscodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnTriggerTranscodeJsonToJson(this);
 }
@@ -805,7 +845,7 @@ extension H265TranscoderObserverOnTriggerTranscodeJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerVideoFrameObserverOnFrameJson {
+class MediaPlayerVideoFrameObserverOnFrameJson implements AgoraSerializable {
   const MediaPlayerVideoFrameObserverOnFrameJson({this.frame});
 
   @JsonKey(name: 'frame')
@@ -815,6 +855,7 @@ class MediaPlayerVideoFrameObserverOnFrameJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerVideoFrameObserverOnFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerVideoFrameObserverOnFrameJsonToJson(this);
 }
@@ -834,7 +875,8 @@ extension MediaPlayerVideoFrameObserverOnFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson {
+class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerSourceStateChangedJson(
       {this.state, this.reason});
 
@@ -848,6 +890,7 @@ class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonToJson(this);
 }
@@ -867,7 +910,8 @@ extension MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPositionChangedJson {
+class MediaPlayerSourceObserverOnPositionChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPositionChangedJson(
       {this.positionMs, this.timestampMs});
 
@@ -881,6 +925,7 @@ class MediaPlayerSourceObserverOnPositionChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPositionChangedJsonToJson(this);
 }
@@ -900,7 +945,7 @@ extension MediaPlayerSourceObserverOnPositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerEventJson {
+class MediaPlayerSourceObserverOnPlayerEventJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerEventJson(
       {this.eventCode, this.elapsedTime, this.message});
 
@@ -917,6 +962,7 @@ class MediaPlayerSourceObserverOnPlayerEventJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerEventJsonToJson(this);
 }
@@ -936,7 +982,7 @@ extension MediaPlayerSourceObserverOnPlayerEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnMetaDataJson {
+class MediaPlayerSourceObserverOnMetaDataJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnMetaDataJson({this.data, this.length});
 
   @JsonKey(name: 'data', ignore: true)
@@ -949,6 +995,7 @@ class MediaPlayerSourceObserverOnMetaDataJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnMetaDataJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnMetaDataJsonToJson(this);
 }
@@ -975,7 +1022,8 @@ extension MediaPlayerSourceObserverOnMetaDataJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayBufferUpdatedJson {
+class MediaPlayerSourceObserverOnPlayBufferUpdatedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayBufferUpdatedJson(
       {this.playCachedBuffer});
 
@@ -986,6 +1034,7 @@ class MediaPlayerSourceObserverOnPlayBufferUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayBufferUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayBufferUpdatedJsonToJson(this);
 }
@@ -1005,7 +1054,7 @@ extension MediaPlayerSourceObserverOnPlayBufferUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPreloadEventJson {
+class MediaPlayerSourceObserverOnPreloadEventJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPreloadEventJson({this.src, this.event});
 
   @JsonKey(name: 'src')
@@ -1018,6 +1067,7 @@ class MediaPlayerSourceObserverOnPreloadEventJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPreloadEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPreloadEventJsonToJson(this);
 }
@@ -1037,13 +1087,14 @@ extension MediaPlayerSourceObserverOnPreloadEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnCompletedJson {
+class MediaPlayerSourceObserverOnCompletedJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnCompletedJson();
 
   factory MediaPlayerSourceObserverOnCompletedJson.fromJson(
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnCompletedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnCompletedJsonToJson(this);
 }
@@ -1063,13 +1114,15 @@ extension MediaPlayerSourceObserverOnCompletedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson {
+class MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson();
 
   factory MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson.fromJson(
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonToJson(this);
 }
@@ -1089,7 +1142,8 @@ extension MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson {
+class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson(
       {this.from, this.to});
 
@@ -1103,6 +1157,7 @@ class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonToJson(this);
 }
@@ -1122,7 +1177,8 @@ extension MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson {
+class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -1132,6 +1188,7 @@ class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonToJson(this);
 }
@@ -1151,7 +1208,8 @@ extension MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerCacheStatsJson {
+class MediaPlayerSourceObserverOnPlayerCacheStatsJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerCacheStatsJson({this.stats});
 
   @JsonKey(name: 'stats')
@@ -1161,6 +1219,7 @@ class MediaPlayerSourceObserverOnPlayerCacheStatsJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerCacheStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerCacheStatsJsonToJson(this);
 }
@@ -1180,7 +1239,8 @@ extension MediaPlayerSourceObserverOnPlayerCacheStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson {
+class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerPlaybackStatsJson({this.stats});
 
   @JsonKey(name: 'stats')
@@ -1190,6 +1250,7 @@ class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonToJson(this);
 }
@@ -1209,7 +1270,8 @@ extension MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnAudioVolumeIndicationJson {
+class MediaPlayerSourceObserverOnAudioVolumeIndicationJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnAudioVolumeIndicationJson({this.volume});
 
   @JsonKey(name: 'volume')
@@ -1219,6 +1281,7 @@ class MediaPlayerSourceObserverOnAudioVolumeIndicationJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnAudioVolumeIndicationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnAudioVolumeIndicationJsonToJson(this);
 }
@@ -1238,7 +1301,8 @@ extension MediaPlayerSourceObserverOnAudioVolumeIndicationJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnMusicChartsResultJson {
+class MusicContentCenterEventHandlerOnMusicChartsResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnMusicChartsResultJson(
       {this.requestId, this.result, this.reason});
 
@@ -1255,6 +1319,7 @@ class MusicContentCenterEventHandlerOnMusicChartsResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnMusicChartsResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnMusicChartsResultJsonToJson(this);
 }
@@ -1274,7 +1339,8 @@ extension MusicContentCenterEventHandlerOnMusicChartsResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnMusicCollectionResultJson {
+class MusicContentCenterEventHandlerOnMusicCollectionResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnMusicCollectionResultJson(
       {this.requestId, this.result, this.reason});
 
@@ -1291,6 +1357,7 @@ class MusicContentCenterEventHandlerOnMusicCollectionResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnMusicCollectionResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnMusicCollectionResultJsonToJson(this);
 }
@@ -1310,7 +1377,8 @@ extension MusicContentCenterEventHandlerOnMusicCollectionResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnLyricResultJson {
+class MusicContentCenterEventHandlerOnLyricResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnLyricResultJson(
       {this.requestId, this.songCode, this.lyricUrl, this.reason});
 
@@ -1330,6 +1398,7 @@ class MusicContentCenterEventHandlerOnLyricResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnLyricResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnLyricResultJsonToJson(this);
 }
@@ -1349,7 +1418,8 @@ extension MusicContentCenterEventHandlerOnLyricResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson {
+class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnSongSimpleInfoResultJson(
       {this.requestId, this.songCode, this.simpleInfo, this.reason});
 
@@ -1369,6 +1439,7 @@ class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonToJson(this);
 }
@@ -1388,7 +1459,8 @@ extension MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnPreLoadEventJson {
+class MusicContentCenterEventHandlerOnPreLoadEventJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnPreLoadEventJson(
       {this.requestId,
       this.songCode,
@@ -1419,6 +1491,7 @@ class MusicContentCenterEventHandlerOnPreLoadEventJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnPreLoadEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnPreLoadEventJsonToJson(this);
 }
@@ -1438,7 +1511,8 @@ extension MusicContentCenterEventHandlerOnPreLoadEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnJoinChannelSuccessJson {
+class RtcEngineEventHandlerOnJoinChannelSuccessJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnJoinChannelSuccessJson(
       {this.connection, this.elapsed});
 
@@ -1452,6 +1526,7 @@ class RtcEngineEventHandlerOnJoinChannelSuccessJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnJoinChannelSuccessJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnJoinChannelSuccessJsonToJson(this);
 }
@@ -1471,7 +1546,8 @@ extension RtcEngineEventHandlerOnJoinChannelSuccessJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRejoinChannelSuccessJson {
+class RtcEngineEventHandlerOnRejoinChannelSuccessJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRejoinChannelSuccessJson(
       {this.connection, this.elapsed});
 
@@ -1485,6 +1561,7 @@ class RtcEngineEventHandlerOnRejoinChannelSuccessJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRejoinChannelSuccessJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRejoinChannelSuccessJsonToJson(this);
 }
@@ -1504,7 +1581,7 @@ extension RtcEngineEventHandlerOnRejoinChannelSuccessJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnProxyConnectedJson {
+class RtcEngineEventHandlerOnProxyConnectedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnProxyConnectedJson(
       {this.channel,
       this.uid,
@@ -1531,6 +1608,7 @@ class RtcEngineEventHandlerOnProxyConnectedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnProxyConnectedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnProxyConnectedJsonToJson(this);
 }
@@ -1550,7 +1628,7 @@ extension RtcEngineEventHandlerOnProxyConnectedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnErrorJson {
+class RtcEngineEventHandlerOnErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnErrorJson({this.err, this.msg});
 
   @JsonKey(name: 'err')
@@ -1563,6 +1641,7 @@ class RtcEngineEventHandlerOnErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnErrorJsonToJson(this);
 }
@@ -1581,7 +1660,7 @@ extension RtcEngineEventHandlerOnErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioQualityJson {
+class RtcEngineEventHandlerOnAudioQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioQualityJson(
       {this.connection, this.remoteUid, this.quality, this.delay, this.lost});
 
@@ -1604,6 +1683,7 @@ class RtcEngineEventHandlerOnAudioQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioQualityJsonToJson(this);
 }
@@ -1623,7 +1703,8 @@ extension RtcEngineEventHandlerOnAudioQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLastmileProbeResultJson {
+class RtcEngineEventHandlerOnLastmileProbeResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLastmileProbeResultJson({this.result});
 
   @JsonKey(name: 'result')
@@ -1633,6 +1714,7 @@ class RtcEngineEventHandlerOnLastmileProbeResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLastmileProbeResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLastmileProbeResultJsonToJson(this);
 }
@@ -1652,7 +1734,8 @@ extension RtcEngineEventHandlerOnLastmileProbeResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioVolumeIndicationJson {
+class RtcEngineEventHandlerOnAudioVolumeIndicationJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioVolumeIndicationJson(
       {this.connection, this.speakers, this.speakerNumber, this.totalVolume});
 
@@ -1672,6 +1755,7 @@ class RtcEngineEventHandlerOnAudioVolumeIndicationJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioVolumeIndicationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioVolumeIndicationJsonToJson(this);
 }
@@ -1691,7 +1775,7 @@ extension RtcEngineEventHandlerOnAudioVolumeIndicationJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLeaveChannelJson {
+class RtcEngineEventHandlerOnLeaveChannelJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLeaveChannelJson({this.connection, this.stats});
 
   @JsonKey(name: 'connection')
@@ -1704,6 +1788,7 @@ class RtcEngineEventHandlerOnLeaveChannelJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLeaveChannelJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLeaveChannelJsonToJson(this);
 }
@@ -1723,7 +1808,7 @@ extension RtcEngineEventHandlerOnLeaveChannelJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtcStatsJson {
+class RtcEngineEventHandlerOnRtcStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtcStatsJson({this.connection, this.stats});
 
   @JsonKey(name: 'connection')
@@ -1736,6 +1821,7 @@ class RtcEngineEventHandlerOnRtcStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtcStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtcStatsJsonToJson(this);
 }
@@ -1754,7 +1840,8 @@ extension RtcEngineEventHandlerOnRtcStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioDeviceStateChangedJson {
+class RtcEngineEventHandlerOnAudioDeviceStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioDeviceStateChangedJson(
       {this.deviceId, this.deviceType, this.deviceState});
 
@@ -1771,6 +1858,7 @@ class RtcEngineEventHandlerOnAudioDeviceStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioDeviceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioDeviceStateChangedJsonToJson(this);
 }
@@ -1790,7 +1878,8 @@ extension RtcEngineEventHandlerOnAudioDeviceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingPositionChangedJson {
+class RtcEngineEventHandlerOnAudioMixingPositionChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingPositionChangedJson({this.position});
 
   @JsonKey(name: 'position')
@@ -1800,6 +1889,7 @@ class RtcEngineEventHandlerOnAudioMixingPositionChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingPositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingPositionChangedJsonToJson(this);
 }
@@ -1819,13 +1909,15 @@ extension RtcEngineEventHandlerOnAudioMixingPositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingFinishedJson {
+class RtcEngineEventHandlerOnAudioMixingFinishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingFinishedJson();
 
   factory RtcEngineEventHandlerOnAudioMixingFinishedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingFinishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingFinishedJsonToJson(this);
 }
@@ -1845,7 +1937,8 @@ extension RtcEngineEventHandlerOnAudioMixingFinishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioEffectFinishedJson {
+class RtcEngineEventHandlerOnAudioEffectFinishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioEffectFinishedJson({this.soundId});
 
   @JsonKey(name: 'soundId')
@@ -1855,6 +1948,7 @@ class RtcEngineEventHandlerOnAudioEffectFinishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioEffectFinishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioEffectFinishedJsonToJson(this);
 }
@@ -1874,7 +1968,8 @@ extension RtcEngineEventHandlerOnAudioEffectFinishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoDeviceStateChangedJson {
+class RtcEngineEventHandlerOnVideoDeviceStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoDeviceStateChangedJson(
       {this.deviceId, this.deviceType, this.deviceState});
 
@@ -1891,6 +1986,7 @@ class RtcEngineEventHandlerOnVideoDeviceStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoDeviceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoDeviceStateChangedJsonToJson(this);
 }
@@ -1910,7 +2006,7 @@ extension RtcEngineEventHandlerOnVideoDeviceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnNetworkQualityJson {
+class RtcEngineEventHandlerOnNetworkQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnNetworkQualityJson(
       {this.connection, this.remoteUid, this.txQuality, this.rxQuality});
 
@@ -1930,6 +2026,7 @@ class RtcEngineEventHandlerOnNetworkQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnNetworkQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnNetworkQualityJsonToJson(this);
 }
@@ -1949,7 +2046,8 @@ extension RtcEngineEventHandlerOnNetworkQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnIntraRequestReceivedJson {
+class RtcEngineEventHandlerOnIntraRequestReceivedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnIntraRequestReceivedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -1959,6 +2057,7 @@ class RtcEngineEventHandlerOnIntraRequestReceivedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnIntraRequestReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnIntraRequestReceivedJsonToJson(this);
 }
@@ -1978,7 +2077,8 @@ extension RtcEngineEventHandlerOnIntraRequestReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson {
+class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -1988,6 +2088,7 @@ class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonToJson(this);
 }
@@ -2007,7 +2108,8 @@ extension RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson {
+class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -2017,6 +2119,7 @@ class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonToJson(this);
 }
@@ -2036,7 +2139,7 @@ extension RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLastmileQualityJson {
+class RtcEngineEventHandlerOnLastmileQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLastmileQualityJson({this.quality});
 
   @JsonKey(name: 'quality')
@@ -2046,6 +2149,7 @@ class RtcEngineEventHandlerOnLastmileQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLastmileQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLastmileQualityJsonToJson(this);
 }
@@ -2065,7 +2169,8 @@ extension RtcEngineEventHandlerOnLastmileQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalVideoFrameJson {
+class RtcEngineEventHandlerOnFirstLocalVideoFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalVideoFrameJson(
       {this.source, this.width, this.height, this.elapsed});
 
@@ -2085,6 +2190,7 @@ class RtcEngineEventHandlerOnFirstLocalVideoFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFrameJsonToJson(this);
 }
@@ -2104,7 +2210,8 @@ extension RtcEngineEventHandlerOnFirstLocalVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson {
+class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson(
       {this.connection, this.elapsed});
 
@@ -2118,6 +2225,7 @@ class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonToJson(this);
 }
@@ -2137,7 +2245,8 @@ extension RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson {
+class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson(
       {this.connection, this.remoteUid, this.width, this.height, this.elapsed});
 
@@ -2160,6 +2269,7 @@ class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonToJson(this);
 }
@@ -2179,7 +2289,7 @@ extension RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoSizeChangedJson {
+class RtcEngineEventHandlerOnVideoSizeChangedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoSizeChangedJson(
       {this.connection,
       this.sourceType,
@@ -2210,6 +2320,7 @@ class RtcEngineEventHandlerOnVideoSizeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoSizeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoSizeChangedJsonToJson(this);
 }
@@ -2229,7 +2340,8 @@ extension RtcEngineEventHandlerOnVideoSizeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoStateChangedJson {
+class RtcEngineEventHandlerOnLocalVideoStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoStateChangedJson(
       {this.source, this.state, this.reason});
 
@@ -2246,6 +2358,7 @@ class RtcEngineEventHandlerOnLocalVideoStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoStateChangedJsonToJson(this);
 }
@@ -2265,7 +2378,8 @@ extension RtcEngineEventHandlerOnLocalVideoStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoStateChangedJson {
+class RtcEngineEventHandlerOnRemoteVideoStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoStateChangedJson(
       {this.connection, this.remoteUid, this.state, this.reason, this.elapsed});
 
@@ -2288,6 +2402,7 @@ class RtcEngineEventHandlerOnRemoteVideoStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoStateChangedJsonToJson(this);
 }
@@ -2307,7 +2422,8 @@ extension RtcEngineEventHandlerOnRemoteVideoStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson {
+class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteVideoFrameJson(
       {this.connection, this.remoteUid, this.width, this.height, this.elapsed});
 
@@ -2330,6 +2446,7 @@ class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonToJson(this);
 }
@@ -2349,7 +2466,7 @@ extension RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserJoinedJson {
+class RtcEngineEventHandlerOnUserJoinedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserJoinedJson(
       {this.connection, this.remoteUid, this.elapsed});
 
@@ -2366,6 +2483,7 @@ class RtcEngineEventHandlerOnUserJoinedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserJoinedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserJoinedJsonToJson(this);
 }
@@ -2385,7 +2503,7 @@ extension RtcEngineEventHandlerOnUserJoinedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserOfflineJson {
+class RtcEngineEventHandlerOnUserOfflineJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserOfflineJson(
       {this.connection, this.remoteUid, this.reason});
 
@@ -2402,6 +2520,7 @@ class RtcEngineEventHandlerOnUserOfflineJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserOfflineJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserOfflineJsonToJson(this);
 }
@@ -2421,7 +2540,7 @@ extension RtcEngineEventHandlerOnUserOfflineJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserMuteAudioJson {
+class RtcEngineEventHandlerOnUserMuteAudioJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserMuteAudioJson(
       {this.connection, this.remoteUid, this.muted});
 
@@ -2438,6 +2557,7 @@ class RtcEngineEventHandlerOnUserMuteAudioJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserMuteAudioJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserMuteAudioJsonToJson(this);
 }
@@ -2457,7 +2577,7 @@ extension RtcEngineEventHandlerOnUserMuteAudioJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserMuteVideoJson {
+class RtcEngineEventHandlerOnUserMuteVideoJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserMuteVideoJson(
       {this.connection, this.remoteUid, this.muted});
 
@@ -2474,6 +2594,7 @@ class RtcEngineEventHandlerOnUserMuteVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserMuteVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserMuteVideoJsonToJson(this);
 }
@@ -2493,7 +2614,7 @@ extension RtcEngineEventHandlerOnUserMuteVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserEnableVideoJson {
+class RtcEngineEventHandlerOnUserEnableVideoJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserEnableVideoJson(
       {this.connection, this.remoteUid, this.enabled});
 
@@ -2510,6 +2631,7 @@ class RtcEngineEventHandlerOnUserEnableVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserEnableVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserEnableVideoJsonToJson(this);
 }
@@ -2529,7 +2651,7 @@ extension RtcEngineEventHandlerOnUserEnableVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserStateChangedJson {
+class RtcEngineEventHandlerOnUserStateChangedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserStateChangedJson(
       {this.connection, this.remoteUid, this.state});
 
@@ -2546,6 +2668,7 @@ class RtcEngineEventHandlerOnUserStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserStateChangedJsonToJson(this);
 }
@@ -2565,7 +2688,8 @@ extension RtcEngineEventHandlerOnUserStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserEnableLocalVideoJson {
+class RtcEngineEventHandlerOnUserEnableLocalVideoJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserEnableLocalVideoJson(
       {this.connection, this.remoteUid, this.enabled});
 
@@ -2582,6 +2706,7 @@ class RtcEngineEventHandlerOnUserEnableLocalVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserEnableLocalVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserEnableLocalVideoJsonToJson(this);
 }
@@ -2601,7 +2726,7 @@ extension RtcEngineEventHandlerOnUserEnableLocalVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioStatsJson {
+class RtcEngineEventHandlerOnRemoteAudioStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioStatsJson(
       {this.connection, this.stats});
 
@@ -2615,6 +2740,7 @@ class RtcEngineEventHandlerOnRemoteAudioStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioStatsJsonToJson(this);
 }
@@ -2634,7 +2760,7 @@ extension RtcEngineEventHandlerOnRemoteAudioStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalAudioStatsJson {
+class RtcEngineEventHandlerOnLocalAudioStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalAudioStatsJson(
       {this.connection, this.stats});
 
@@ -2648,6 +2774,7 @@ class RtcEngineEventHandlerOnLocalAudioStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalAudioStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalAudioStatsJsonToJson(this);
 }
@@ -2667,7 +2794,7 @@ extension RtcEngineEventHandlerOnLocalAudioStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoStatsJson {
+class RtcEngineEventHandlerOnLocalVideoStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoStatsJson(
       {this.connection, this.stats});
 
@@ -2681,6 +2808,7 @@ class RtcEngineEventHandlerOnLocalVideoStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoStatsJsonToJson(this);
 }
@@ -2700,7 +2828,7 @@ extension RtcEngineEventHandlerOnLocalVideoStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoStatsJson {
+class RtcEngineEventHandlerOnRemoteVideoStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoStatsJson(
       {this.connection, this.stats});
 
@@ -2714,6 +2842,7 @@ class RtcEngineEventHandlerOnRemoteVideoStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoStatsJsonToJson(this);
 }
@@ -2733,13 +2862,14 @@ extension RtcEngineEventHandlerOnRemoteVideoStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraReadyJson {
+class RtcEngineEventHandlerOnCameraReadyJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraReadyJson();
 
   factory RtcEngineEventHandlerOnCameraReadyJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraReadyJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraReadyJsonToJson(this);
 }
@@ -2759,7 +2889,8 @@ extension RtcEngineEventHandlerOnCameraReadyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraFocusAreaChangedJson {
+class RtcEngineEventHandlerOnCameraFocusAreaChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraFocusAreaChangedJson(
       {this.x, this.y, this.width, this.height});
 
@@ -2779,6 +2910,7 @@ class RtcEngineEventHandlerOnCameraFocusAreaChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraFocusAreaChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraFocusAreaChangedJsonToJson(this);
 }
@@ -2798,7 +2930,8 @@ extension RtcEngineEventHandlerOnCameraFocusAreaChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraExposureAreaChangedJson {
+class RtcEngineEventHandlerOnCameraExposureAreaChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraExposureAreaChangedJson(
       {this.x, this.y, this.width, this.height});
 
@@ -2818,6 +2951,7 @@ class RtcEngineEventHandlerOnCameraExposureAreaChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraExposureAreaChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraExposureAreaChangedJsonToJson(this);
 }
@@ -2837,7 +2971,8 @@ extension RtcEngineEventHandlerOnCameraExposureAreaChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFacePositionChangedJson {
+class RtcEngineEventHandlerOnFacePositionChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFacePositionChangedJson(
       {this.imageWidth,
       this.imageHeight,
@@ -2864,6 +2999,7 @@ class RtcEngineEventHandlerOnFacePositionChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFacePositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFacePositionChangedJsonToJson(this);
 }
@@ -2883,13 +3019,14 @@ extension RtcEngineEventHandlerOnFacePositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoStoppedJson {
+class RtcEngineEventHandlerOnVideoStoppedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoStoppedJson();
 
   factory RtcEngineEventHandlerOnVideoStoppedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoStoppedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoStoppedJsonToJson(this);
 }
@@ -2909,7 +3046,8 @@ extension RtcEngineEventHandlerOnVideoStoppedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingStateChangedJson {
+class RtcEngineEventHandlerOnAudioMixingStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingStateChangedJson(
       {this.state, this.reason});
 
@@ -2923,6 +3061,7 @@ class RtcEngineEventHandlerOnAudioMixingStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingStateChangedJsonToJson(this);
 }
@@ -2942,7 +3081,8 @@ extension RtcEngineEventHandlerOnAudioMixingStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson {
+class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRhythmPlayerStateChangedJson(
       {this.state, this.reason});
 
@@ -2956,6 +3096,7 @@ class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonToJson(this);
 }
@@ -2975,7 +3116,7 @@ extension RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionLostJson {
+class RtcEngineEventHandlerOnConnectionLostJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionLostJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -2985,6 +3126,7 @@ class RtcEngineEventHandlerOnConnectionLostJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionLostJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionLostJsonToJson(this);
 }
@@ -3004,7 +3146,8 @@ extension RtcEngineEventHandlerOnConnectionLostJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionInterruptedJson {
+class RtcEngineEventHandlerOnConnectionInterruptedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionInterruptedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3014,6 +3157,7 @@ class RtcEngineEventHandlerOnConnectionInterruptedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionInterruptedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionInterruptedJsonToJson(this);
 }
@@ -3033,7 +3177,7 @@ extension RtcEngineEventHandlerOnConnectionInterruptedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionBannedJson {
+class RtcEngineEventHandlerOnConnectionBannedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionBannedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3043,6 +3187,7 @@ class RtcEngineEventHandlerOnConnectionBannedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionBannedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionBannedJsonToJson(this);
 }
@@ -3062,7 +3207,7 @@ extension RtcEngineEventHandlerOnConnectionBannedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnStreamMessageJson {
+class RtcEngineEventHandlerOnStreamMessageJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnStreamMessageJson(
       {this.connection,
       this.remoteUid,
@@ -3093,6 +3238,7 @@ class RtcEngineEventHandlerOnStreamMessageJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnStreamMessageJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnStreamMessageJsonToJson(this);
 }
@@ -3125,7 +3271,8 @@ extension RtcEngineEventHandlerOnStreamMessageJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnStreamMessageErrorJson {
+class RtcEngineEventHandlerOnStreamMessageErrorJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnStreamMessageErrorJson(
       {this.connection,
       this.remoteUid,
@@ -3156,6 +3303,7 @@ class RtcEngineEventHandlerOnStreamMessageErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnStreamMessageErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnStreamMessageErrorJsonToJson(this);
 }
@@ -3175,7 +3323,7 @@ extension RtcEngineEventHandlerOnStreamMessageErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRequestTokenJson {
+class RtcEngineEventHandlerOnRequestTokenJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRequestTokenJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3185,6 +3333,7 @@ class RtcEngineEventHandlerOnRequestTokenJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRequestTokenJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRequestTokenJsonToJson(this);
 }
@@ -3204,7 +3353,8 @@ extension RtcEngineEventHandlerOnRequestTokenJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson {
+class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson(
       {this.connection, this.token});
 
@@ -3218,6 +3368,7 @@ class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonToJson(this);
 }
@@ -3237,7 +3388,8 @@ extension RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLicenseValidationFailureJson {
+class RtcEngineEventHandlerOnLicenseValidationFailureJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLicenseValidationFailureJson(
       {this.connection, this.reason});
 
@@ -3251,6 +3403,7 @@ class RtcEngineEventHandlerOnLicenseValidationFailureJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLicenseValidationFailureJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLicenseValidationFailureJsonToJson(this);
 }
@@ -3270,7 +3423,8 @@ extension RtcEngineEventHandlerOnLicenseValidationFailureJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson {
+class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson(
       {this.connection, this.elapsed});
 
@@ -3284,6 +3438,7 @@ class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonToJson(this);
 }
@@ -3303,7 +3458,8 @@ extension RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson {
+class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson(
       {this.connection, this.uid, this.elapsed});
 
@@ -3320,6 +3476,7 @@ class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonToJson(this);
 }
@@ -3339,7 +3496,8 @@ extension RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson {
+class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteAudioFrameJson(
       {this.connection, this.userId, this.elapsed});
 
@@ -3356,6 +3514,7 @@ class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonToJson(this);
 }
@@ -3375,7 +3534,8 @@ extension RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalAudioStateChangedJson {
+class RtcEngineEventHandlerOnLocalAudioStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalAudioStateChangedJson(
       {this.connection, this.state, this.reason});
 
@@ -3392,6 +3552,7 @@ class RtcEngineEventHandlerOnLocalAudioStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalAudioStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalAudioStateChangedJsonToJson(this);
 }
@@ -3411,7 +3572,8 @@ extension RtcEngineEventHandlerOnLocalAudioStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioStateChangedJson {
+class RtcEngineEventHandlerOnRemoteAudioStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioStateChangedJson(
       {this.connection, this.remoteUid, this.state, this.reason, this.elapsed});
 
@@ -3434,6 +3596,7 @@ class RtcEngineEventHandlerOnRemoteAudioStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioStateChangedJsonToJson(this);
 }
@@ -3453,7 +3616,7 @@ extension RtcEngineEventHandlerOnRemoteAudioStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnActiveSpeakerJson {
+class RtcEngineEventHandlerOnActiveSpeakerJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnActiveSpeakerJson({this.connection, this.uid});
 
   @JsonKey(name: 'connection')
@@ -3466,6 +3629,7 @@ class RtcEngineEventHandlerOnActiveSpeakerJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnActiveSpeakerJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnActiveSpeakerJsonToJson(this);
 }
@@ -3485,7 +3649,8 @@ extension RtcEngineEventHandlerOnActiveSpeakerJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnContentInspectResultJson {
+class RtcEngineEventHandlerOnContentInspectResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnContentInspectResultJson({this.result});
 
   @JsonKey(name: 'result')
@@ -3495,6 +3660,7 @@ class RtcEngineEventHandlerOnContentInspectResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnContentInspectResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnContentInspectResultJsonToJson(this);
 }
@@ -3514,7 +3680,7 @@ extension RtcEngineEventHandlerOnContentInspectResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnSnapshotTakenJson {
+class RtcEngineEventHandlerOnSnapshotTakenJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnSnapshotTakenJson(
       {this.connection,
       this.uid,
@@ -3545,6 +3711,7 @@ class RtcEngineEventHandlerOnSnapshotTakenJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnSnapshotTakenJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnSnapshotTakenJsonToJson(this);
 }
@@ -3564,7 +3731,8 @@ extension RtcEngineEventHandlerOnSnapshotTakenJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnClientRoleChangedJson {
+class RtcEngineEventHandlerOnClientRoleChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnClientRoleChangedJson(
       {this.connection, this.oldRole, this.newRole, this.newRoleOptions});
 
@@ -3584,6 +3752,7 @@ class RtcEngineEventHandlerOnClientRoleChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnClientRoleChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnClientRoleChangedJsonToJson(this);
 }
@@ -3603,7 +3772,8 @@ extension RtcEngineEventHandlerOnClientRoleChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnClientRoleChangeFailedJson {
+class RtcEngineEventHandlerOnClientRoleChangeFailedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnClientRoleChangeFailedJson(
       {this.connection, this.reason, this.currentRole});
 
@@ -3620,6 +3790,7 @@ class RtcEngineEventHandlerOnClientRoleChangeFailedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnClientRoleChangeFailedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnClientRoleChangeFailedJsonToJson(this);
 }
@@ -3639,7 +3810,8 @@ extension RtcEngineEventHandlerOnClientRoleChangeFailedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson {
+class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson(
       {this.deviceType, this.volume, this.muted});
 
@@ -3656,6 +3828,7 @@ class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonToJson(this);
 }
@@ -3675,7 +3848,8 @@ extension RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson {
+class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtmpStreamingStateChangedJson(
       {this.url, this.state, this.reason});
 
@@ -3692,6 +3866,7 @@ class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonToJson(this);
 }
@@ -3711,7 +3886,8 @@ extension RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtmpStreamingEventJson {
+class RtcEngineEventHandlerOnRtmpStreamingEventJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtmpStreamingEventJson(
       {this.url, this.eventCode});
 
@@ -3725,6 +3901,7 @@ class RtcEngineEventHandlerOnRtmpStreamingEventJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtmpStreamingEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtmpStreamingEventJsonToJson(this);
 }
@@ -3744,13 +3921,15 @@ extension RtcEngineEventHandlerOnRtmpStreamingEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTranscodingUpdatedJson {
+class RtcEngineEventHandlerOnTranscodingUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTranscodingUpdatedJson();
 
   factory RtcEngineEventHandlerOnTranscodingUpdatedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTranscodingUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTranscodingUpdatedJsonToJson(this);
 }
@@ -3770,7 +3949,8 @@ extension RtcEngineEventHandlerOnTranscodingUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioRoutingChangedJson {
+class RtcEngineEventHandlerOnAudioRoutingChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioRoutingChangedJson({this.routing});
 
   @JsonKey(name: 'routing')
@@ -3780,6 +3960,7 @@ class RtcEngineEventHandlerOnAudioRoutingChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioRoutingChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioRoutingChangedJsonToJson(this);
 }
@@ -3799,7 +3980,8 @@ extension RtcEngineEventHandlerOnAudioRoutingChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson {
+class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson(
       {this.state, this.code});
 
@@ -3813,6 +3995,7 @@ class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonToJson(this);
 }
@@ -3832,7 +4015,8 @@ extension RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson {
+class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson(
       {this.isFallbackOrRecover});
 
@@ -3844,6 +4028,7 @@ class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson {
       _$RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonToJson(this);
 }
@@ -3863,7 +4048,8 @@ extension RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson {
+class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson(
       {this.uid, this.isFallbackOrRecover});
 
@@ -3878,6 +4064,7 @@ class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson {
       _$RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonToJson(
           this);
@@ -3898,7 +4085,8 @@ extension RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson {
+class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioTransportStatsJson(
       {this.connection,
       this.remoteUid,
@@ -3925,6 +4113,7 @@ class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonToJson(this);
 }
@@ -3944,7 +4133,8 @@ extension RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson {
+class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoTransportStatsJson(
       {this.connection,
       this.remoteUid,
@@ -3971,6 +4161,7 @@ class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonToJson(this);
 }
@@ -3990,7 +4181,8 @@ extension RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionStateChangedJson {
+class RtcEngineEventHandlerOnConnectionStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionStateChangedJson(
       {this.connection, this.state, this.reason});
 
@@ -4007,6 +4199,7 @@ class RtcEngineEventHandlerOnConnectionStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionStateChangedJsonToJson(this);
 }
@@ -4026,7 +4219,7 @@ extension RtcEngineEventHandlerOnConnectionStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnWlAccMessageJson {
+class RtcEngineEventHandlerOnWlAccMessageJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnWlAccMessageJson(
       {this.connection, this.reason, this.action, this.wlAccMsg});
 
@@ -4046,6 +4239,7 @@ class RtcEngineEventHandlerOnWlAccMessageJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnWlAccMessageJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnWlAccMessageJsonToJson(this);
 }
@@ -4065,7 +4259,7 @@ extension RtcEngineEventHandlerOnWlAccMessageJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnWlAccStatsJson {
+class RtcEngineEventHandlerOnWlAccStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnWlAccStatsJson(
       {this.connection, this.currentStats, this.averageStats});
 
@@ -4082,6 +4276,7 @@ class RtcEngineEventHandlerOnWlAccStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnWlAccStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnWlAccStatsJsonToJson(this);
 }
@@ -4101,7 +4296,8 @@ extension RtcEngineEventHandlerOnWlAccStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnNetworkTypeChangedJson {
+class RtcEngineEventHandlerOnNetworkTypeChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnNetworkTypeChangedJson(
       {this.connection, this.type});
 
@@ -4115,6 +4311,7 @@ class RtcEngineEventHandlerOnNetworkTypeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnNetworkTypeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnNetworkTypeChangedJsonToJson(this);
 }
@@ -4134,7 +4331,7 @@ extension RtcEngineEventHandlerOnNetworkTypeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnEncryptionErrorJson {
+class RtcEngineEventHandlerOnEncryptionErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnEncryptionErrorJson(
       {this.connection, this.errorType});
 
@@ -4148,6 +4345,7 @@ class RtcEngineEventHandlerOnEncryptionErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnEncryptionErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnEncryptionErrorJsonToJson(this);
 }
@@ -4167,7 +4365,7 @@ extension RtcEngineEventHandlerOnEncryptionErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnPermissionErrorJson {
+class RtcEngineEventHandlerOnPermissionErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnPermissionErrorJson({this.permissionType});
 
   @JsonKey(name: 'permissionType')
@@ -4177,6 +4375,7 @@ class RtcEngineEventHandlerOnPermissionErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnPermissionErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnPermissionErrorJsonToJson(this);
 }
@@ -4196,7 +4395,8 @@ extension RtcEngineEventHandlerOnPermissionErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalUserRegisteredJson {
+class RtcEngineEventHandlerOnLocalUserRegisteredJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalUserRegisteredJson(
       {this.uid, this.userAccount});
 
@@ -4210,6 +4410,7 @@ class RtcEngineEventHandlerOnLocalUserRegisteredJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalUserRegisteredJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalUserRegisteredJsonToJson(this);
 }
@@ -4229,7 +4430,7 @@ extension RtcEngineEventHandlerOnLocalUserRegisteredJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserInfoUpdatedJson {
+class RtcEngineEventHandlerOnUserInfoUpdatedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserInfoUpdatedJson({this.uid, this.info});
 
   @JsonKey(name: 'uid')
@@ -4242,6 +4443,7 @@ class RtcEngineEventHandlerOnUserInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserInfoUpdatedJsonToJson(this);
 }
@@ -4261,7 +4463,8 @@ extension RtcEngineEventHandlerOnUserInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserAccountUpdatedJson {
+class RtcEngineEventHandlerOnUserAccountUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserAccountUpdatedJson(
       {this.connection, this.remoteUid, this.remoteUserAccount});
 
@@ -4278,6 +4481,7 @@ class RtcEngineEventHandlerOnUserAccountUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserAccountUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserAccountUpdatedJsonToJson(this);
 }
@@ -4297,7 +4501,8 @@ extension RtcEngineEventHandlerOnUserAccountUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoRenderingTracingResultJson {
+class RtcEngineEventHandlerOnVideoRenderingTracingResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoRenderingTracingResultJson(
       {this.connection, this.uid, this.currentEvent, this.tracingInfo});
 
@@ -4317,6 +4522,7 @@ class RtcEngineEventHandlerOnVideoRenderingTracingResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoRenderingTracingResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoRenderingTracingResultJsonToJson(this);
 }
@@ -4336,7 +4542,8 @@ extension RtcEngineEventHandlerOnVideoRenderingTracingResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson {
+class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson(
       {this.stream, this.error});
 
@@ -4350,6 +4557,7 @@ class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonToJson(this);
 }
@@ -4369,7 +4577,7 @@ extension RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUploadLogResultJson {
+class RtcEngineEventHandlerOnUploadLogResultJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUploadLogResultJson(
       {this.connection, this.requestId, this.success, this.reason});
 
@@ -4389,6 +4597,7 @@ class RtcEngineEventHandlerOnUploadLogResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUploadLogResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUploadLogResultJsonToJson(this);
 }
@@ -4408,7 +4617,8 @@ extension RtcEngineEventHandlerOnUploadLogResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson {
+class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioSubscribeStateChangedJson(
       {this.channel,
       this.uid,
@@ -4435,6 +4645,7 @@ class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonToJson(this);
 }
@@ -4454,7 +4665,8 @@ extension RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson {
+class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoSubscribeStateChangedJson(
       {this.channel,
       this.uid,
@@ -4481,6 +4693,7 @@ class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonToJson(this);
 }
@@ -4500,7 +4713,8 @@ extension RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioPublishStateChangedJson {
+class RtcEngineEventHandlerOnAudioPublishStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioPublishStateChangedJson(
       {this.channel, this.oldState, this.newState, this.elapseSinceLastState});
 
@@ -4520,6 +4734,7 @@ class RtcEngineEventHandlerOnAudioPublishStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioPublishStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioPublishStateChangedJsonToJson(this);
 }
@@ -4539,7 +4754,8 @@ extension RtcEngineEventHandlerOnAudioPublishStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoPublishStateChangedJson {
+class RtcEngineEventHandlerOnVideoPublishStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoPublishStateChangedJson(
       {this.source,
       this.channel,
@@ -4566,6 +4782,7 @@ class RtcEngineEventHandlerOnVideoPublishStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoPublishStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoPublishStateChangedJsonToJson(this);
 }
@@ -4585,7 +4802,8 @@ extension RtcEngineEventHandlerOnVideoPublishStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson {
+class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson(
       {this.connection,
       this.uid,
@@ -4616,6 +4834,7 @@ class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonToJson(this);
 }
@@ -4635,7 +4854,8 @@ extension RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMetadataReceivedJson {
+class RtcEngineEventHandlerOnAudioMetadataReceivedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMetadataReceivedJson(
       {this.connection, this.uid, this.metadata, this.length});
 
@@ -4655,6 +4875,7 @@ class RtcEngineEventHandlerOnAudioMetadataReceivedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMetadataReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMetadataReceivedJsonToJson(this);
 }
@@ -4682,7 +4903,8 @@ extension RtcEngineEventHandlerOnAudioMetadataReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionEventWithContextJson {
+class RtcEngineEventHandlerOnExtensionEventWithContextJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionEventWithContextJson(
       {this.context, this.key, this.value});
 
@@ -4699,6 +4921,7 @@ class RtcEngineEventHandlerOnExtensionEventWithContextJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionEventWithContextJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionEventWithContextJsonToJson(this);
 }
@@ -4718,7 +4941,8 @@ extension RtcEngineEventHandlerOnExtensionEventWithContextJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionStartedWithContextJson {
+class RtcEngineEventHandlerOnExtensionStartedWithContextJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionStartedWithContextJson({this.context});
 
   @JsonKey(name: 'context')
@@ -4728,6 +4952,7 @@ class RtcEngineEventHandlerOnExtensionStartedWithContextJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionStartedWithContextJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionStartedWithContextJsonToJson(this);
 }
@@ -4747,7 +4972,8 @@ extension RtcEngineEventHandlerOnExtensionStartedWithContextJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionStoppedWithContextJson {
+class RtcEngineEventHandlerOnExtensionStoppedWithContextJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionStoppedWithContextJson({this.context});
 
   @JsonKey(name: 'context')
@@ -4757,6 +4983,7 @@ class RtcEngineEventHandlerOnExtensionStoppedWithContextJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionStoppedWithContextJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionStoppedWithContextJsonToJson(this);
 }
@@ -4776,7 +5003,8 @@ extension RtcEngineEventHandlerOnExtensionStoppedWithContextJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionErrorWithContextJson {
+class RtcEngineEventHandlerOnExtensionErrorWithContextJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionErrorWithContextJson(
       {this.context, this.error, this.message});
 
@@ -4793,6 +5021,7 @@ class RtcEngineEventHandlerOnExtensionErrorWithContextJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionErrorWithContextJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionErrorWithContextJsonToJson(this);
 }
@@ -4812,7 +5041,7 @@ extension RtcEngineEventHandlerOnExtensionErrorWithContextJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnSetRtmFlagResultJson {
+class RtcEngineEventHandlerOnSetRtmFlagResultJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnSetRtmFlagResultJson(
       {this.connection, this.code});
 
@@ -4826,6 +5055,7 @@ class RtcEngineEventHandlerOnSetRtmFlagResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnSetRtmFlagResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnSetRtmFlagResultJsonToJson(this);
 }
@@ -4845,7 +5075,7 @@ extension RtcEngineEventHandlerOnSetRtmFlagResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MetadataObserverOnMetadataReceivedJson {
+class MetadataObserverOnMetadataReceivedJson implements AgoraSerializable {
   const MetadataObserverOnMetadataReceivedJson({this.metadata});
 
   @JsonKey(name: 'metadata')
@@ -4855,6 +5085,7 @@ class MetadataObserverOnMetadataReceivedJson {
           Map<String, dynamic> json) =>
       _$MetadataObserverOnMetadataReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MetadataObserverOnMetadataReceivedJsonToJson(this);
 }
@@ -4874,7 +5105,8 @@ extension MetadataObserverOnMetadataReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson {
+class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson
+    implements AgoraSerializable {
   const DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson(
       {this.state, this.reason, this.message});
 
@@ -4892,6 +5124,7 @@ class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson {
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonToJson(
           this);
@@ -4912,7 +5145,8 @@ extension DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonBuff
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson {
+class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson
+    implements AgoraSerializable {
   const DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson(
       {this.stats});
 
@@ -4924,6 +5158,7 @@ class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson {
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJsonToJson(this);
 }

--- a/lib/src/impl/agora_music_content_center_impl_json.dart
+++ b/lib/src/impl/agora_music_content_center_impl_json.dart
@@ -1,10 +1,11 @@
+import '/src/_serializable.dart';
 import '/src/agora_music_content_center.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'agora_music_content_center_impl_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicCollectionJson {
+class MusicCollectionJson implements AgoraSerializable {
   /// @nodoc
   MusicCollectionJson(
       {required this.count,
@@ -33,5 +34,6 @@ class MusicCollectionJson {
       _$MusicCollectionJsonFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicCollectionJsonToJson(this);
 }

--- a/lib/src/impl/json_converters.dart
+++ b/lib/src/impl/json_converters.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/agora_media_base.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -36,7 +37,7 @@ class _VideoFrameMetaInfoInternal implements VideoFrameMetaInfo {
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class _VideoFrameMetaInfoInternalJson {
+class _VideoFrameMetaInfoInternalJson implements AgoraSerializable {
   // ignore: non_constant_identifier_names
   const _VideoFrameMetaInfoInternalJson({this.KEY_FACE_CAPTURE});
   @JsonKey(name: 'KEY_FACE_CAPTURE')
@@ -49,6 +50,7 @@ class _VideoFrameMetaInfoInternalJson {
       _$VideoFrameMetaInfoInternalJsonFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFrameMetaInfoInternalJsonToJson(this);
 }
 


### PR DESCRIPTION
...so class instances will be shown as `Type(a: xx, b: yy)` instead of `Instance 'Type'` when parsed by readables (e.g. console).