### PR TITLE
feat: make data classes serializable (#2223)

### DIFF
--- a/lib/src/_serializable.dart
+++ b/lib/src/_serializable.dart
@@ -1,0 +1,6 @@
+abstract class AgoraSerializable {
+  Map<String, dynamic> toJson();
+
+  @override
+  String toString() => '$runtimeType({$toJson()})';
+}

--- a/lib/src/agora_base.dart
+++ b/lib/src/agora_base.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_base.g.dart';
 
@@ -966,7 +967,7 @@ extension DegradationPreferenceExt on DegradationPreference {
 
 /// The video dimension.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDimensions {
+class VideoDimensions implements AgoraSerializable {
   /// @nodoc
   const VideoDimensions({this.width, this.height});
 
@@ -983,6 +984,7 @@ class VideoDimensions {
       _$VideoDimensionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDimensionsToJson(this);
 }
 
@@ -1179,7 +1181,7 @@ extension TCcModeExt on TCcMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SenderOptions {
+class SenderOptions implements AgoraSerializable {
   /// @nodoc
   const SenderOptions({this.ccMode, this.codecType, this.targetBitrate});
 
@@ -1200,6 +1202,7 @@ class SenderOptions {
       _$SenderOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SenderOptionsToJson(this);
 }
 
@@ -1344,7 +1347,7 @@ extension WatermarkFitModeExt on WatermarkFitMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedAudioFrameAdvancedSettings {
+class EncodedAudioFrameAdvancedSettings implements AgoraSerializable {
   /// @nodoc
   const EncodedAudioFrameAdvancedSettings({this.speech, this.sendEvenIfEmpty});
 
@@ -1362,13 +1365,14 @@ class EncodedAudioFrameAdvancedSettings {
       _$EncodedAudioFrameAdvancedSettingsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$EncodedAudioFrameAdvancedSettingsToJson(this);
 }
 
 /// Audio information after encoding.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedAudioFrameInfo {
+class EncodedAudioFrameInfo implements AgoraSerializable {
   /// @nodoc
   const EncodedAudioFrameInfo(
       {this.codec,
@@ -1407,12 +1411,13 @@ class EncodedAudioFrameInfo {
       _$EncodedAudioFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncodedAudioFrameInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmDataInfo {
+class AudioPcmDataInfo implements AgoraSerializable {
   /// @nodoc
   const AudioPcmDataInfo(
       {this.samplesPerChannel,
@@ -1446,6 +1451,7 @@ class AudioPcmDataInfo {
       _$AudioPcmDataInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmDataInfoToJson(this);
 }
 
@@ -1525,7 +1531,7 @@ extension VideoStreamTypeExt on VideoStreamType {
 
 /// Video subscription options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoSubscriptionOptions {
+class VideoSubscriptionOptions implements AgoraSerializable {
   /// @nodoc
   const VideoSubscriptionOptions({this.type, this.encodedFrameOnly});
 
@@ -1542,6 +1548,7 @@ class VideoSubscriptionOptions {
       _$VideoSubscriptionOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoSubscriptionOptionsToJson(this);
 }
 
@@ -1568,7 +1575,7 @@ extension MaxUserAccountLengthTypeExt on MaxUserAccountLengthType {
 
 /// Information about externally encoded video frames.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncodedVideoFrameInfo {
+class EncodedVideoFrameInfo implements AgoraSerializable {
   /// @nodoc
   const EncodedVideoFrameInfo(
       {this.uid,
@@ -1637,6 +1644,7 @@ class EncodedVideoFrameInfo {
       _$EncodedVideoFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncodedVideoFrameInfoToJson(this);
 }
 
@@ -1696,7 +1704,7 @@ extension EncodingPreferenceExt on EncodingPreference {
 
 /// Advanced options for video encoding.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvanceOptions {
+class AdvanceOptions implements AgoraSerializable {
   /// @nodoc
   const AdvanceOptions({this.encodingPreference, this.compressionPreference});
 
@@ -1713,6 +1721,7 @@ class AdvanceOptions {
       _$AdvanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvanceOptionsToJson(this);
 }
 
@@ -1811,7 +1820,7 @@ extension CodecCapMaskExt on CodecCapMask {
 
 /// The level of the codec capability.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CodecCapLevels {
+class CodecCapLevels implements AgoraSerializable {
   /// @nodoc
   const CodecCapLevels({this.hwDecodingLevel, this.swDecodingLevel});
 
@@ -1828,12 +1837,13 @@ class CodecCapLevels {
       _$CodecCapLevelsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CodecCapLevelsToJson(this);
 }
 
 /// The codec capability of the SDK.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CodecCapInfo {
+class CodecCapInfo implements AgoraSerializable {
   /// @nodoc
   const CodecCapInfo({this.codecType, this.codecCapMask, this.codecLevels});
 
@@ -1854,6 +1864,7 @@ class CodecCapInfo {
       _$CodecCapInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CodecCapInfoToJson(this);
 }
 
@@ -1861,7 +1872,7 @@ class CodecCapInfo {
 ///
 /// This enumeration class applies to Android and iOS only.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FocalLengthInfo {
+class FocalLengthInfo implements AgoraSerializable {
   /// @nodoc
   const FocalLengthInfo({this.cameraDirection, this.focalLengthType});
 
@@ -1878,12 +1889,13 @@ class FocalLengthInfo {
       _$FocalLengthInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$FocalLengthInfoToJson(this);
 }
 
 /// Video encoder configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoEncoderConfiguration {
+class VideoEncoderConfiguration implements AgoraSerializable {
   /// @nodoc
   const VideoEncoderConfiguration(
       {this.codecType,
@@ -1937,6 +1949,7 @@ class VideoEncoderConfiguration {
       _$VideoEncoderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoEncoderConfigurationToJson(this);
 }
 
@@ -1944,7 +1957,7 @@ class VideoEncoderConfiguration {
 ///
 /// The following table shows the SDK behaviors under different parameter settings:
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DataStreamConfig {
+class DataStreamConfig implements AgoraSerializable {
   /// @nodoc
   const DataStreamConfig({this.syncWithAudio, this.ordered});
 
@@ -1961,6 +1974,7 @@ class DataStreamConfig {
       _$DataStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DataStreamConfigToJson(this);
 }
 
@@ -1995,7 +2009,7 @@ extension SimulcastStreamModeExt on SimulcastStreamMode {
 
 /// The configuration of the low-quality video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SimulcastStreamConfig {
+class SimulcastStreamConfig implements AgoraSerializable {
   /// @nodoc
   const SimulcastStreamConfig({this.dimensions, this.kBitrate, this.framerate});
 
@@ -2016,12 +2030,13 @@ class SimulcastStreamConfig {
       _$SimulcastStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SimulcastStreamConfigToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SimulcastConfig {
+class SimulcastConfig implements AgoraSerializable {
   /// @nodoc
   const SimulcastConfig({this.configs});
 
@@ -2034,6 +2049,7 @@ class SimulcastConfig {
       _$SimulcastConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SimulcastConfigToJson(this);
 }
 
@@ -2088,7 +2104,7 @@ extension StreamLayerIndexExt on StreamLayerIndex {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class StreamLayerConfig {
+class StreamLayerConfig implements AgoraSerializable {
   /// @nodoc
   const StreamLayerConfig({this.dimensions, this.framerate, this.enable});
 
@@ -2109,12 +2125,13 @@ class StreamLayerConfig {
       _$StreamLayerConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$StreamLayerConfigToJson(this);
 }
 
 /// The location of the target area relative to the screen or window. If you do not set this parameter, the SDK selects the whole screen or window.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Rectangle {
+class Rectangle implements AgoraSerializable {
   /// @nodoc
   const Rectangle({this.x, this.y, this.width, this.height});
 
@@ -2139,6 +2156,7 @@ class Rectangle {
       _$RectangleFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RectangleToJson(this);
 }
 
@@ -2148,7 +2166,7 @@ class Rectangle {
 ///  (xRatio, yRatio) refers to the coordinates of the upper left corner of the watermark, which determines the distance from the upper left corner of the watermark to the upper left corner of the screen.
 ///  The widthRatio determines the width of the watermark.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WatermarkRatio {
+class WatermarkRatio implements AgoraSerializable {
   /// @nodoc
   const WatermarkRatio({this.xRatio, this.yRatio, this.widthRatio});
 
@@ -2169,12 +2187,13 @@ class WatermarkRatio {
       _$WatermarkRatioFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WatermarkRatioToJson(this);
 }
 
 /// Configurations of the watermark image.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WatermarkOptions {
+class WatermarkOptions implements AgoraSerializable {
   /// @nodoc
   const WatermarkOptions(
       {this.visibleInPreview,
@@ -2208,12 +2227,13 @@ class WatermarkOptions {
       _$WatermarkOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WatermarkOptionsToJson(this);
 }
 
 /// Statistics of a call session.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcStats {
+class RtcStats implements AgoraSerializable {
   /// @nodoc
   const RtcStats(
       {this.duration,
@@ -2390,6 +2410,7 @@ class RtcStats {
       _$RtcStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcStatsToJson(this);
 }
 
@@ -2474,7 +2495,7 @@ extension AudienceLatencyLevelTypeExt on AudienceLatencyLevelType {
 
 /// Setting of user role properties.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ClientRoleOptions {
+class ClientRoleOptions implements AgoraSerializable {
   /// @nodoc
   const ClientRoleOptions({this.audienceLatencyLevel});
 
@@ -2487,6 +2508,7 @@ class ClientRoleOptions {
       _$ClientRoleOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ClientRoleOptionsToJson(this);
 }
 
@@ -2676,7 +2698,7 @@ extension AudioScenarioTypeExt on AudioScenarioType {
 
 /// The format of the video frame.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFormat {
+class VideoFormat implements AgoraSerializable {
   /// @nodoc
   const VideoFormat({this.width, this.height, this.fps});
 
@@ -2697,6 +2719,7 @@ class VideoFormat {
       _$VideoFormatFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFormatToJson(this);
 }
 
@@ -3405,7 +3428,7 @@ extension RemoteUserStateExt on RemoteUserState {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoTrackInfo {
+class VideoTrackInfo implements AgoraSerializable {
   /// @nodoc
   const VideoTrackInfo(
       {this.isLocal,
@@ -3454,6 +3477,7 @@ class VideoTrackInfo {
       _$VideoTrackInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoTrackInfoToJson(this);
 }
 
@@ -3496,7 +3520,7 @@ extension RemoteVideoDownscaleLevelExt on RemoteVideoDownscaleLevel {
 
 /// The volume information of users.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioVolumeInfo {
+class AudioVolumeInfo implements AgoraSerializable {
   /// @nodoc
   const AudioVolumeInfo({this.uid, this.volume, this.vad, this.voicePitch});
 
@@ -3527,6 +3551,7 @@ class AudioVolumeInfo {
       _$AudioVolumeInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioVolumeInfoToJson(this);
 }
 
@@ -3534,7 +3559,7 @@ class AudioVolumeInfo {
 ///
 /// This class is for Android only.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DeviceInfo {
+class DeviceInfo implements AgoraSerializable {
   /// @nodoc
   const DeviceInfo({this.isLowLatencyAudioSupported});
 
@@ -3547,12 +3572,13 @@ class DeviceInfo {
       _$DeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DeviceInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Packet {
+class Packet implements AgoraSerializable {
   /// @nodoc
   const Packet({this.buffer, this.size});
 
@@ -3568,6 +3594,7 @@ class Packet {
   factory Packet.fromJson(Map<String, dynamic> json) => _$PacketFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PacketToJson(this);
 }
 
@@ -3685,7 +3712,7 @@ extension AudioCodecProfileTypeExt on AudioCodecProfileType {
 
 /// Local audio statistics.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalAudioStats {
+class LocalAudioStats implements AgoraSerializable {
   /// @nodoc
   const LocalAudioStats(
       {this.numChannels,
@@ -3739,6 +3766,7 @@ class LocalAudioStats {
       _$LocalAudioStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalAudioStatsToJson(this);
 }
 
@@ -3907,7 +3935,7 @@ extension RtmpStreamingEventExt on RtmpStreamingEvent {
 ///
 /// This class sets the properties of the watermark and background images in the live video.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcImage {
+class RtcImage implements AgoraSerializable {
   /// @nodoc
   const RtcImage(
       {this.url,
@@ -3953,6 +3981,7 @@ class RtcImage {
       _$RtcImageFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcImageToJson(this);
 }
 
@@ -3960,7 +3989,7 @@ class RtcImage {
 ///
 /// If you want to enable the advanced features of streaming with transcoding, contact.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LiveStreamAdvancedFeature {
+class LiveStreamAdvancedFeature implements AgoraSerializable {
   /// @nodoc
   const LiveStreamAdvancedFeature({this.featureName, this.opened});
 
@@ -3977,6 +4006,7 @@ class LiveStreamAdvancedFeature {
       _$LiveStreamAdvancedFeatureFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LiveStreamAdvancedFeatureToJson(this);
 }
 
@@ -4027,7 +4057,7 @@ extension ConnectionStateTypeExt on ConnectionStateType {
 
 /// Transcoding configurations of each host.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class TranscodingUser {
+class TranscodingUser implements AgoraSerializable {
   /// @nodoc
   const TranscodingUser(
       {this.uid,
@@ -4082,12 +4112,13 @@ class TranscodingUser {
       _$TranscodingUserFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$TranscodingUserToJson(this);
 }
 
 /// Transcoding configurations for Media Push.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LiveTranscoding {
+class LiveTranscoding implements AgoraSerializable {
   /// @nodoc
   const LiveTranscoding(
       {this.width,
@@ -4220,12 +4251,13 @@ class LiveTranscoding {
       _$LiveTranscodingFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LiveTranscodingToJson(this);
 }
 
 /// The video streams for local video mixing.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class TranscodingVideoStream {
+class TranscodingVideoStream implements AgoraSerializable {
   /// @nodoc
   const TranscodingVideoStream(
       {this.sourceType,
@@ -4291,12 +4323,13 @@ class TranscodingVideoStream {
       _$TranscodingVideoStreamFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$TranscodingVideoStreamToJson(this);
 }
 
 /// The configuration of the video mixing on the local client.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalTranscoderConfiguration {
+class LocalTranscoderConfiguration implements AgoraSerializable {
   /// @nodoc
   const LocalTranscoderConfiguration(
       {this.streamCount,
@@ -4325,6 +4358,7 @@ class LocalTranscoderConfiguration {
       _$LocalTranscoderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalTranscoderConfigurationToJson(this);
 }
 
@@ -4371,7 +4405,7 @@ extension VideoTranscoderErrorExt on VideoTranscoderError {
 
 /// Configurations of the last-mile network test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeConfig {
+class LastmileProbeConfig implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeConfig(
       {this.probeUplink,
@@ -4400,6 +4434,7 @@ class LastmileProbeConfig {
       _$LastmileProbeConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeConfigToJson(this);
 }
 
@@ -4434,7 +4469,7 @@ extension LastmileProbeResultStateExt on LastmileProbeResultState {
 
 /// Results of the uplink or downlink last-mile network test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeOneWayResult {
+class LastmileProbeOneWayResult implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeOneWayResult(
       {this.packetLossRate, this.jitter, this.availableBandwidth});
@@ -4456,12 +4491,13 @@ class LastmileProbeOneWayResult {
       _$LastmileProbeOneWayResultFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeOneWayResultToJson(this);
 }
 
 /// Results of the uplink and downlink last-mile network tests.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LastmileProbeResult {
+class LastmileProbeResult implements AgoraSerializable {
   /// @nodoc
   const LastmileProbeResult(
       {this.state, this.uplinkReport, this.downlinkReport, this.rtt});
@@ -4487,6 +4523,7 @@ class LastmileProbeResult {
       _$LastmileProbeResultFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LastmileProbeResultToJson(this);
 }
 
@@ -4712,7 +4749,7 @@ extension WlaccSuggestActionExt on WlaccSuggestAction {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class WlAccStats {
+class WlAccStats implements AgoraSerializable {
   /// @nodoc
   const WlAccStats(
       {this.e2eDelayPercent, this.frozenRatioPercent, this.lossRatePercent});
@@ -4734,6 +4771,7 @@ class WlAccStats {
       _$WlAccStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$WlAccStatsToJson(this);
 }
 
@@ -4817,7 +4855,7 @@ extension VideoViewSetupModeExt on VideoViewSetupMode {
 
 /// Attributes of the video canvas object.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoCanvas {
+class VideoCanvas implements AgoraSerializable {
   /// @nodoc
   const VideoCanvas(
       {this.uid,
@@ -4890,6 +4928,7 @@ class VideoCanvas {
       _$VideoCanvasFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoCanvasToJson(this);
 }
 
@@ -4924,7 +4963,7 @@ extension PipStateExt on PipState {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PipOptions {
+class PipOptions implements AgoraSerializable {
   /// @nodoc
   const PipOptions(
       {this.contentSource,
@@ -4958,12 +4997,13 @@ class PipOptions {
       _$PipOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PipOptionsToJson(this);
 }
 
 /// Image enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class BeautyOptions {
+class BeautyOptions implements AgoraSerializable {
   /// @nodoc
   const BeautyOptions(
       {this.lighteningContrastLevel,
@@ -4997,6 +5037,7 @@ class BeautyOptions {
       _$BeautyOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$BeautyOptionsToJson(this);
 }
 
@@ -5031,7 +5072,7 @@ extension LighteningContrastLevelExt on LighteningContrastLevel {
 
 /// The low-light enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LowlightEnhanceOptions {
+class LowlightEnhanceOptions implements AgoraSerializable {
   /// @nodoc
   const LowlightEnhanceOptions({this.mode, this.level});
 
@@ -5048,6 +5089,7 @@ class LowlightEnhanceOptions {
       _$LowlightEnhanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LowlightEnhanceOptionsToJson(this);
 }
 
@@ -5103,7 +5145,7 @@ extension LowLightEnhanceLevelExt on LowLightEnhanceLevel {
 
 /// Video noise reduction options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDenoiserOptions {
+class VideoDenoiserOptions implements AgoraSerializable {
   /// @nodoc
   const VideoDenoiserOptions({this.mode, this.level});
 
@@ -5120,6 +5162,7 @@ class VideoDenoiserOptions {
       _$VideoDenoiserOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDenoiserOptionsToJson(this);
 }
 
@@ -5179,7 +5222,7 @@ extension VideoDenoiserLevelExt on VideoDenoiserLevel {
 
 /// The color enhancement options.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ColorEnhanceOptions {
+class ColorEnhanceOptions implements AgoraSerializable {
   /// @nodoc
   const ColorEnhanceOptions({this.strengthLevel, this.skinProtectLevel});
 
@@ -5198,12 +5241,13 @@ class ColorEnhanceOptions {
       _$ColorEnhanceOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ColorEnhanceOptionsToJson(this);
 }
 
 /// The custom background.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VirtualBackgroundSource {
+class VirtualBackgroundSource implements AgoraSerializable {
   /// @nodoc
   const VirtualBackgroundSource(
       {this.backgroundSourceType, this.color, this.source, this.blurDegree});
@@ -5229,6 +5273,7 @@ class VirtualBackgroundSource {
       _$VirtualBackgroundSourceFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VirtualBackgroundSourceToJson(this);
 }
 
@@ -5300,7 +5345,7 @@ extension BackgroundBlurDegreeExt on BackgroundBlurDegree {
 
 /// Processing properties for background images.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SegmentationProperty {
+class SegmentationProperty implements AgoraSerializable {
   /// @nodoc
   const SegmentationProperty({this.modelType, this.greenCapacity});
 
@@ -5317,6 +5362,7 @@ class SegmentationProperty {
       _$SegmentationPropertyFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SegmentationPropertyToJson(this);
 }
 
@@ -5380,7 +5426,7 @@ extension AudioTrackTypeExt on AudioTrackType {
 
 /// The configuration of custom audio tracks.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioTrackConfig {
+class AudioTrackConfig implements AgoraSerializable {
   /// @nodoc
   const AudioTrackConfig(
       {this.enableLocalPlayback,
@@ -5404,6 +5450,7 @@ class AudioTrackConfig {
       _$AudioTrackConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioTrackConfigToJson(this);
 }
 
@@ -5699,7 +5746,7 @@ extension HeadphoneEqualizerPresetExt on HeadphoneEqualizerPreset {
 
 /// Screen sharing configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureParameters {
+class ScreenCaptureParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureParameters(
       {this.dimensions,
@@ -5766,6 +5813,7 @@ class ScreenCaptureParameters {
       _$ScreenCaptureParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureParametersToJson(this);
 }
 
@@ -5862,7 +5910,7 @@ extension AudioEncodedFrameObserverPositionExt
 
 /// Recording configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioRecordingConfiguration {
+class AudioRecordingConfiguration implements AgoraSerializable {
   /// @nodoc
   const AudioRecordingConfiguration(
       {this.filePath,
@@ -5909,12 +5957,13 @@ class AudioRecordingConfiguration {
       _$AudioRecordingConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioRecordingConfigurationToJson(this);
 }
 
 /// Observer settings for the encoded audio.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverConfig {
+class AudioEncodedFrameObserverConfig implements AgoraSerializable {
   /// @nodoc
   const AudioEncodedFrameObserverConfig({this.postionType, this.encodingType});
 
@@ -5931,6 +5980,7 @@ class AudioEncodedFrameObserverConfig {
       _$AudioEncodedFrameObserverConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverConfigToJson(this);
 }
@@ -6182,7 +6232,7 @@ extension ChannelMediaRelayStateExt on ChannelMediaRelayState {
 
 /// Channel media information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaInfo {
+class ChannelMediaInfo implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaInfo({this.uid, this.channelName, this.token});
 
@@ -6203,12 +6253,13 @@ class ChannelMediaInfo {
       _$ChannelMediaInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaInfoToJson(this);
 }
 
 /// Configuration of cross channel media relay.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaRelayConfiguration {
+class ChannelMediaRelayConfiguration implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaRelayConfiguration(
       {this.srcInfo, this.destInfos, this.destCount});
@@ -6234,12 +6285,13 @@ class ChannelMediaRelayConfiguration {
       _$ChannelMediaRelayConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaRelayConfigurationToJson(this);
 }
 
 /// The uplink network information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UplinkNetworkInfo {
+class UplinkNetworkInfo implements AgoraSerializable {
   /// @nodoc
   const UplinkNetworkInfo({this.videoEncoderTargetBitrateBps});
 
@@ -6252,12 +6304,13 @@ class UplinkNetworkInfo {
       _$UplinkNetworkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UplinkNetworkInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DownlinkNetworkInfo {
+class DownlinkNetworkInfo implements AgoraSerializable {
   /// @nodoc
   const DownlinkNetworkInfo(
       {this.lastmileBufferDelayTimeMs,
@@ -6291,12 +6344,13 @@ class DownlinkNetworkInfo {
       _$DownlinkNetworkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DownlinkNetworkInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PeerDownlinkInfo {
+class PeerDownlinkInfo implements AgoraSerializable {
   /// @nodoc
   const PeerDownlinkInfo(
       {this.userId,
@@ -6325,6 +6379,7 @@ class PeerDownlinkInfo {
       _$PeerDownlinkInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PeerDownlinkInfoToJson(this);
 }
 
@@ -6385,7 +6440,7 @@ extension EncryptionModeExt on EncryptionMode {
 
 /// Built-in encryption configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EncryptionConfig {
+class EncryptionConfig implements AgoraSerializable {
   /// @nodoc
   const EncryptionConfig(
       {this.encryptionMode,
@@ -6414,6 +6469,7 @@ class EncryptionConfig {
       _$EncryptionConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EncryptionConfigToJson(this);
 }
 
@@ -6592,7 +6648,7 @@ extension StreamPublishStateExt on StreamPublishState {
 
 /// The configuration of the audio and video call loop test.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class EchoTestConfiguration {
+class EchoTestConfiguration implements AgoraSerializable {
   /// @nodoc
   const EchoTestConfiguration(
       {this.view,
@@ -6633,12 +6689,13 @@ class EchoTestConfiguration {
       _$EchoTestConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$EchoTestConfigurationToJson(this);
 }
 
 /// The information of the user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UserInfo {
+class UserInfo implements AgoraSerializable {
   /// @nodoc
   const UserInfo({this.uid, this.userAccount});
 
@@ -6655,6 +6712,7 @@ class UserInfo {
       _$UserInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UserInfoToJson(this);
 }
 
@@ -6734,7 +6792,7 @@ extension ThreadPriorityTypeExt on ThreadPriorityType {
 
 /// The video configuration for the shared screen stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenVideoParameters {
+class ScreenVideoParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenVideoParameters(
       {this.dimensions, this.frameRate, this.bitrate, this.contentHint});
@@ -6760,6 +6818,7 @@ class ScreenVideoParameters {
       _$ScreenVideoParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenVideoParametersToJson(this);
 }
 
@@ -6767,7 +6826,7 @@ class ScreenVideoParameters {
 ///
 /// Only available where captureAudio is true.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenAudioParameters {
+class ScreenAudioParameters implements AgoraSerializable {
   /// @nodoc
   const ScreenAudioParameters(
       {this.sampleRate, this.channels, this.captureSignalVolume});
@@ -6789,12 +6848,13 @@ class ScreenAudioParameters {
       _$ScreenAudioParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenAudioParametersToJson(this);
 }
 
 /// Screen sharing configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureParameters2 {
+class ScreenCaptureParameters2 implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureParameters2(
       {this.captureAudio,
@@ -6825,6 +6885,7 @@ class ScreenCaptureParameters2 {
       _$ScreenCaptureParameters2FromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureParameters2ToJson(this);
 }
 
@@ -6855,7 +6916,7 @@ extension MediaTraceEventExt on MediaTraceEvent {
 
 /// Indicators during video frame rendering progress.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoRenderingTracingInfo {
+class VideoRenderingTracingInfo implements AgoraSerializable {
   /// @nodoc
   const VideoRenderingTracingInfo(
       {this.elapsedTime,
@@ -6911,6 +6972,7 @@ class VideoRenderingTracingInfo {
       _$VideoRenderingTracingInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoRenderingTracingInfoToJson(this);
 }
 
@@ -6966,7 +7028,7 @@ extension LocalProxyModeExt on LocalProxyMode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LogUploadServerInfo {
+class LogUploadServerInfo implements AgoraSerializable {
   /// @nodoc
   const LogUploadServerInfo(
       {this.serverDomain, this.serverPath, this.serverPort, this.serverHttps});
@@ -6992,12 +7054,13 @@ class LogUploadServerInfo {
       _$LogUploadServerInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LogUploadServerInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvancedConfigInfo {
+class AdvancedConfigInfo implements AgoraSerializable {
   /// @nodoc
   const AdvancedConfigInfo({this.logUploadServer});
 
@@ -7010,12 +7073,13 @@ class AdvancedConfigInfo {
       _$AdvancedConfigInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvancedConfigInfoToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalAccessPointConfiguration {
+class LocalAccessPointConfiguration implements AgoraSerializable {
   /// @nodoc
   const LocalAccessPointConfiguration(
       {this.ipList,
@@ -7064,12 +7128,13 @@ class LocalAccessPointConfiguration {
       _$LocalAccessPointConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalAccessPointConfigurationToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RecorderStreamInfo {
+class RecorderStreamInfo implements AgoraSerializable {
   /// @nodoc
   const RecorderStreamInfo({this.channelId, this.uid});
 
@@ -7086,12 +7151,13 @@ class RecorderStreamInfo {
       _$RecorderStreamInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RecorderStreamInfoToJson(this);
 }
 
 /// The spatial audio parameters.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SpatialAudioParams {
+class SpatialAudioParams implements AgoraSerializable {
   /// @nodoc
   const SpatialAudioParams(
       {this.speakerAzimuth,
@@ -7140,12 +7206,13 @@ class SpatialAudioParams {
       _$SpatialAudioParamsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SpatialAudioParamsToJson(this);
 }
 
 /// Layout information of a specific sub-video stream within the mixed stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoLayout {
+class VideoLayout implements AgoraSerializable {
   /// @nodoc
   const VideoLayout(
       {this.channelId,
@@ -7197,5 +7264,6 @@ class VideoLayout {
       _$VideoLayoutFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoLayoutToJson(this);
 }

--- a/lib/src/agora_h265_transcoder.dart
+++ b/lib/src/agora_h265_transcoder.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_h265_transcoder.g.dart';
 

--- a/lib/src/agora_log.dart
+++ b/lib/src/agora_log.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_log.g.dart';
 
@@ -102,7 +103,7 @@ const defaultLogSizeInKb = 2048;
 
 /// Configuration of Agora SDK log files.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LogConfig {
+class LogConfig implements AgoraSerializable {
   /// @nodoc
   const LogConfig({this.filePath, this.fileSizeInKB, this.level});
 
@@ -123,5 +124,6 @@ class LogConfig {
       _$LogConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LogConfigToJson(this);
 }

--- a/lib/src/agora_media_base.dart
+++ b/lib/src/agora_media_base.dart
@@ -1,4 +1,6 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
+
 part 'agora_media_base.g.dart';
 
 /// @nodoc
@@ -191,7 +193,7 @@ extension BytesPerSampleExt on BytesPerSample {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioParameters {
+class AudioParameters implements AgoraSerializable {
   /// @nodoc
   const AudioParameters({this.sampleRate, this.channels, this.framesPerBuffer});
 
@@ -212,6 +214,7 @@ class AudioParameters {
       _$AudioParametersFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioParametersToJson(this);
 }
 
@@ -322,7 +325,7 @@ const kMaxCodecNameLength = 50;
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PacketOptions {
+class PacketOptions implements AgoraSerializable {
   /// @nodoc
   const PacketOptions({this.timestamp, this.audioLevelIndication});
 
@@ -339,12 +342,13 @@ class PacketOptions {
       _$PacketOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PacketOptionsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameInfo {
+class AudioEncodedFrameInfo implements AgoraSerializable {
   /// @nodoc
   const AudioEncodedFrameInfo({this.sendTs, this.codec});
 
@@ -361,12 +365,13 @@ class AudioEncodedFrameInfo {
       _$AudioEncodedFrameInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioEncodedFrameInfoToJson(this);
 }
 
 /// The parameters of the audio frame in PCM format.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmFrame {
+class AudioPcmFrame implements AgoraSerializable {
   /// @nodoc
   const AudioPcmFrame(
       {this.captureTimestamp,
@@ -410,6 +415,7 @@ class AudioPcmFrame {
       _$AudioPcmFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmFrameToJson(this);
 }
 
@@ -606,7 +612,7 @@ extension MetaInfoKeyExt on MetaInfoKey {
 
 /// The external video frame.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ExternalVideoFrame {
+class ExternalVideoFrame implements AgoraSerializable {
   /// @nodoc
   const ExternalVideoFrame(
       {this.type,
@@ -712,6 +718,7 @@ class ExternalVideoFrame {
       _$ExternalVideoFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ExternalVideoFrameToJson(this);
 }
 
@@ -773,7 +780,7 @@ extension VideoBufferTypeExt on VideoBufferType {
 ///
 /// Note that the buffer provides a pointer to a pointer. This interface cannot modify the pointer of the buffer, but it can modify the content of the buffer.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrame {
+class VideoFrame implements AgoraSerializable {
   /// @nodoc
   const VideoFrame(
       {this.type,
@@ -880,6 +887,7 @@ class VideoFrame {
       _$VideoFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFrameToJson(this);
 }
 
@@ -1011,7 +1019,7 @@ extension ContentInspectTypeExt on ContentInspectType {
 
 /// ContentInspectModule A structure used to configure the frequency of video screenshot and upload.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ContentInspectModule {
+class ContentInspectModule implements AgoraSerializable {
   /// @nodoc
   const ContentInspectModule({this.type, this.interval, this.position});
 
@@ -1032,12 +1040,13 @@ class ContentInspectModule {
       _$ContentInspectModuleFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ContentInspectModuleToJson(this);
 }
 
 /// Screenshot and upload configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ContentInspectConfig {
+class ContentInspectConfig implements AgoraSerializable {
   /// @nodoc
   const ContentInspectConfig(
       {this.extraInfo, this.serverConfig, this.modules, this.moduleCount});
@@ -1063,12 +1072,13 @@ class ContentInspectConfig {
       _$ContentInspectConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ContentInspectConfigToJson(this);
 }
 
 /// The snapshot configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SnapshotConfig {
+class SnapshotConfig implements AgoraSerializable {
   /// @nodoc
   const SnapshotConfig({this.filePath, this.position});
 
@@ -1089,6 +1099,7 @@ class SnapshotConfig {
       _$SnapshotConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SnapshotConfigToJson(this);
 }
 
@@ -1181,7 +1192,7 @@ extension AudioFrameTypeExt on AudioFrameType {
 
 /// Raw audio data.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrame {
+class AudioFrame implements AgoraSerializable {
   /// @nodoc
   const AudioFrame(
       {this.type,
@@ -1247,6 +1258,7 @@ class AudioFrame {
       _$AudioFrameFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioFrameToJson(this);
 }
 
@@ -1296,7 +1308,7 @@ extension AudioFramePositionExt on AudioFramePosition {
 /// The SDK calculates the sampling interval through the samplesPerCall, sampleRate, and channel parameters in AudioParams, and triggers the onRecordAudioFrame, onPlaybackAudioFrame, onMixedAudioFrame, and onEarMonitoringAudioFrame callbacks according to the sampling interval. Sample interval (sec) = samplePerCall /(sampleRate × channel).
 ///  Ensure that the sample interval ≥ 0.01 (s).
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioParams {
+class AudioParams implements AgoraSerializable {
   /// @nodoc
   const AudioParams(
       {this.sampleRate, this.channels, this.mode, this.samplesPerCall});
@@ -1329,6 +1341,7 @@ class AudioParams {
       _$AudioParamsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioParamsToJson(this);
 }
 
@@ -1369,7 +1382,7 @@ class AudioFrameObserver extends AudioFrameObserverBase {
 
 /// The audio spectrum data.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumData {
+class AudioSpectrumData implements AgoraSerializable {
   /// @nodoc
   const AudioSpectrumData({this.audioSpectrumData, this.dataLength});
 
@@ -1386,12 +1399,13 @@ class AudioSpectrumData {
       _$AudioSpectrumDataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioSpectrumDataToJson(this);
 }
 
 /// Audio spectrum information of the remote user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class UserAudioSpectrumInfo {
+class UserAudioSpectrumInfo implements AgoraSerializable {
   /// @nodoc
   const UserAudioSpectrumInfo({this.uid, this.spectrumData});
 
@@ -1408,6 +1422,7 @@ class UserAudioSpectrumInfo {
       _$UserAudioSpectrumInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$UserAudioSpectrumInfoToJson(this);
 }
 
@@ -1689,7 +1704,7 @@ extension RecorderReasonCodeExt on RecorderReasonCode {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderConfiguration {
+class MediaRecorderConfiguration implements AgoraSerializable {
   /// @nodoc
   const MediaRecorderConfiguration(
       {this.storagePath,
@@ -1723,6 +1738,7 @@ class MediaRecorderConfiguration {
       _$MediaRecorderConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MediaRecorderConfigurationToJson(this);
 }
 
@@ -1755,7 +1771,7 @@ class FaceInfoObserver {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RecorderInfo {
+class RecorderInfo implements AgoraSerializable {
   /// @nodoc
   const RecorderInfo({this.fileName, this.durationMs, this.fileSize});
 
@@ -1776,6 +1792,7 @@ class RecorderInfo {
       _$RecorderInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RecorderInfoToJson(this);
 }
 

--- a/lib/src/agora_media_engine.dart
+++ b/lib/src/agora_media_engine.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_media_engine.g.dart';
 

--- a/lib/src/agora_media_player.dart
+++ b/lib/src/agora_media_player.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 
 /// This class provides media player functions and supports multiple instances.

--- a/lib/src/agora_media_player_source.dart
+++ b/lib/src/agora_media_player_source.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 
 /// Provides callbacks for media players.

--- a/lib/src/agora_media_player_types.dart
+++ b/lib/src/agora_media_player_types.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_media_player_types.g.dart';
 
@@ -323,7 +324,7 @@ extension PlayerPreloadEventExt on PlayerPreloadEvent {
 
 /// The detailed information of the media stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerStreamInfo {
+class PlayerStreamInfo implements AgoraSerializable {
   /// @nodoc
   const PlayerStreamInfo(
       {this.streamIndex,
@@ -397,12 +398,13 @@ class PlayerStreamInfo {
       _$PlayerStreamInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerStreamInfoToJson(this);
 }
 
 /// Information about the video bitrate of the media resource being played.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SrcInfo {
+class SrcInfo implements AgoraSerializable {
   /// @nodoc
   const SrcInfo({this.bitrateInKbps, this.name});
 
@@ -419,6 +421,7 @@ class SrcInfo {
       _$SrcInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SrcInfoToJson(this);
 }
 
@@ -449,7 +452,7 @@ extension MediaPlayerMetadataTypeExt on MediaPlayerMetadataType {
 
 /// Statistics about the media files being cached.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CacheStatistics {
+class CacheStatistics implements AgoraSerializable {
   /// @nodoc
   const CacheStatistics({this.fileSize, this.cacheSize, this.downloadSize});
 
@@ -470,12 +473,13 @@ class CacheStatistics {
       _$CacheStatisticsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CacheStatisticsToJson(this);
 }
 
 /// The information of the media file being played.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerPlaybackStats {
+class PlayerPlaybackStats implements AgoraSerializable {
   /// @nodoc
   const PlayerPlaybackStats(
       {this.videoFps,
@@ -504,12 +508,13 @@ class PlayerPlaybackStats {
       _$PlayerPlaybackStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerPlaybackStatsToJson(this);
 }
 
 /// Information related to the media player.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PlayerUpdatedInfo {
+class PlayerUpdatedInfo implements AgoraSerializable {
   /// @nodoc
   const PlayerUpdatedInfo(
       {this.internalPlayerUuid,
@@ -553,12 +558,13 @@ class PlayerUpdatedInfo {
       _$PlayerUpdatedInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PlayerUpdatedInfoToJson(this);
 }
 
 /// Information related to the media file to be played and the playback scenario configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaSource {
+class MediaSource implements AgoraSerializable {
   /// @nodoc
   const MediaSource(
       {this.url,
@@ -610,5 +616,6 @@ class MediaSource {
       _$MediaSourceFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MediaSourceToJson(this);
 }

--- a/lib/src/agora_media_recorder.dart
+++ b/lib/src/agora_media_recorder.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 
 /// @nodoc

--- a/lib/src/agora_media_streaming_source.dart
+++ b/lib/src/agora_media_streaming_source.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_media_streaming_source.g.dart';
 
@@ -153,7 +154,7 @@ extension StreamingSrcStateExt on StreamingSrcState {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class InputSeiData {
+class InputSeiData implements AgoraSerializable {
   /// @nodoc
   const InputSeiData(
       {this.type,
@@ -187,5 +188,6 @@ class InputSeiData {
       _$InputSeiDataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$InputSeiDataToJson(this);
 }

--- a/lib/src/agora_music_content_center.dart
+++ b/lib/src/agora_music_content_center.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_music_content_center.g.dart';
 
@@ -114,7 +115,7 @@ extension MusicContentCenterStateReasonExt on MusicContentCenterStateReason {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicChartInfo {
+class MusicChartInfo implements AgoraSerializable {
   /// @nodoc
   const MusicChartInfo({this.chartName, this.id});
 
@@ -131,6 +132,7 @@ class MusicChartInfo {
       _$MusicChartInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicChartInfoToJson(this);
 }
 
@@ -161,7 +163,7 @@ extension MusicCacheStatusTypeExt on MusicCacheStatusType {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicCacheInfo {
+class MusicCacheInfo implements AgoraSerializable {
   /// @nodoc
   const MusicCacheInfo({this.songCode, this.status});
 
@@ -178,6 +180,7 @@ class MusicCacheInfo {
       _$MusicCacheInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicCacheInfoToJson(this);
 }
 
@@ -192,7 +195,7 @@ abstract class MusicChartCollection {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MvProperty {
+class MvProperty implements AgoraSerializable {
   /// @nodoc
   const MvProperty({this.resolution, this.bandwidth});
 
@@ -209,12 +212,13 @@ class MvProperty {
       _$MvPropertyFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MvPropertyToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ClimaxSegment {
+class ClimaxSegment implements AgoraSerializable {
   /// @nodoc
   const ClimaxSegment({this.startTimeMs, this.endTimeMs});
 
@@ -231,12 +235,13 @@ class ClimaxSegment {
       _$ClimaxSegmentFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ClimaxSegmentToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Music {
+class Music implements AgoraSerializable {
   /// @nodoc
   const Music(
       {this.songCode,
@@ -314,6 +319,7 @@ class Music {
   factory Music.fromJson(Map<String, dynamic> json) => _$MusicFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicToJson(this);
 }
 
@@ -386,7 +392,7 @@ class MusicContentCenterEventHandler {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterConfiguration {
+class MusicContentCenterConfiguration implements AgoraSerializable {
   /// @nodoc
   const MusicContentCenterConfiguration(
       {this.appId, this.token, this.mccUid, this.maxCacheSize, this.mccDomain});
@@ -416,6 +422,7 @@ class MusicContentCenterConfiguration {
       _$MusicContentCenterConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterConfigurationToJson(this);
 }

--- a/lib/src/agora_rhythm_player.dart
+++ b/lib/src/agora_rhythm_player.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rhythm_player.g.dart';
 
@@ -77,7 +78,7 @@ extension RhythmPlayerReasonExt on RhythmPlayerReason {
 
 /// The metronome configuration.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AgoraRhythmPlayerConfig {
+class AgoraRhythmPlayerConfig implements AgoraSerializable {
   /// @nodoc
   const AgoraRhythmPlayerConfig({this.beatsPerMeasure, this.beatsPerMinute});
 
@@ -94,5 +95,6 @@ class AgoraRhythmPlayerConfig {
       _$AgoraRhythmPlayerConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AgoraRhythmPlayerConfigToJson(this);
 }

--- a/lib/src/agora_rtc_engine.dart
+++ b/lib/src/agora_rtc_engine.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rtc_engine.g.dart';
 
@@ -367,7 +368,7 @@ extension PriorityTypeExt on PriorityType {
 
 /// The statistics of the local video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LocalVideoStats {
+class LocalVideoStats implements AgoraSerializable {
   /// @nodoc
   const LocalVideoStats(
       {this.uid,
@@ -498,12 +499,13 @@ class LocalVideoStats {
       _$LocalVideoStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LocalVideoStatsToJson(this);
 }
 
 /// Audio statistics of the remote user.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteAudioStats {
+class RemoteAudioStats implements AgoraSerializable {
   /// @nodoc
   const RemoteAudioStats(
       {this.uid,
@@ -617,12 +619,13 @@ class RemoteAudioStats {
       _$RemoteAudioStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteAudioStatsToJson(this);
 }
 
 /// Statistics of the remote video stream.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteVideoStats {
+class RemoteVideoStats implements AgoraSerializable {
   /// @nodoc
   const RemoteVideoStats(
       {this.uid,
@@ -726,12 +729,13 @@ class RemoteVideoStats {
       _$RemoteVideoStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteVideoStatsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoCompositingLayout {
+class VideoCompositingLayout implements AgoraSerializable {
   /// @nodoc
   const VideoCompositingLayout(
       {this.canvasWidth,
@@ -775,12 +779,13 @@ class VideoCompositingLayout {
       _$VideoCompositingLayoutFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoCompositingLayoutToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Region {
+class Region implements AgoraSerializable {
   /// @nodoc
   const Region(
       {this.uid,
@@ -828,12 +833,13 @@ class Region {
   factory Region.fromJson(Map<String, dynamic> json) => _$RegionFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RegionToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class InjectStreamConfig {
+class InjectStreamConfig implements AgoraSerializable {
   /// @nodoc
   const InjectStreamConfig(
       {this.width,
@@ -882,6 +888,7 @@ class InjectStreamConfig {
       _$InjectStreamConfigFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$InjectStreamConfigToJson(this);
 }
 
@@ -914,7 +921,7 @@ extension RtmpStreamLifeCycleTypeExt on RtmpStreamLifeCycleType {
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class PublisherConfiguration {
+class PublisherConfiguration implements AgoraSerializable {
   /// @nodoc
   const PublisherConfiguration(
       {this.width,
@@ -988,6 +995,7 @@ class PublisherConfiguration {
       _$PublisherConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$PublisherConfigurationToJson(this);
 }
 
@@ -1047,7 +1055,7 @@ extension CloudProxyTypeExt on CloudProxyType {
 
 /// The camera capturer preference.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class CameraCapturerConfiguration {
+class CameraCapturerConfiguration implements AgoraSerializable {
   /// @nodoc
   const CameraCapturerConfiguration(
       {this.cameraDirection,
@@ -1095,12 +1103,13 @@ class CameraCapturerConfiguration {
       _$CameraCapturerConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$CameraCapturerConfigurationToJson(this);
 }
 
 /// The configuration of the captured screen.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureConfiguration {
+class ScreenCaptureConfiguration implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureConfiguration(
       {this.isCaptureWindow,
@@ -1139,12 +1148,13 @@ class ScreenCaptureConfiguration {
       _$ScreenCaptureConfigurationFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureConfigurationToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SIZE {
+class SIZE implements AgoraSerializable {
   /// @nodoc
   const SIZE({this.width, this.height});
 
@@ -1160,6 +1170,7 @@ class SIZE {
   factory SIZE.fromJson(Map<String, dynamic> json) => _$SIZEFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SIZEToJson(this);
 }
 
@@ -1167,7 +1178,7 @@ class SIZE {
 ///
 /// The default image is in the ARGB format. If you need to use another format, you need to convert the image on your own.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ThumbImageBuffer {
+class ThumbImageBuffer implements AgoraSerializable {
   /// @nodoc
   const ThumbImageBuffer({this.buffer, this.length, this.width, this.height});
 
@@ -1192,6 +1203,7 @@ class ThumbImageBuffer {
       _$ThumbImageBufferFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ThumbImageBufferToJson(this);
 }
 
@@ -1230,7 +1242,7 @@ extension ScreenCaptureSourceTypeExt on ScreenCaptureSourceType {
 
 /// The information about the specified shareable window or screen.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ScreenCaptureSourceInfo {
+class ScreenCaptureSourceInfo implements AgoraSerializable {
   /// @nodoc
   const ScreenCaptureSourceInfo(
       {this.type,
@@ -1299,12 +1311,13 @@ class ScreenCaptureSourceInfo {
       _$ScreenCaptureSourceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ScreenCaptureSourceInfoToJson(this);
 }
 
 /// The advanced options for audio.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AdvancedAudioOptions {
+class AdvancedAudioOptions implements AgoraSerializable {
   /// @nodoc
   const AdvancedAudioOptions({this.audioProcessingChannels});
 
@@ -1317,12 +1330,13 @@ class AdvancedAudioOptions {
       _$AdvancedAudioOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AdvancedAudioOptionsToJson(this);
 }
 
 /// Image configurations.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ImageTrackOptions {
+class ImageTrackOptions implements AgoraSerializable {
   /// @nodoc
   const ImageTrackOptions({this.imageUrl, this.fps, this.mirrorMode});
 
@@ -1343,6 +1357,7 @@ class ImageTrackOptions {
       _$ImageTrackOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ImageTrackOptionsToJson(this);
 }
 
@@ -1350,7 +1365,7 @@ class ImageTrackOptions {
 ///
 /// Agora supports publishing multiple audio streams and one video stream at the same time and in the same RtcConnection. For example, publishMicrophoneTrack, publishCustomAudioTrack, and publishMediaPlayerAudioTrack can be set as true at the same time, but only one of publishCameraTrack, publishScreenCaptureVideo, publishScreenTrack, publishCustomVideoTrack, or publishEncodedVideoTrack can be set as true. Agora recommends that you set member parameter values yourself according to your business scenario, otherwise the SDK will automatically assign values to member parameters.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ChannelMediaOptions {
+class ChannelMediaOptions implements AgoraSerializable {
   /// @nodoc
   const ChannelMediaOptions(
       {this.publishCameraTrack,
@@ -1548,6 +1563,7 @@ class ChannelMediaOptions {
       _$ChannelMediaOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ChannelMediaOptionsToJson(this);
 }
 
@@ -1623,7 +1639,7 @@ extension FeatureTypeExt on FeatureType {
 
 /// The options for leaving a channel.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class LeaveChannelOptions {
+class LeaveChannelOptions implements AgoraSerializable {
   /// @nodoc
   const LeaveChannelOptions(
       {this.stopAudioMixing, this.stopAllEffect, this.stopMicrophoneRecording});
@@ -1645,6 +1661,7 @@ class LeaveChannelOptions {
       _$LeaveChannelOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$LeaveChannelOptionsToJson(this);
 }
 
@@ -2712,7 +2729,7 @@ abstract class VideoDeviceManager {
 
 /// Configurations for the RtcEngineContext instance.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineContext {
+class RtcEngineContext implements AgoraSerializable {
   /// @nodoc
   const RtcEngineContext(
       {this.appId,
@@ -2781,6 +2798,7 @@ class RtcEngineContext {
       _$RtcEngineContextFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineContextToJson(this);
 }
 
@@ -2853,7 +2871,7 @@ extension MaxMetadataSizeTypeExt on MaxMetadataSizeType {
 
 /// Media metadata.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class Metadata {
+class Metadata implements AgoraSerializable {
   /// @nodoc
   const Metadata({this.uid, this.size, this.buffer, this.timeStampMs});
 
@@ -2880,6 +2898,7 @@ class Metadata {
       _$MetadataFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MetadataToJson(this);
 }
 
@@ -2963,7 +2982,7 @@ extension DirectCdnStreamingStateExt on DirectCdnStreamingState {
 
 /// The statistics of the current CDN streaming.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingStats {
+class DirectCdnStreamingStats implements AgoraSerializable {
   /// @nodoc
   const DirectCdnStreamingStats(
       {this.videoWidth,
@@ -2997,6 +3016,7 @@ class DirectCdnStreamingStats {
       _$DirectCdnStreamingStatsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DirectCdnStreamingStatsToJson(this);
 }
 
@@ -3030,7 +3050,7 @@ class DirectCdnStreamingEventHandler {
 
 /// The media setting options for the host.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingMediaOptions {
+class DirectCdnStreamingMediaOptions implements AgoraSerializable {
   /// @nodoc
   const DirectCdnStreamingMediaOptions(
       {this.publishCameraTrack,
@@ -3074,12 +3094,13 @@ class DirectCdnStreamingMediaOptions {
       _$DirectCdnStreamingMediaOptionsFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$DirectCdnStreamingMediaOptionsToJson(this);
 }
 
 /// @nodoc
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class ExtensionInfo {
+class ExtensionInfo implements AgoraSerializable {
   /// @nodoc
   const ExtensionInfo(
       {this.mediaSourceType, this.remoteUid, this.channelId, this.localUid});
@@ -3105,6 +3126,7 @@ class ExtensionInfo {
       _$ExtensionInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$ExtensionInfoToJson(this);
 }
 
@@ -6707,7 +6729,7 @@ extension VideoProfileTypeExt on VideoProfileType {
 
 /// SDK version information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SDKBuildInfo {
+class SDKBuildInfo implements AgoraSerializable {
   /// @nodoc
   const SDKBuildInfo({this.build, this.version});
 
@@ -6724,12 +6746,13 @@ class SDKBuildInfo {
       _$SDKBuildInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SDKBuildInfoToJson(this);
 }
 
 /// The VideoDeviceInfo class that contains the ID and device name of the video devices.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceInfo {
+class VideoDeviceInfo implements AgoraSerializable {
   /// @nodoc
   const VideoDeviceInfo({this.deviceId, this.deviceName});
 
@@ -6746,12 +6769,13 @@ class VideoDeviceInfo {
       _$VideoDeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoDeviceInfoToJson(this);
 }
 
 /// The AudioDeviceInfo class that contains the ID, name and type of the audio devices.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceInfo {
+class AudioDeviceInfo implements AgoraSerializable {
   /// @nodoc
   const AudioDeviceInfo({this.deviceId, this.deviceTypeName, this.deviceName});
 
@@ -6772,5 +6796,6 @@ class AudioDeviceInfo {
       _$AudioDeviceInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$AudioDeviceInfoToJson(this);
 }

--- a/lib/src/agora_rtc_engine_ex.dart
+++ b/lib/src/agora_rtc_engine_ex.dart
@@ -1,9 +1,10 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_rtc_engine_ex.g.dart';
 
 /// Contains connection information.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcConnection {
+class RtcConnection implements AgoraSerializable {
   /// @nodoc
   const RtcConnection({this.channelId, this.localUid});
 
@@ -20,6 +21,7 @@ class RtcConnection {
       _$RtcConnectionFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RtcConnectionToJson(this);
 }
 

--- a/lib/src/agora_spatial_audio.dart
+++ b/lib/src/agora_spatial_audio.dart
@@ -1,9 +1,10 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'agora_spatial_audio.g.dart';
 
 /// The spatial position of the remote user or the media player.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RemoteVoicePositionInfo {
+class RemoteVoicePositionInfo implements AgoraSerializable {
   /// @nodoc
   const RemoteVoicePositionInfo({this.position, this.forward});
 
@@ -20,12 +21,13 @@ class RemoteVoicePositionInfo {
       _$RemoteVoicePositionInfoFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$RemoteVoicePositionInfoToJson(this);
 }
 
 /// Sound insulation area settings.
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class SpatialAudioZone {
+class SpatialAudioZone implements AgoraSerializable {
   /// @nodoc
   const SpatialAudioZone(
       {this.zoneSetId,
@@ -83,6 +85,7 @@ class SpatialAudioZone {
       _$SpatialAudioZoneFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$SpatialAudioZoneToJson(this);
 }
 

--- a/lib/src/audio_device_manager.dart
+++ b/lib/src/audio_device_manager.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'audio_device_manager.g.dart';
 

--- a/lib/src/binding/call_api_impl_params_json.dart
+++ b/lib/src/binding/call_api_impl_params_json.dart
@@ -2,11 +2,12 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, unused_import
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'call_api_impl_params_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetDurationJson {
+class MediaPlayerGetDurationJson implements AgoraSerializable {
   const MediaPlayerGetDurationJson(this.duration);
 
   @JsonKey(name: 'duration')
@@ -15,11 +16,12 @@ class MediaPlayerGetDurationJson {
   factory MediaPlayerGetDurationJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetDurationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetDurationJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPlayPositionJson {
+class MediaPlayerGetPlayPositionJson implements AgoraSerializable {
   const MediaPlayerGetPlayPositionJson(this.pos);
 
   @JsonKey(name: 'pos')
@@ -28,11 +30,12 @@ class MediaPlayerGetPlayPositionJson {
   factory MediaPlayerGetPlayPositionJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetPlayPositionJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetPlayPositionJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetStreamCountJson {
+class MediaPlayerGetStreamCountJson implements AgoraSerializable {
   const MediaPlayerGetStreamCountJson(this.count);
 
   @JsonKey(name: 'count')
@@ -41,11 +44,12 @@ class MediaPlayerGetStreamCountJson {
   factory MediaPlayerGetStreamCountJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetStreamCountJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetStreamCountJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetStreamInfoJson {
+class MediaPlayerGetStreamInfoJson implements AgoraSerializable {
   const MediaPlayerGetStreamInfoJson(this.info);
 
   @JsonKey(name: 'info')
@@ -54,11 +58,12 @@ class MediaPlayerGetStreamInfoJson {
   factory MediaPlayerGetStreamInfoJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetStreamInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetStreamInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetMuteJson {
+class MediaPlayerGetMuteJson implements AgoraSerializable {
   const MediaPlayerGetMuteJson(this.muted);
 
   @JsonKey(name: 'muted')
@@ -67,11 +72,12 @@ class MediaPlayerGetMuteJson {
   factory MediaPlayerGetMuteJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MediaPlayerGetMuteJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPlayoutVolumeJson {
+class MediaPlayerGetPlayoutVolumeJson implements AgoraSerializable {
   const MediaPlayerGetPlayoutVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -80,12 +86,13 @@ class MediaPlayerGetPlayoutVolumeJson {
   factory MediaPlayerGetPlayoutVolumeJson.fromJson(Map<String, dynamic> json) =>
       _$MediaPlayerGetPlayoutVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerGetPlayoutVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerGetPublishSignalVolumeJson {
+class MediaPlayerGetPublishSignalVolumeJson implements AgoraSerializable {
   const MediaPlayerGetPublishSignalVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -95,12 +102,13 @@ class MediaPlayerGetPublishSignalVolumeJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerGetPublishSignalVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerGetPublishSignalVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerCacheManagerGetCacheDirJson {
+class MediaPlayerCacheManagerGetCacheDirJson implements AgoraSerializable {
   const MediaPlayerCacheManagerGetCacheDirJson(this.path);
 
   @JsonKey(name: 'path')
@@ -110,12 +118,13 @@ class MediaPlayerCacheManagerGetCacheDirJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerCacheManagerGetCacheDirJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerCacheManagerGetCacheDirJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetMusicChartsJson {
+class MusicContentCenterGetMusicChartsJson implements AgoraSerializable {
   const MusicContentCenterGetMusicChartsJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -125,12 +134,14 @@ class MusicContentCenterGetMusicChartsJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetMusicChartsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetMusicChartsJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetMusicCollectionByMusicChartIdJson {
+class MusicContentCenterGetMusicCollectionByMusicChartIdJson
+    implements AgoraSerializable {
   const MusicContentCenterGetMusicCollectionByMusicChartIdJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -140,12 +151,13 @@ class MusicContentCenterGetMusicCollectionByMusicChartIdJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetMusicCollectionByMusicChartIdJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetMusicCollectionByMusicChartIdJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterSearchMusicJson {
+class MusicContentCenterSearchMusicJson implements AgoraSerializable {
   const MusicContentCenterSearchMusicJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -155,12 +167,13 @@ class MusicContentCenterSearchMusicJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterSearchMusicJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterSearchMusicJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterPreloadJson {
+class MusicContentCenterPreloadJson implements AgoraSerializable {
   const MusicContentCenterPreloadJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -169,11 +182,12 @@ class MusicContentCenterPreloadJson {
   factory MusicContentCenterPreloadJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterPreloadJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MusicContentCenterPreloadJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetCachesJson {
+class MusicContentCenterGetCachesJson implements AgoraSerializable {
   const MusicContentCenterGetCachesJson(this.cacheInfo);
 
   @JsonKey(name: 'cacheInfo')
@@ -182,12 +196,13 @@ class MusicContentCenterGetCachesJson {
   factory MusicContentCenterGetCachesJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterGetCachesJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetCachesJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetLyricJson {
+class MusicContentCenterGetLyricJson implements AgoraSerializable {
   const MusicContentCenterGetLyricJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -196,11 +211,12 @@ class MusicContentCenterGetLyricJson {
   factory MusicContentCenterGetLyricJson.fromJson(Map<String, dynamic> json) =>
       _$MusicContentCenterGetLyricJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$MusicContentCenterGetLyricJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetSongSimpleInfoJson {
+class MusicContentCenterGetSongSimpleInfoJson implements AgoraSerializable {
   const MusicContentCenterGetSongSimpleInfoJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -210,12 +226,13 @@ class MusicContentCenterGetSongSimpleInfoJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetSongSimpleInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetSongSimpleInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterGetInternalSongCodeJson {
+class MusicContentCenterGetInternalSongCodeJson implements AgoraSerializable {
   const MusicContentCenterGetInternalSongCodeJson(this.internalSongCode);
 
   @JsonKey(name: 'internalSongCode')
@@ -225,12 +242,13 @@ class MusicContentCenterGetInternalSongCodeJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterGetInternalSongCodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterGetInternalSongCodeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceManagerGetDeviceJson {
+class VideoDeviceManagerGetDeviceJson implements AgoraSerializable {
   const VideoDeviceManagerGetDeviceJson(this.deviceIdUTF8);
 
   @JsonKey(name: 'deviceIdUTF8')
@@ -239,12 +257,13 @@ class VideoDeviceManagerGetDeviceJson {
   factory VideoDeviceManagerGetDeviceJson.fromJson(Map<String, dynamic> json) =>
       _$VideoDeviceManagerGetDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoDeviceManagerGetDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoDeviceManagerGetCapabilityJson {
+class VideoDeviceManagerGetCapabilityJson implements AgoraSerializable {
   const VideoDeviceManagerGetCapabilityJson(this.capability);
 
   @JsonKey(name: 'capability')
@@ -254,12 +273,13 @@ class VideoDeviceManagerGetCapabilityJson {
           Map<String, dynamic> json) =>
       _$VideoDeviceManagerGetCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoDeviceManagerGetCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineQueryCodecCapabilityJson {
+class RtcEngineQueryCodecCapabilityJson implements AgoraSerializable {
   const RtcEngineQueryCodecCapabilityJson(this.codecInfo);
 
   @JsonKey(name: 'codecInfo')
@@ -269,12 +289,13 @@ class RtcEngineQueryCodecCapabilityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineQueryCodecCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineQueryCodecCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineUploadLogFileJson {
+class RtcEngineUploadLogFileJson implements AgoraSerializable {
   const RtcEngineUploadLogFileJson(this.requestId);
 
   @JsonKey(name: 'requestId')
@@ -283,11 +304,12 @@ class RtcEngineUploadLogFileJson {
   factory RtcEngineUploadLogFileJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineUploadLogFileJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineUploadLogFileJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetExtensionPropertyJson {
+class RtcEngineGetExtensionPropertyJson implements AgoraSerializable {
   const RtcEngineGetExtensionPropertyJson(this.value);
 
   @JsonKey(name: 'value')
@@ -297,12 +319,13 @@ class RtcEngineGetExtensionPropertyJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetExtensionPropertyJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetExtensionPropertyJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetAudioDeviceInfoJson {
+class RtcEngineGetAudioDeviceInfoJson implements AgoraSerializable {
   const RtcEngineGetAudioDeviceInfoJson(this.deviceInfo);
 
   @JsonKey(name: 'deviceInfo')
@@ -311,12 +334,14 @@ class RtcEngineGetAudioDeviceInfoJson {
   factory RtcEngineGetAudioDeviceInfoJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetAudioDeviceInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetAudioDeviceInfoJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineQueryCameraFocalLengthCapabilityJson {
+class RtcEngineQueryCameraFocalLengthCapabilityJson
+    implements AgoraSerializable {
   const RtcEngineQueryCameraFocalLengthCapabilityJson(this.focalLengthInfos);
 
   @JsonKey(name: 'focalLengthInfos')
@@ -326,12 +351,13 @@ class RtcEngineQueryCameraFocalLengthCapabilityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineQueryCameraFocalLengthCapabilityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineQueryCameraFocalLengthCapabilityJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetCallIdJson {
+class RtcEngineGetCallIdJson implements AgoraSerializable {
   const RtcEngineGetCallIdJson(this.callId);
 
   @JsonKey(name: 'callId')
@@ -340,11 +366,12 @@ class RtcEngineGetCallIdJson {
   factory RtcEngineGetCallIdJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetCallIdJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineGetCallIdJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineCreateDataStreamJson {
+class RtcEngineCreateDataStreamJson implements AgoraSerializable {
   const RtcEngineCreateDataStreamJson(this.streamId);
 
   @JsonKey(name: 'streamId')
@@ -353,11 +380,12 @@ class RtcEngineCreateDataStreamJson {
   factory RtcEngineCreateDataStreamJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineCreateDataStreamJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineCreateDataStreamJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetUserInfoByUserAccountJson {
+class RtcEngineGetUserInfoByUserAccountJson implements AgoraSerializable {
   const RtcEngineGetUserInfoByUserAccountJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -367,12 +395,13 @@ class RtcEngineGetUserInfoByUserAccountJson {
           Map<String, dynamic> json) =>
       _$RtcEngineGetUserInfoByUserAccountJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineGetUserInfoByUserAccountJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineGetUserInfoByUidJson {
+class RtcEngineGetUserInfoByUidJson implements AgoraSerializable {
   const RtcEngineGetUserInfoByUidJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -381,11 +410,12 @@ class RtcEngineGetUserInfoByUidJson {
   factory RtcEngineGetUserInfoByUidJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineGetUserInfoByUidJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineGetUserInfoByUidJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExCreateDataStreamExJson {
+class RtcEngineExCreateDataStreamExJson implements AgoraSerializable {
   const RtcEngineExCreateDataStreamExJson(this.streamId);
 
   @JsonKey(name: 'streamId')
@@ -395,12 +425,13 @@ class RtcEngineExCreateDataStreamExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExCreateDataStreamExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExCreateDataStreamExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetUserInfoByUserAccountExJson {
+class RtcEngineExGetUserInfoByUserAccountExJson implements AgoraSerializable {
   const RtcEngineExGetUserInfoByUserAccountExJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -410,12 +441,13 @@ class RtcEngineExGetUserInfoByUserAccountExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExGetUserInfoByUserAccountExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExGetUserInfoByUserAccountExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetUserInfoByUidExJson {
+class RtcEngineExGetUserInfoByUidExJson implements AgoraSerializable {
   const RtcEngineExGetUserInfoByUidExJson(this.userInfo);
 
   @JsonKey(name: 'userInfo')
@@ -425,12 +457,13 @@ class RtcEngineExGetUserInfoByUidExJson {
           Map<String, dynamic> json) =>
       _$RtcEngineExGetUserInfoByUidExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineExGetUserInfoByUidExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineExGetCallIdExJson {
+class RtcEngineExGetCallIdExJson implements AgoraSerializable {
   const RtcEngineExGetCallIdExJson(this.callId);
 
   @JsonKey(name: 'callId')
@@ -439,11 +472,12 @@ class RtcEngineExGetCallIdExJson {
   factory RtcEngineExGetCallIdExJson.fromJson(Map<String, dynamic> json) =>
       _$RtcEngineExGetCallIdExJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RtcEngineExGetCallIdExJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceJson {
+class AudioDeviceManagerGetPlaybackDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -453,12 +487,14 @@ class AudioDeviceManagerGetPlaybackDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceVolumeJson {
+class AudioDeviceManagerGetPlaybackDeviceVolumeJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -468,12 +504,13 @@ class AudioDeviceManagerGetPlaybackDeviceVolumeJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceJson {
+class AudioDeviceManagerGetRecordingDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -483,12 +520,14 @@ class AudioDeviceManagerGetRecordingDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceVolumeJson {
+class AudioDeviceManagerGetRecordingDeviceVolumeJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceVolumeJson(this.volume);
 
   @JsonKey(name: 'volume')
@@ -498,12 +537,13 @@ class AudioDeviceManagerGetRecordingDeviceVolumeJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceVolumeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceVolumeJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetLoopbackDeviceJson {
+class AudioDeviceManagerGetLoopbackDeviceJson implements AgoraSerializable {
   const AudioDeviceManagerGetLoopbackDeviceJson(this.deviceId);
 
   @JsonKey(name: 'deviceId')
@@ -513,12 +553,13 @@ class AudioDeviceManagerGetLoopbackDeviceJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetLoopbackDeviceJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetLoopbackDeviceJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetPlaybackDeviceMuteJson {
+class AudioDeviceManagerGetPlaybackDeviceMuteJson implements AgoraSerializable {
   const AudioDeviceManagerGetPlaybackDeviceMuteJson(this.mute);
 
   @JsonKey(name: 'mute')
@@ -528,12 +569,14 @@ class AudioDeviceManagerGetPlaybackDeviceMuteJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetPlaybackDeviceMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetPlaybackDeviceMuteJsonToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioDeviceManagerGetRecordingDeviceMuteJson {
+class AudioDeviceManagerGetRecordingDeviceMuteJson
+    implements AgoraSerializable {
   const AudioDeviceManagerGetRecordingDeviceMuteJson(this.mute);
 
   @JsonKey(name: 'mute')
@@ -543,6 +586,7 @@ class AudioDeviceManagerGetRecordingDeviceMuteJson {
           Map<String, dynamic> json) =>
       _$AudioDeviceManagerGetRecordingDeviceMuteJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioDeviceManagerGetRecordingDeviceMuteJsonToJson(this);
 }

--- a/lib/src/binding/event_handler_param_json.dart
+++ b/lib/src/binding/event_handler_param_json.dart
@@ -2,11 +2,13 @@
 
 // ignore_for_file: public_member_api_docs, unused_local_variable, unused_import, prefer_is_empty
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'event_handler_param_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -23,6 +25,7 @@ class AudioEncodedFrameObserverOnRecordAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonToJson(this);
 }
@@ -52,7 +55,8 @@ extension AudioEncodedFrameObserverOnRecordAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -69,6 +73,7 @@ class AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonToJson(this);
 }
@@ -98,7 +103,8 @@ extension AudioEncodedFrameObserverOnPlaybackAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson {
+class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson
+    implements AgoraSerializable {
   const AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson(
       {this.frameBuffer, this.length, this.audioEncodedFrameInfo});
 
@@ -115,6 +121,7 @@ class AudioEncodedFrameObserverOnMixedAudioEncodedFrameJson {
           Map<String, dynamic> json) =>
       _$AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonToJson(this);
 }
@@ -144,7 +151,7 @@ extension AudioEncodedFrameObserverOnMixedAudioEncodedFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioPcmFrameSinkOnFrameJson {
+class AudioPcmFrameSinkOnFrameJson implements AgoraSerializable {
   const AudioPcmFrameSinkOnFrameJson({this.frame});
 
   @JsonKey(name: 'frame')
@@ -153,6 +160,7 @@ class AudioPcmFrameSinkOnFrameJson {
   factory AudioPcmFrameSinkOnFrameJson.fromJson(Map<String, dynamic> json) =>
       _$AudioPcmFrameSinkOnFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$AudioPcmFrameSinkOnFrameJsonToJson(this);
 }
 
@@ -170,7 +178,8 @@ extension AudioPcmFrameSinkOnFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnRecordAudioFrameJson {
+class AudioFrameObserverBaseOnRecordAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnRecordAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -184,6 +193,7 @@ class AudioFrameObserverBaseOnRecordAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnRecordAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnRecordAudioFrameJsonToJson(this);
 }
@@ -203,7 +213,8 @@ extension AudioFrameObserverBaseOnRecordAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnPlaybackAudioFrameJson {
+class AudioFrameObserverBaseOnPlaybackAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnPlaybackAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -217,6 +228,7 @@ class AudioFrameObserverBaseOnPlaybackAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnPlaybackAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnPlaybackAudioFrameJsonToJson(this);
 }
@@ -236,7 +248,7 @@ extension AudioFrameObserverBaseOnPlaybackAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnMixedAudioFrameJson {
+class AudioFrameObserverBaseOnMixedAudioFrameJson implements AgoraSerializable {
   const AudioFrameObserverBaseOnMixedAudioFrameJson(
       {this.channelId, this.audioFrame});
 
@@ -250,6 +262,7 @@ class AudioFrameObserverBaseOnMixedAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnMixedAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnMixedAudioFrameJsonToJson(this);
 }
@@ -269,7 +282,8 @@ extension AudioFrameObserverBaseOnMixedAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson {
+class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson
+    implements AgoraSerializable {
   const AudioFrameObserverBaseOnEarMonitoringAudioFrameJson({this.audioFrame});
 
   @JsonKey(name: 'audioFrame')
@@ -279,6 +293,7 @@ class AudioFrameObserverBaseOnEarMonitoringAudioFrameJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonToJson(this);
 }
@@ -298,7 +313,8 @@ extension AudioFrameObserverBaseOnEarMonitoringAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson {
+class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson
+    implements AgoraSerializable {
   const AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson(
       {this.channelId, this.uid, this.audioFrame});
 
@@ -315,6 +331,7 @@ class AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJson {
           Map<String, dynamic> json) =>
       _$AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonToJson(this);
 }
@@ -334,7 +351,8 @@ extension AudioFrameObserverOnPlaybackAudioFrameBeforeMixingJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumObserverOnLocalAudioSpectrumJson {
+class AudioSpectrumObserverOnLocalAudioSpectrumJson
+    implements AgoraSerializable {
   const AudioSpectrumObserverOnLocalAudioSpectrumJson({this.data});
 
   @JsonKey(name: 'data')
@@ -344,6 +362,7 @@ class AudioSpectrumObserverOnLocalAudioSpectrumJson {
           Map<String, dynamic> json) =>
       _$AudioSpectrumObserverOnLocalAudioSpectrumJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioSpectrumObserverOnLocalAudioSpectrumJsonToJson(this);
 }
@@ -363,7 +382,8 @@ extension AudioSpectrumObserverOnLocalAudioSpectrumJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class AudioSpectrumObserverOnRemoteAudioSpectrumJson {
+class AudioSpectrumObserverOnRemoteAudioSpectrumJson
+    implements AgoraSerializable {
   const AudioSpectrumObserverOnRemoteAudioSpectrumJson(
       {this.spectrums, this.spectrumNumber});
 
@@ -377,6 +397,7 @@ class AudioSpectrumObserverOnRemoteAudioSpectrumJson {
           Map<String, dynamic> json) =>
       _$AudioSpectrumObserverOnRemoteAudioSpectrumJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$AudioSpectrumObserverOnRemoteAudioSpectrumJsonToJson(this);
 }
@@ -396,7 +417,8 @@ extension AudioSpectrumObserverOnRemoteAudioSpectrumJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson {
+class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson
+    implements AgoraSerializable {
   const VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson(
       {this.uid, this.imageBuffer, this.length, this.videoEncodedFrameInfo});
 
@@ -416,6 +438,7 @@ class VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJson {
           Map<String, dynamic> json) =>
       _$VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonToJson(this);
 }
@@ -446,7 +469,7 @@ extension VideoEncodedFrameObserverOnEncodedVideoFrameReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnCaptureVideoFrameJson {
+class VideoFrameObserverOnCaptureVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnCaptureVideoFrameJson(
       {this.sourceType, this.videoFrame});
 
@@ -460,6 +483,7 @@ class VideoFrameObserverOnCaptureVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnCaptureVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnCaptureVideoFrameJsonToJson(this);
 }
@@ -479,7 +503,7 @@ extension VideoFrameObserverOnCaptureVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnPreEncodeVideoFrameJson {
+class VideoFrameObserverOnPreEncodeVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnPreEncodeVideoFrameJson(
       {this.sourceType, this.videoFrame});
 
@@ -493,6 +517,7 @@ class VideoFrameObserverOnPreEncodeVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnPreEncodeVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnPreEncodeVideoFrameJsonToJson(this);
 }
@@ -512,7 +537,8 @@ extension VideoFrameObserverOnPreEncodeVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnMediaPlayerVideoFrameJson {
+class VideoFrameObserverOnMediaPlayerVideoFrameJson
+    implements AgoraSerializable {
   const VideoFrameObserverOnMediaPlayerVideoFrameJson(
       {this.videoFrame, this.mediaPlayerId});
 
@@ -526,6 +552,7 @@ class VideoFrameObserverOnMediaPlayerVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnMediaPlayerVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnMediaPlayerVideoFrameJsonToJson(this);
 }
@@ -545,7 +572,7 @@ extension VideoFrameObserverOnMediaPlayerVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnRenderVideoFrameJson {
+class VideoFrameObserverOnRenderVideoFrameJson implements AgoraSerializable {
   const VideoFrameObserverOnRenderVideoFrameJson(
       {this.channelId, this.remoteUid, this.videoFrame});
 
@@ -562,6 +589,7 @@ class VideoFrameObserverOnRenderVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnRenderVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnRenderVideoFrameJsonToJson(this);
 }
@@ -581,7 +609,8 @@ extension VideoFrameObserverOnRenderVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class VideoFrameObserverOnTranscodedVideoFrameJson {
+class VideoFrameObserverOnTranscodedVideoFrameJson
+    implements AgoraSerializable {
   const VideoFrameObserverOnTranscodedVideoFrameJson({this.videoFrame});
 
   @JsonKey(name: 'videoFrame')
@@ -591,6 +620,7 @@ class VideoFrameObserverOnTranscodedVideoFrameJson {
           Map<String, dynamic> json) =>
       _$VideoFrameObserverOnTranscodedVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$VideoFrameObserverOnTranscodedVideoFrameJsonToJson(this);
 }
@@ -610,7 +640,7 @@ extension VideoFrameObserverOnTranscodedVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class FaceInfoObserverOnFaceInfoJson {
+class FaceInfoObserverOnFaceInfoJson implements AgoraSerializable {
   const FaceInfoObserverOnFaceInfoJson({this.outFaceInfo});
 
   @JsonKey(name: 'outFaceInfo')
@@ -619,6 +649,7 @@ class FaceInfoObserverOnFaceInfoJson {
   factory FaceInfoObserverOnFaceInfoJson.fromJson(Map<String, dynamic> json) =>
       _$FaceInfoObserverOnFaceInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$FaceInfoObserverOnFaceInfoJsonToJson(this);
 }
 
@@ -636,7 +667,8 @@ extension FaceInfoObserverOnFaceInfoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderObserverOnRecorderStateChangedJson {
+class MediaRecorderObserverOnRecorderStateChangedJson
+    implements AgoraSerializable {
   const MediaRecorderObserverOnRecorderStateChangedJson(
       {this.channelId, this.uid, this.state, this.reason});
 
@@ -656,6 +688,7 @@ class MediaRecorderObserverOnRecorderStateChangedJson {
           Map<String, dynamic> json) =>
       _$MediaRecorderObserverOnRecorderStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaRecorderObserverOnRecorderStateChangedJsonToJson(this);
 }
@@ -675,7 +708,8 @@ extension MediaRecorderObserverOnRecorderStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaRecorderObserverOnRecorderInfoUpdatedJson {
+class MediaRecorderObserverOnRecorderInfoUpdatedJson
+    implements AgoraSerializable {
   const MediaRecorderObserverOnRecorderInfoUpdatedJson(
       {this.channelId, this.uid, this.info});
 
@@ -692,6 +726,7 @@ class MediaRecorderObserverOnRecorderInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaRecorderObserverOnRecorderInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaRecorderObserverOnRecorderInfoUpdatedJsonToJson(this);
 }
@@ -711,7 +746,7 @@ extension MediaRecorderObserverOnRecorderInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnEnableTranscodeJson {
+class H265TranscoderObserverOnEnableTranscodeJson implements AgoraSerializable {
   const H265TranscoderObserverOnEnableTranscodeJson({this.result});
 
   @JsonKey(name: 'result')
@@ -721,6 +756,7 @@ class H265TranscoderObserverOnEnableTranscodeJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnEnableTranscodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnEnableTranscodeJsonToJson(this);
 }
@@ -740,7 +776,7 @@ extension H265TranscoderObserverOnEnableTranscodeJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnQueryChannelJson {
+class H265TranscoderObserverOnQueryChannelJson implements AgoraSerializable {
   const H265TranscoderObserverOnQueryChannelJson(
       {this.result, this.originChannel, this.transcodeChannel});
 
@@ -757,6 +793,7 @@ class H265TranscoderObserverOnQueryChannelJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnQueryChannelJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnQueryChannelJsonToJson(this);
 }
@@ -776,7 +813,8 @@ extension H265TranscoderObserverOnQueryChannelJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class H265TranscoderObserverOnTriggerTranscodeJson {
+class H265TranscoderObserverOnTriggerTranscodeJson
+    implements AgoraSerializable {
   const H265TranscoderObserverOnTriggerTranscodeJson({this.result});
 
   @JsonKey(name: 'result')
@@ -786,6 +824,7 @@ class H265TranscoderObserverOnTriggerTranscodeJson {
           Map<String, dynamic> json) =>
       _$H265TranscoderObserverOnTriggerTranscodeJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$H265TranscoderObserverOnTriggerTranscodeJsonToJson(this);
 }
@@ -805,7 +844,7 @@ extension H265TranscoderObserverOnTriggerTranscodeJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerVideoFrameObserverOnFrameJson {
+class MediaPlayerVideoFrameObserverOnFrameJson implements AgoraSerializable {
   const MediaPlayerVideoFrameObserverOnFrameJson({this.frame});
 
   @JsonKey(name: 'frame')
@@ -815,6 +854,7 @@ class MediaPlayerVideoFrameObserverOnFrameJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerVideoFrameObserverOnFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerVideoFrameObserverOnFrameJsonToJson(this);
 }
@@ -834,7 +874,8 @@ extension MediaPlayerVideoFrameObserverOnFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson {
+class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerSourceStateChangedJson(
       {this.state, this.reason});
 
@@ -848,6 +889,7 @@ class MediaPlayerSourceObserverOnPlayerSourceStateChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonToJson(this);
 }
@@ -867,7 +909,8 @@ extension MediaPlayerSourceObserverOnPlayerSourceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPositionChangedJson {
+class MediaPlayerSourceObserverOnPositionChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPositionChangedJson(
       {this.positionMs, this.timestampMs});
 
@@ -881,6 +924,7 @@ class MediaPlayerSourceObserverOnPositionChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPositionChangedJsonToJson(this);
 }
@@ -900,7 +944,7 @@ extension MediaPlayerSourceObserverOnPositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerEventJson {
+class MediaPlayerSourceObserverOnPlayerEventJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerEventJson(
       {this.eventCode, this.elapsedTime, this.message});
 
@@ -917,6 +961,7 @@ class MediaPlayerSourceObserverOnPlayerEventJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerEventJsonToJson(this);
 }
@@ -936,7 +981,7 @@ extension MediaPlayerSourceObserverOnPlayerEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnMetaDataJson {
+class MediaPlayerSourceObserverOnMetaDataJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnMetaDataJson({this.data, this.length});
 
   @JsonKey(name: 'data', ignore: true)
@@ -949,6 +994,7 @@ class MediaPlayerSourceObserverOnMetaDataJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnMetaDataJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnMetaDataJsonToJson(this);
 }
@@ -975,7 +1021,8 @@ extension MediaPlayerSourceObserverOnMetaDataJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayBufferUpdatedJson {
+class MediaPlayerSourceObserverOnPlayBufferUpdatedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayBufferUpdatedJson(
       {this.playCachedBuffer});
 
@@ -986,6 +1033,7 @@ class MediaPlayerSourceObserverOnPlayBufferUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayBufferUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayBufferUpdatedJsonToJson(this);
 }
@@ -1005,7 +1053,7 @@ extension MediaPlayerSourceObserverOnPlayBufferUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPreloadEventJson {
+class MediaPlayerSourceObserverOnPreloadEventJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPreloadEventJson({this.src, this.event});
 
   @JsonKey(name: 'src')
@@ -1018,6 +1066,7 @@ class MediaPlayerSourceObserverOnPreloadEventJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPreloadEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPreloadEventJsonToJson(this);
 }
@@ -1037,13 +1086,14 @@ extension MediaPlayerSourceObserverOnPreloadEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnCompletedJson {
+class MediaPlayerSourceObserverOnCompletedJson implements AgoraSerializable {
   const MediaPlayerSourceObserverOnCompletedJson();
 
   factory MediaPlayerSourceObserverOnCompletedJson.fromJson(
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnCompletedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnCompletedJsonToJson(this);
 }
@@ -1063,13 +1113,15 @@ extension MediaPlayerSourceObserverOnCompletedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson {
+class MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson();
 
   factory MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJson.fromJson(
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonToJson(this);
 }
@@ -1089,7 +1141,8 @@ extension MediaPlayerSourceObserverOnAgoraCDNTokenWillExpireJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson {
+class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson(
       {this.from, this.to});
 
@@ -1103,6 +1156,7 @@ class MediaPlayerSourceObserverOnPlayerSrcInfoChangedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonToJson(this);
 }
@@ -1122,7 +1176,8 @@ extension MediaPlayerSourceObserverOnPlayerSrcInfoChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson {
+class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -1132,6 +1187,7 @@ class MediaPlayerSourceObserverOnPlayerInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonToJson(this);
 }
@@ -1151,7 +1207,8 @@ extension MediaPlayerSourceObserverOnPlayerInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerCacheStatsJson {
+class MediaPlayerSourceObserverOnPlayerCacheStatsJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerCacheStatsJson({this.stats});
 
   @JsonKey(name: 'stats')
@@ -1161,6 +1218,7 @@ class MediaPlayerSourceObserverOnPlayerCacheStatsJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerCacheStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerCacheStatsJsonToJson(this);
 }
@@ -1180,7 +1238,8 @@ extension MediaPlayerSourceObserverOnPlayerCacheStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson {
+class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnPlayerPlaybackStatsJson({this.stats});
 
   @JsonKey(name: 'stats')
@@ -1190,6 +1249,7 @@ class MediaPlayerSourceObserverOnPlayerPlaybackStatsJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonToJson(this);
 }
@@ -1209,7 +1269,8 @@ extension MediaPlayerSourceObserverOnPlayerPlaybackStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MediaPlayerSourceObserverOnAudioVolumeIndicationJson {
+class MediaPlayerSourceObserverOnAudioVolumeIndicationJson
+    implements AgoraSerializable {
   const MediaPlayerSourceObserverOnAudioVolumeIndicationJson({this.volume});
 
   @JsonKey(name: 'volume')
@@ -1219,6 +1280,7 @@ class MediaPlayerSourceObserverOnAudioVolumeIndicationJson {
           Map<String, dynamic> json) =>
       _$MediaPlayerSourceObserverOnAudioVolumeIndicationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MediaPlayerSourceObserverOnAudioVolumeIndicationJsonToJson(this);
 }
@@ -1238,7 +1300,8 @@ extension MediaPlayerSourceObserverOnAudioVolumeIndicationJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnMusicChartsResultJson {
+class MusicContentCenterEventHandlerOnMusicChartsResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnMusicChartsResultJson(
       {this.requestId, this.result, this.reason});
 
@@ -1255,6 +1318,7 @@ class MusicContentCenterEventHandlerOnMusicChartsResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnMusicChartsResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnMusicChartsResultJsonToJson(this);
 }
@@ -1274,7 +1338,8 @@ extension MusicContentCenterEventHandlerOnMusicChartsResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnMusicCollectionResultJson {
+class MusicContentCenterEventHandlerOnMusicCollectionResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnMusicCollectionResultJson(
       {this.requestId, this.result, this.reason});
 
@@ -1291,6 +1356,7 @@ class MusicContentCenterEventHandlerOnMusicCollectionResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnMusicCollectionResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnMusicCollectionResultJsonToJson(this);
 }
@@ -1310,7 +1376,8 @@ extension MusicContentCenterEventHandlerOnMusicCollectionResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnLyricResultJson {
+class MusicContentCenterEventHandlerOnLyricResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnLyricResultJson(
       {this.requestId, this.songCode, this.lyricUrl, this.reason});
 
@@ -1330,6 +1397,7 @@ class MusicContentCenterEventHandlerOnLyricResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnLyricResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnLyricResultJsonToJson(this);
 }
@@ -1349,7 +1417,8 @@ extension MusicContentCenterEventHandlerOnLyricResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson {
+class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnSongSimpleInfoResultJson(
       {this.requestId, this.songCode, this.simpleInfo, this.reason});
 
@@ -1369,6 +1438,7 @@ class MusicContentCenterEventHandlerOnSongSimpleInfoResultJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonToJson(this);
 }
@@ -1388,7 +1458,8 @@ extension MusicContentCenterEventHandlerOnSongSimpleInfoResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicContentCenterEventHandlerOnPreLoadEventJson {
+class MusicContentCenterEventHandlerOnPreLoadEventJson
+    implements AgoraSerializable {
   const MusicContentCenterEventHandlerOnPreLoadEventJson(
       {this.requestId,
       this.songCode,
@@ -1419,6 +1490,7 @@ class MusicContentCenterEventHandlerOnPreLoadEventJson {
           Map<String, dynamic> json) =>
       _$MusicContentCenterEventHandlerOnPreLoadEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MusicContentCenterEventHandlerOnPreLoadEventJsonToJson(this);
 }
@@ -1438,7 +1510,8 @@ extension MusicContentCenterEventHandlerOnPreLoadEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnJoinChannelSuccessJson {
+class RtcEngineEventHandlerOnJoinChannelSuccessJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnJoinChannelSuccessJson(
       {this.connection, this.elapsed});
 
@@ -1452,6 +1525,7 @@ class RtcEngineEventHandlerOnJoinChannelSuccessJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnJoinChannelSuccessJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnJoinChannelSuccessJsonToJson(this);
 }
@@ -1471,7 +1545,8 @@ extension RtcEngineEventHandlerOnJoinChannelSuccessJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRejoinChannelSuccessJson {
+class RtcEngineEventHandlerOnRejoinChannelSuccessJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRejoinChannelSuccessJson(
       {this.connection, this.elapsed});
 
@@ -1485,6 +1560,7 @@ class RtcEngineEventHandlerOnRejoinChannelSuccessJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRejoinChannelSuccessJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRejoinChannelSuccessJsonToJson(this);
 }
@@ -1504,7 +1580,7 @@ extension RtcEngineEventHandlerOnRejoinChannelSuccessJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnProxyConnectedJson {
+class RtcEngineEventHandlerOnProxyConnectedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnProxyConnectedJson(
       {this.channel,
       this.uid,
@@ -1531,6 +1607,7 @@ class RtcEngineEventHandlerOnProxyConnectedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnProxyConnectedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnProxyConnectedJsonToJson(this);
 }
@@ -1550,7 +1627,7 @@ extension RtcEngineEventHandlerOnProxyConnectedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnErrorJson {
+class RtcEngineEventHandlerOnErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnErrorJson({this.err, this.msg});
 
   @JsonKey(name: 'err')
@@ -1563,6 +1640,7 @@ class RtcEngineEventHandlerOnErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnErrorJsonToJson(this);
 }
@@ -1581,7 +1659,7 @@ extension RtcEngineEventHandlerOnErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioQualityJson {
+class RtcEngineEventHandlerOnAudioQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioQualityJson(
       {this.connection, this.remoteUid, this.quality, this.delay, this.lost});
 
@@ -1604,6 +1682,7 @@ class RtcEngineEventHandlerOnAudioQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioQualityJsonToJson(this);
 }
@@ -1623,7 +1702,8 @@ extension RtcEngineEventHandlerOnAudioQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLastmileProbeResultJson {
+class RtcEngineEventHandlerOnLastmileProbeResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLastmileProbeResultJson({this.result});
 
   @JsonKey(name: 'result')
@@ -1633,6 +1713,7 @@ class RtcEngineEventHandlerOnLastmileProbeResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLastmileProbeResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLastmileProbeResultJsonToJson(this);
 }
@@ -1652,7 +1733,8 @@ extension RtcEngineEventHandlerOnLastmileProbeResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioVolumeIndicationJson {
+class RtcEngineEventHandlerOnAudioVolumeIndicationJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioVolumeIndicationJson(
       {this.connection, this.speakers, this.speakerNumber, this.totalVolume});
 
@@ -1672,6 +1754,7 @@ class RtcEngineEventHandlerOnAudioVolumeIndicationJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioVolumeIndicationJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioVolumeIndicationJsonToJson(this);
 }
@@ -1691,7 +1774,7 @@ extension RtcEngineEventHandlerOnAudioVolumeIndicationJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLeaveChannelJson {
+class RtcEngineEventHandlerOnLeaveChannelJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLeaveChannelJson({this.connection, this.stats});
 
   @JsonKey(name: 'connection')
@@ -1704,6 +1787,7 @@ class RtcEngineEventHandlerOnLeaveChannelJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLeaveChannelJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLeaveChannelJsonToJson(this);
 }
@@ -1723,7 +1807,7 @@ extension RtcEngineEventHandlerOnLeaveChannelJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtcStatsJson {
+class RtcEngineEventHandlerOnRtcStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtcStatsJson({this.connection, this.stats});
 
   @JsonKey(name: 'connection')
@@ -1736,6 +1820,7 @@ class RtcEngineEventHandlerOnRtcStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtcStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtcStatsJsonToJson(this);
 }
@@ -1754,7 +1839,8 @@ extension RtcEngineEventHandlerOnRtcStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioDeviceStateChangedJson {
+class RtcEngineEventHandlerOnAudioDeviceStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioDeviceStateChangedJson(
       {this.deviceId, this.deviceType, this.deviceState});
 
@@ -1771,6 +1857,7 @@ class RtcEngineEventHandlerOnAudioDeviceStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioDeviceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioDeviceStateChangedJsonToJson(this);
 }
@@ -1790,7 +1877,8 @@ extension RtcEngineEventHandlerOnAudioDeviceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingPositionChangedJson {
+class RtcEngineEventHandlerOnAudioMixingPositionChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingPositionChangedJson({this.position});
 
   @JsonKey(name: 'position')
@@ -1800,6 +1888,7 @@ class RtcEngineEventHandlerOnAudioMixingPositionChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingPositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingPositionChangedJsonToJson(this);
 }
@@ -1819,13 +1908,15 @@ extension RtcEngineEventHandlerOnAudioMixingPositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingFinishedJson {
+class RtcEngineEventHandlerOnAudioMixingFinishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingFinishedJson();
 
   factory RtcEngineEventHandlerOnAudioMixingFinishedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingFinishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingFinishedJsonToJson(this);
 }
@@ -1845,7 +1936,8 @@ extension RtcEngineEventHandlerOnAudioMixingFinishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioEffectFinishedJson {
+class RtcEngineEventHandlerOnAudioEffectFinishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioEffectFinishedJson({this.soundId});
 
   @JsonKey(name: 'soundId')
@@ -1855,6 +1947,7 @@ class RtcEngineEventHandlerOnAudioEffectFinishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioEffectFinishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioEffectFinishedJsonToJson(this);
 }
@@ -1874,7 +1967,8 @@ extension RtcEngineEventHandlerOnAudioEffectFinishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoDeviceStateChangedJson {
+class RtcEngineEventHandlerOnVideoDeviceStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoDeviceStateChangedJson(
       {this.deviceId, this.deviceType, this.deviceState});
 
@@ -1891,6 +1985,7 @@ class RtcEngineEventHandlerOnVideoDeviceStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoDeviceStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoDeviceStateChangedJsonToJson(this);
 }
@@ -1910,7 +2005,7 @@ extension RtcEngineEventHandlerOnVideoDeviceStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnPipStateChangedJson {
+class RtcEngineEventHandlerOnPipStateChangedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnPipStateChangedJson({this.state});
 
   @JsonKey(name: 'state')
@@ -1920,6 +2015,7 @@ class RtcEngineEventHandlerOnPipStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnPipStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnPipStateChangedJsonToJson(this);
 }
@@ -1939,7 +2035,7 @@ extension RtcEngineEventHandlerOnPipStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnNetworkQualityJson {
+class RtcEngineEventHandlerOnNetworkQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnNetworkQualityJson(
       {this.connection, this.remoteUid, this.txQuality, this.rxQuality});
 
@@ -1959,6 +2055,7 @@ class RtcEngineEventHandlerOnNetworkQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnNetworkQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnNetworkQualityJsonToJson(this);
 }
@@ -1978,7 +2075,8 @@ extension RtcEngineEventHandlerOnNetworkQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnIntraRequestReceivedJson {
+class RtcEngineEventHandlerOnIntraRequestReceivedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnIntraRequestReceivedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -1988,6 +2086,7 @@ class RtcEngineEventHandlerOnIntraRequestReceivedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnIntraRequestReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnIntraRequestReceivedJsonToJson(this);
 }
@@ -2007,7 +2106,8 @@ extension RtcEngineEventHandlerOnIntraRequestReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson {
+class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -2017,6 +2117,7 @@ class RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonToJson(this);
 }
@@ -2036,7 +2137,8 @@ extension RtcEngineEventHandlerOnUplinkNetworkInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson {
+class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson({this.info});
 
   @JsonKey(name: 'info')
@@ -2046,6 +2148,7 @@ class RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonToJson(this);
 }
@@ -2065,7 +2168,7 @@ extension RtcEngineEventHandlerOnDownlinkNetworkInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLastmileQualityJson {
+class RtcEngineEventHandlerOnLastmileQualityJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLastmileQualityJson({this.quality});
 
   @JsonKey(name: 'quality')
@@ -2075,6 +2178,7 @@ class RtcEngineEventHandlerOnLastmileQualityJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLastmileQualityJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLastmileQualityJsonToJson(this);
 }
@@ -2094,7 +2198,8 @@ extension RtcEngineEventHandlerOnLastmileQualityJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalVideoFrameJson {
+class RtcEngineEventHandlerOnFirstLocalVideoFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalVideoFrameJson(
       {this.source, this.width, this.height, this.elapsed});
 
@@ -2114,6 +2219,7 @@ class RtcEngineEventHandlerOnFirstLocalVideoFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFrameJsonToJson(this);
 }
@@ -2133,7 +2239,8 @@ extension RtcEngineEventHandlerOnFirstLocalVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson {
+class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson(
       {this.connection, this.elapsed});
 
@@ -2147,6 +2254,7 @@ class RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonToJson(this);
 }
@@ -2166,7 +2274,8 @@ extension RtcEngineEventHandlerOnFirstLocalVideoFramePublishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson {
+class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson(
       {this.connection, this.remoteUid, this.width, this.height, this.elapsed});
 
@@ -2189,6 +2298,7 @@ class RtcEngineEventHandlerOnFirstRemoteVideoDecodedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonToJson(this);
 }
@@ -2208,7 +2318,7 @@ extension RtcEngineEventHandlerOnFirstRemoteVideoDecodedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoSizeChangedJson {
+class RtcEngineEventHandlerOnVideoSizeChangedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoSizeChangedJson(
       {this.connection,
       this.sourceType,
@@ -2239,6 +2349,7 @@ class RtcEngineEventHandlerOnVideoSizeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoSizeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoSizeChangedJsonToJson(this);
 }
@@ -2258,7 +2369,8 @@ extension RtcEngineEventHandlerOnVideoSizeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoStateChangedJson {
+class RtcEngineEventHandlerOnLocalVideoStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoStateChangedJson(
       {this.source, this.state, this.reason});
 
@@ -2275,6 +2387,7 @@ class RtcEngineEventHandlerOnLocalVideoStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoStateChangedJsonToJson(this);
 }
@@ -2294,7 +2407,8 @@ extension RtcEngineEventHandlerOnLocalVideoStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoStateChangedJson {
+class RtcEngineEventHandlerOnRemoteVideoStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoStateChangedJson(
       {this.connection, this.remoteUid, this.state, this.reason, this.elapsed});
 
@@ -2317,6 +2431,7 @@ class RtcEngineEventHandlerOnRemoteVideoStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoStateChangedJsonToJson(this);
 }
@@ -2336,7 +2451,8 @@ extension RtcEngineEventHandlerOnRemoteVideoStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson {
+class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteVideoFrameJson(
       {this.connection, this.remoteUid, this.width, this.height, this.elapsed});
 
@@ -2359,6 +2475,7 @@ class RtcEngineEventHandlerOnFirstRemoteVideoFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonToJson(this);
 }
@@ -2378,7 +2495,7 @@ extension RtcEngineEventHandlerOnFirstRemoteVideoFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserJoinedJson {
+class RtcEngineEventHandlerOnUserJoinedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserJoinedJson(
       {this.connection, this.remoteUid, this.elapsed});
 
@@ -2395,6 +2512,7 @@ class RtcEngineEventHandlerOnUserJoinedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserJoinedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserJoinedJsonToJson(this);
 }
@@ -2414,7 +2532,7 @@ extension RtcEngineEventHandlerOnUserJoinedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserOfflineJson {
+class RtcEngineEventHandlerOnUserOfflineJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserOfflineJson(
       {this.connection, this.remoteUid, this.reason});
 
@@ -2431,6 +2549,7 @@ class RtcEngineEventHandlerOnUserOfflineJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserOfflineJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserOfflineJsonToJson(this);
 }
@@ -2450,7 +2569,7 @@ extension RtcEngineEventHandlerOnUserOfflineJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserMuteAudioJson {
+class RtcEngineEventHandlerOnUserMuteAudioJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserMuteAudioJson(
       {this.connection, this.remoteUid, this.muted});
 
@@ -2467,6 +2586,7 @@ class RtcEngineEventHandlerOnUserMuteAudioJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserMuteAudioJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserMuteAudioJsonToJson(this);
 }
@@ -2486,7 +2606,7 @@ extension RtcEngineEventHandlerOnUserMuteAudioJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserMuteVideoJson {
+class RtcEngineEventHandlerOnUserMuteVideoJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserMuteVideoJson(
       {this.connection, this.remoteUid, this.muted});
 
@@ -2503,6 +2623,7 @@ class RtcEngineEventHandlerOnUserMuteVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserMuteVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserMuteVideoJsonToJson(this);
 }
@@ -2522,7 +2643,7 @@ extension RtcEngineEventHandlerOnUserMuteVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserEnableVideoJson {
+class RtcEngineEventHandlerOnUserEnableVideoJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserEnableVideoJson(
       {this.connection, this.remoteUid, this.enabled});
 
@@ -2539,6 +2660,7 @@ class RtcEngineEventHandlerOnUserEnableVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserEnableVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserEnableVideoJsonToJson(this);
 }
@@ -2558,7 +2680,7 @@ extension RtcEngineEventHandlerOnUserEnableVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserStateChangedJson {
+class RtcEngineEventHandlerOnUserStateChangedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserStateChangedJson(
       {this.connection, this.remoteUid, this.state});
 
@@ -2575,6 +2697,7 @@ class RtcEngineEventHandlerOnUserStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserStateChangedJsonToJson(this);
 }
@@ -2594,7 +2717,8 @@ extension RtcEngineEventHandlerOnUserStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserEnableLocalVideoJson {
+class RtcEngineEventHandlerOnUserEnableLocalVideoJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserEnableLocalVideoJson(
       {this.connection, this.remoteUid, this.enabled});
 
@@ -2611,6 +2735,7 @@ class RtcEngineEventHandlerOnUserEnableLocalVideoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserEnableLocalVideoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserEnableLocalVideoJsonToJson(this);
 }
@@ -2630,7 +2755,7 @@ extension RtcEngineEventHandlerOnUserEnableLocalVideoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioStatsJson {
+class RtcEngineEventHandlerOnRemoteAudioStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioStatsJson(
       {this.connection, this.stats});
 
@@ -2644,6 +2769,7 @@ class RtcEngineEventHandlerOnRemoteAudioStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioStatsJsonToJson(this);
 }
@@ -2663,7 +2789,7 @@ extension RtcEngineEventHandlerOnRemoteAudioStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalAudioStatsJson {
+class RtcEngineEventHandlerOnLocalAudioStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalAudioStatsJson(
       {this.connection, this.stats});
 
@@ -2677,6 +2803,7 @@ class RtcEngineEventHandlerOnLocalAudioStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalAudioStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalAudioStatsJsonToJson(this);
 }
@@ -2696,7 +2823,7 @@ extension RtcEngineEventHandlerOnLocalAudioStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoStatsJson {
+class RtcEngineEventHandlerOnLocalVideoStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoStatsJson(
       {this.connection, this.stats});
 
@@ -2710,6 +2837,7 @@ class RtcEngineEventHandlerOnLocalVideoStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoStatsJsonToJson(this);
 }
@@ -2729,7 +2857,7 @@ extension RtcEngineEventHandlerOnLocalVideoStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoStatsJson {
+class RtcEngineEventHandlerOnRemoteVideoStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoStatsJson(
       {this.connection, this.stats});
 
@@ -2743,6 +2871,7 @@ class RtcEngineEventHandlerOnRemoteVideoStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoStatsJsonToJson(this);
 }
@@ -2762,13 +2891,14 @@ extension RtcEngineEventHandlerOnRemoteVideoStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraReadyJson {
+class RtcEngineEventHandlerOnCameraReadyJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraReadyJson();
 
   factory RtcEngineEventHandlerOnCameraReadyJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraReadyJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraReadyJsonToJson(this);
 }
@@ -2788,7 +2918,8 @@ extension RtcEngineEventHandlerOnCameraReadyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraFocusAreaChangedJson {
+class RtcEngineEventHandlerOnCameraFocusAreaChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraFocusAreaChangedJson(
       {this.x, this.y, this.width, this.height});
 
@@ -2808,6 +2939,7 @@ class RtcEngineEventHandlerOnCameraFocusAreaChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraFocusAreaChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraFocusAreaChangedJsonToJson(this);
 }
@@ -2827,7 +2959,8 @@ extension RtcEngineEventHandlerOnCameraFocusAreaChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnCameraExposureAreaChangedJson {
+class RtcEngineEventHandlerOnCameraExposureAreaChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnCameraExposureAreaChangedJson(
       {this.x, this.y, this.width, this.height});
 
@@ -2847,6 +2980,7 @@ class RtcEngineEventHandlerOnCameraExposureAreaChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnCameraExposureAreaChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnCameraExposureAreaChangedJsonToJson(this);
 }
@@ -2866,7 +3000,8 @@ extension RtcEngineEventHandlerOnCameraExposureAreaChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFacePositionChangedJson {
+class RtcEngineEventHandlerOnFacePositionChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFacePositionChangedJson(
       {this.imageWidth,
       this.imageHeight,
@@ -2893,6 +3028,7 @@ class RtcEngineEventHandlerOnFacePositionChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFacePositionChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFacePositionChangedJsonToJson(this);
 }
@@ -2912,13 +3048,14 @@ extension RtcEngineEventHandlerOnFacePositionChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoStoppedJson {
+class RtcEngineEventHandlerOnVideoStoppedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoStoppedJson();
 
   factory RtcEngineEventHandlerOnVideoStoppedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoStoppedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoStoppedJsonToJson(this);
 }
@@ -2938,7 +3075,8 @@ extension RtcEngineEventHandlerOnVideoStoppedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMixingStateChangedJson {
+class RtcEngineEventHandlerOnAudioMixingStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMixingStateChangedJson(
       {this.state, this.reason});
 
@@ -2952,6 +3090,7 @@ class RtcEngineEventHandlerOnAudioMixingStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMixingStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMixingStateChangedJsonToJson(this);
 }
@@ -2971,7 +3110,8 @@ extension RtcEngineEventHandlerOnAudioMixingStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson {
+class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRhythmPlayerStateChangedJson(
       {this.state, this.reason});
 
@@ -2985,6 +3125,7 @@ class RtcEngineEventHandlerOnRhythmPlayerStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonToJson(this);
 }
@@ -3004,7 +3145,7 @@ extension RtcEngineEventHandlerOnRhythmPlayerStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionLostJson {
+class RtcEngineEventHandlerOnConnectionLostJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionLostJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3014,6 +3155,7 @@ class RtcEngineEventHandlerOnConnectionLostJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionLostJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionLostJsonToJson(this);
 }
@@ -3033,7 +3175,8 @@ extension RtcEngineEventHandlerOnConnectionLostJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionInterruptedJson {
+class RtcEngineEventHandlerOnConnectionInterruptedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionInterruptedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3043,6 +3186,7 @@ class RtcEngineEventHandlerOnConnectionInterruptedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionInterruptedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionInterruptedJsonToJson(this);
 }
@@ -3062,7 +3206,7 @@ extension RtcEngineEventHandlerOnConnectionInterruptedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionBannedJson {
+class RtcEngineEventHandlerOnConnectionBannedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionBannedJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3072,6 +3216,7 @@ class RtcEngineEventHandlerOnConnectionBannedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionBannedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionBannedJsonToJson(this);
 }
@@ -3091,7 +3236,7 @@ extension RtcEngineEventHandlerOnConnectionBannedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnStreamMessageJson {
+class RtcEngineEventHandlerOnStreamMessageJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnStreamMessageJson(
       {this.connection,
       this.remoteUid,
@@ -3122,6 +3267,7 @@ class RtcEngineEventHandlerOnStreamMessageJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnStreamMessageJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnStreamMessageJsonToJson(this);
 }
@@ -3154,7 +3300,8 @@ extension RtcEngineEventHandlerOnStreamMessageJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnStreamMessageErrorJson {
+class RtcEngineEventHandlerOnStreamMessageErrorJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnStreamMessageErrorJson(
       {this.connection,
       this.remoteUid,
@@ -3185,6 +3332,7 @@ class RtcEngineEventHandlerOnStreamMessageErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnStreamMessageErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnStreamMessageErrorJsonToJson(this);
 }
@@ -3204,7 +3352,7 @@ extension RtcEngineEventHandlerOnStreamMessageErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRequestTokenJson {
+class RtcEngineEventHandlerOnRequestTokenJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnRequestTokenJson({this.connection});
 
   @JsonKey(name: 'connection')
@@ -3214,6 +3362,7 @@ class RtcEngineEventHandlerOnRequestTokenJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRequestTokenJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRequestTokenJsonToJson(this);
 }
@@ -3233,7 +3382,8 @@ extension RtcEngineEventHandlerOnRequestTokenJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson {
+class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson(
       {this.connection, this.token});
 
@@ -3247,6 +3397,7 @@ class RtcEngineEventHandlerOnTokenPrivilegeWillExpireJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonToJson(this);
 }
@@ -3266,7 +3417,8 @@ extension RtcEngineEventHandlerOnTokenPrivilegeWillExpireJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLicenseValidationFailureJson {
+class RtcEngineEventHandlerOnLicenseValidationFailureJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLicenseValidationFailureJson(
       {this.connection, this.reason});
 
@@ -3280,6 +3432,7 @@ class RtcEngineEventHandlerOnLicenseValidationFailureJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLicenseValidationFailureJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLicenseValidationFailureJsonToJson(this);
 }
@@ -3299,7 +3452,8 @@ extension RtcEngineEventHandlerOnLicenseValidationFailureJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson {
+class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson(
       {this.connection, this.elapsed});
 
@@ -3313,6 +3467,7 @@ class RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonToJson(this);
 }
@@ -3332,7 +3487,8 @@ extension RtcEngineEventHandlerOnFirstLocalAudioFramePublishedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson {
+class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson(
       {this.connection, this.uid, this.elapsed});
 
@@ -3349,6 +3505,7 @@ class RtcEngineEventHandlerOnFirstRemoteAudioDecodedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonToJson(this);
 }
@@ -3368,7 +3525,8 @@ extension RtcEngineEventHandlerOnFirstRemoteAudioDecodedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson {
+class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnFirstRemoteAudioFrameJson(
       {this.connection, this.userId, this.elapsed});
 
@@ -3385,6 +3543,7 @@ class RtcEngineEventHandlerOnFirstRemoteAudioFrameJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonToJson(this);
 }
@@ -3404,7 +3563,8 @@ extension RtcEngineEventHandlerOnFirstRemoteAudioFrameJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalAudioStateChangedJson {
+class RtcEngineEventHandlerOnLocalAudioStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalAudioStateChangedJson(
       {this.connection, this.state, this.reason});
 
@@ -3421,6 +3581,7 @@ class RtcEngineEventHandlerOnLocalAudioStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalAudioStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalAudioStateChangedJsonToJson(this);
 }
@@ -3440,7 +3601,8 @@ extension RtcEngineEventHandlerOnLocalAudioStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioStateChangedJson {
+class RtcEngineEventHandlerOnRemoteAudioStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioStateChangedJson(
       {this.connection, this.remoteUid, this.state, this.reason, this.elapsed});
 
@@ -3463,6 +3625,7 @@ class RtcEngineEventHandlerOnRemoteAudioStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioStateChangedJsonToJson(this);
 }
@@ -3482,7 +3645,7 @@ extension RtcEngineEventHandlerOnRemoteAudioStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnActiveSpeakerJson {
+class RtcEngineEventHandlerOnActiveSpeakerJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnActiveSpeakerJson({this.connection, this.uid});
 
   @JsonKey(name: 'connection')
@@ -3495,6 +3658,7 @@ class RtcEngineEventHandlerOnActiveSpeakerJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnActiveSpeakerJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnActiveSpeakerJsonToJson(this);
 }
@@ -3514,7 +3678,8 @@ extension RtcEngineEventHandlerOnActiveSpeakerJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnContentInspectResultJson {
+class RtcEngineEventHandlerOnContentInspectResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnContentInspectResultJson({this.result});
 
   @JsonKey(name: 'result')
@@ -3524,6 +3689,7 @@ class RtcEngineEventHandlerOnContentInspectResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnContentInspectResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnContentInspectResultJsonToJson(this);
 }
@@ -3543,7 +3709,7 @@ extension RtcEngineEventHandlerOnContentInspectResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnSnapshotTakenJson {
+class RtcEngineEventHandlerOnSnapshotTakenJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnSnapshotTakenJson(
       {this.connection,
       this.uid,
@@ -3574,6 +3740,7 @@ class RtcEngineEventHandlerOnSnapshotTakenJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnSnapshotTakenJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnSnapshotTakenJsonToJson(this);
 }
@@ -3593,7 +3760,8 @@ extension RtcEngineEventHandlerOnSnapshotTakenJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnClientRoleChangedJson {
+class RtcEngineEventHandlerOnClientRoleChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnClientRoleChangedJson(
       {this.connection, this.oldRole, this.newRole, this.newRoleOptions});
 
@@ -3613,6 +3781,7 @@ class RtcEngineEventHandlerOnClientRoleChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnClientRoleChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnClientRoleChangedJsonToJson(this);
 }
@@ -3632,7 +3801,8 @@ extension RtcEngineEventHandlerOnClientRoleChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnClientRoleChangeFailedJson {
+class RtcEngineEventHandlerOnClientRoleChangeFailedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnClientRoleChangeFailedJson(
       {this.connection, this.reason, this.currentRole});
 
@@ -3649,6 +3819,7 @@ class RtcEngineEventHandlerOnClientRoleChangeFailedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnClientRoleChangeFailedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnClientRoleChangeFailedJsonToJson(this);
 }
@@ -3668,7 +3839,8 @@ extension RtcEngineEventHandlerOnClientRoleChangeFailedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson {
+class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson(
       {this.deviceType, this.volume, this.muted});
 
@@ -3685,6 +3857,7 @@ class RtcEngineEventHandlerOnAudioDeviceVolumeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonToJson(this);
 }
@@ -3704,7 +3877,8 @@ extension RtcEngineEventHandlerOnAudioDeviceVolumeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson {
+class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtmpStreamingStateChangedJson(
       {this.url, this.state, this.reason});
 
@@ -3721,6 +3895,7 @@ class RtcEngineEventHandlerOnRtmpStreamingStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonToJson(this);
 }
@@ -3740,7 +3915,8 @@ extension RtcEngineEventHandlerOnRtmpStreamingStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRtmpStreamingEventJson {
+class RtcEngineEventHandlerOnRtmpStreamingEventJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRtmpStreamingEventJson(
       {this.url, this.eventCode});
 
@@ -3754,6 +3930,7 @@ class RtcEngineEventHandlerOnRtmpStreamingEventJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRtmpStreamingEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRtmpStreamingEventJsonToJson(this);
 }
@@ -3773,13 +3950,15 @@ extension RtcEngineEventHandlerOnRtmpStreamingEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTranscodingUpdatedJson {
+class RtcEngineEventHandlerOnTranscodingUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTranscodingUpdatedJson();
 
   factory RtcEngineEventHandlerOnTranscodingUpdatedJson.fromJson(
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTranscodingUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTranscodingUpdatedJsonToJson(this);
 }
@@ -3799,7 +3978,8 @@ extension RtcEngineEventHandlerOnTranscodingUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioRoutingChangedJson {
+class RtcEngineEventHandlerOnAudioRoutingChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioRoutingChangedJson({this.routing});
 
   @JsonKey(name: 'routing')
@@ -3809,6 +3989,7 @@ class RtcEngineEventHandlerOnAudioRoutingChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioRoutingChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioRoutingChangedJsonToJson(this);
 }
@@ -3828,7 +4009,8 @@ extension RtcEngineEventHandlerOnAudioRoutingChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson {
+class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson(
       {this.state, this.code});
 
@@ -3842,6 +4024,7 @@ class RtcEngineEventHandlerOnChannelMediaRelayStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonToJson(this);
 }
@@ -3861,7 +4044,8 @@ extension RtcEngineEventHandlerOnChannelMediaRelayStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson {
+class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson(
       {this.isFallbackOrRecover});
 
@@ -3873,6 +4057,7 @@ class RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJson {
       _$RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonToJson(this);
 }
@@ -3892,7 +4077,8 @@ extension RtcEngineEventHandlerOnLocalPublishFallbackToAudioOnlyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson {
+class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson(
       {this.uid, this.isFallbackOrRecover});
 
@@ -3907,6 +4093,7 @@ class RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJson {
       _$RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonToJson(
           this);
@@ -3927,7 +4114,8 @@ extension RtcEngineEventHandlerOnRemoteSubscribeFallbackToAudioOnlyJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson {
+class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteAudioTransportStatsJson(
       {this.connection,
       this.remoteUid,
@@ -3954,6 +4142,7 @@ class RtcEngineEventHandlerOnRemoteAudioTransportStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonToJson(this);
 }
@@ -3973,7 +4162,8 @@ extension RtcEngineEventHandlerOnRemoteAudioTransportStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson {
+class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnRemoteVideoTransportStatsJson(
       {this.connection,
       this.remoteUid,
@@ -4000,6 +4190,7 @@ class RtcEngineEventHandlerOnRemoteVideoTransportStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonToJson(this);
 }
@@ -4019,7 +4210,8 @@ extension RtcEngineEventHandlerOnRemoteVideoTransportStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnConnectionStateChangedJson {
+class RtcEngineEventHandlerOnConnectionStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnConnectionStateChangedJson(
       {this.connection, this.state, this.reason});
 
@@ -4036,6 +4228,7 @@ class RtcEngineEventHandlerOnConnectionStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnConnectionStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnConnectionStateChangedJsonToJson(this);
 }
@@ -4055,7 +4248,7 @@ extension RtcEngineEventHandlerOnConnectionStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnWlAccMessageJson {
+class RtcEngineEventHandlerOnWlAccMessageJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnWlAccMessageJson(
       {this.connection, this.reason, this.action, this.wlAccMsg});
 
@@ -4075,6 +4268,7 @@ class RtcEngineEventHandlerOnWlAccMessageJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnWlAccMessageJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnWlAccMessageJsonToJson(this);
 }
@@ -4094,7 +4288,7 @@ extension RtcEngineEventHandlerOnWlAccMessageJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnWlAccStatsJson {
+class RtcEngineEventHandlerOnWlAccStatsJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnWlAccStatsJson(
       {this.connection, this.currentStats, this.averageStats});
 
@@ -4111,6 +4305,7 @@ class RtcEngineEventHandlerOnWlAccStatsJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnWlAccStatsJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnWlAccStatsJsonToJson(this);
 }
@@ -4130,7 +4325,8 @@ extension RtcEngineEventHandlerOnWlAccStatsJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnNetworkTypeChangedJson {
+class RtcEngineEventHandlerOnNetworkTypeChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnNetworkTypeChangedJson(
       {this.connection, this.type});
 
@@ -4144,6 +4340,7 @@ class RtcEngineEventHandlerOnNetworkTypeChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnNetworkTypeChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnNetworkTypeChangedJsonToJson(this);
 }
@@ -4163,7 +4360,7 @@ extension RtcEngineEventHandlerOnNetworkTypeChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnEncryptionErrorJson {
+class RtcEngineEventHandlerOnEncryptionErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnEncryptionErrorJson(
       {this.connection, this.errorType});
 
@@ -4177,6 +4374,7 @@ class RtcEngineEventHandlerOnEncryptionErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnEncryptionErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnEncryptionErrorJsonToJson(this);
 }
@@ -4196,7 +4394,7 @@ extension RtcEngineEventHandlerOnEncryptionErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnPermissionErrorJson {
+class RtcEngineEventHandlerOnPermissionErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnPermissionErrorJson({this.permissionType});
 
   @JsonKey(name: 'permissionType')
@@ -4206,6 +4404,7 @@ class RtcEngineEventHandlerOnPermissionErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnPermissionErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnPermissionErrorJsonToJson(this);
 }
@@ -4225,7 +4424,8 @@ extension RtcEngineEventHandlerOnPermissionErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalUserRegisteredJson {
+class RtcEngineEventHandlerOnLocalUserRegisteredJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalUserRegisteredJson(
       {this.uid, this.userAccount});
 
@@ -4239,6 +4439,7 @@ class RtcEngineEventHandlerOnLocalUserRegisteredJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalUserRegisteredJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalUserRegisteredJsonToJson(this);
 }
@@ -4258,7 +4459,7 @@ extension RtcEngineEventHandlerOnLocalUserRegisteredJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserInfoUpdatedJson {
+class RtcEngineEventHandlerOnUserInfoUpdatedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserInfoUpdatedJson({this.uid, this.info});
 
   @JsonKey(name: 'uid')
@@ -4271,6 +4472,7 @@ class RtcEngineEventHandlerOnUserInfoUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserInfoUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserInfoUpdatedJsonToJson(this);
 }
@@ -4290,7 +4492,8 @@ extension RtcEngineEventHandlerOnUserInfoUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUserAccountUpdatedJson {
+class RtcEngineEventHandlerOnUserAccountUpdatedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnUserAccountUpdatedJson(
       {this.connection, this.remoteUid, this.remoteUserAccount});
 
@@ -4307,6 +4510,7 @@ class RtcEngineEventHandlerOnUserAccountUpdatedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUserAccountUpdatedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUserAccountUpdatedJsonToJson(this);
 }
@@ -4326,7 +4530,8 @@ extension RtcEngineEventHandlerOnUserAccountUpdatedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoRenderingTracingResultJson {
+class RtcEngineEventHandlerOnVideoRenderingTracingResultJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoRenderingTracingResultJson(
       {this.connection, this.uid, this.currentEvent, this.tracingInfo});
 
@@ -4346,6 +4551,7 @@ class RtcEngineEventHandlerOnVideoRenderingTracingResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoRenderingTracingResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoRenderingTracingResultJsonToJson(this);
 }
@@ -4365,7 +4571,8 @@ extension RtcEngineEventHandlerOnVideoRenderingTracingResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson {
+class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson(
       {this.stream, this.error});
 
@@ -4379,6 +4586,7 @@ class RtcEngineEventHandlerOnLocalVideoTranscoderErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonToJson(this);
 }
@@ -4398,7 +4606,7 @@ extension RtcEngineEventHandlerOnLocalVideoTranscoderErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnUploadLogResultJson {
+class RtcEngineEventHandlerOnUploadLogResultJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnUploadLogResultJson(
       {this.connection, this.requestId, this.success, this.reason});
 
@@ -4418,6 +4626,7 @@ class RtcEngineEventHandlerOnUploadLogResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnUploadLogResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnUploadLogResultJsonToJson(this);
 }
@@ -4437,7 +4646,8 @@ extension RtcEngineEventHandlerOnUploadLogResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson {
+class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioSubscribeStateChangedJson(
       {this.channel,
       this.uid,
@@ -4464,6 +4674,7 @@ class RtcEngineEventHandlerOnAudioSubscribeStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonToJson(this);
 }
@@ -4483,7 +4694,8 @@ extension RtcEngineEventHandlerOnAudioSubscribeStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson {
+class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoSubscribeStateChangedJson(
       {this.channel,
       this.uid,
@@ -4510,6 +4722,7 @@ class RtcEngineEventHandlerOnVideoSubscribeStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonToJson(this);
 }
@@ -4529,7 +4742,8 @@ extension RtcEngineEventHandlerOnVideoSubscribeStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioPublishStateChangedJson {
+class RtcEngineEventHandlerOnAudioPublishStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioPublishStateChangedJson(
       {this.channel, this.oldState, this.newState, this.elapseSinceLastState});
 
@@ -4549,6 +4763,7 @@ class RtcEngineEventHandlerOnAudioPublishStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioPublishStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioPublishStateChangedJsonToJson(this);
 }
@@ -4568,7 +4783,8 @@ extension RtcEngineEventHandlerOnAudioPublishStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnVideoPublishStateChangedJson {
+class RtcEngineEventHandlerOnVideoPublishStateChangedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnVideoPublishStateChangedJson(
       {this.source,
       this.channel,
@@ -4595,6 +4811,7 @@ class RtcEngineEventHandlerOnVideoPublishStateChangedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnVideoPublishStateChangedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnVideoPublishStateChangedJsonToJson(this);
 }
@@ -4614,7 +4831,8 @@ extension RtcEngineEventHandlerOnVideoPublishStateChangedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson {
+class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson(
       {this.connection,
       this.uid,
@@ -4645,6 +4863,7 @@ class RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonToJson(this);
 }
@@ -4664,7 +4883,8 @@ extension RtcEngineEventHandlerOnTranscodedStreamLayoutInfoJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnAudioMetadataReceivedJson {
+class RtcEngineEventHandlerOnAudioMetadataReceivedJson
+    implements AgoraSerializable {
   const RtcEngineEventHandlerOnAudioMetadataReceivedJson(
       {this.connection, this.uid, this.metadata, this.length});
 
@@ -4684,6 +4904,7 @@ class RtcEngineEventHandlerOnAudioMetadataReceivedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnAudioMetadataReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnAudioMetadataReceivedJsonToJson(this);
 }
@@ -4711,7 +4932,7 @@ extension RtcEngineEventHandlerOnAudioMetadataReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionEventJson {
+class RtcEngineEventHandlerOnExtensionEventJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionEventJson(
       {this.provider, this.extension, this.key, this.value});
 
@@ -4731,6 +4952,7 @@ class RtcEngineEventHandlerOnExtensionEventJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionEventJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionEventJsonToJson(this);
 }
@@ -4750,7 +4972,7 @@ extension RtcEngineEventHandlerOnExtensionEventJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionStartedJson {
+class RtcEngineEventHandlerOnExtensionStartedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionStartedJson(
       {this.provider, this.extension});
 
@@ -4764,6 +4986,7 @@ class RtcEngineEventHandlerOnExtensionStartedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionStartedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionStartedJsonToJson(this);
 }
@@ -4783,7 +5006,7 @@ extension RtcEngineEventHandlerOnExtensionStartedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionStoppedJson {
+class RtcEngineEventHandlerOnExtensionStoppedJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionStoppedJson(
       {this.provider, this.extension});
 
@@ -4797,6 +5020,7 @@ class RtcEngineEventHandlerOnExtensionStoppedJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionStoppedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionStoppedJsonToJson(this);
 }
@@ -4816,7 +5040,7 @@ extension RtcEngineEventHandlerOnExtensionStoppedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnExtensionErrorJson {
+class RtcEngineEventHandlerOnExtensionErrorJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnExtensionErrorJson(
       {this.provider, this.extension, this.error, this.message});
 
@@ -4836,6 +5060,7 @@ class RtcEngineEventHandlerOnExtensionErrorJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnExtensionErrorJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnExtensionErrorJsonToJson(this);
 }
@@ -4855,7 +5080,7 @@ extension RtcEngineEventHandlerOnExtensionErrorJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class RtcEngineEventHandlerOnSetRtmFlagResultJson {
+class RtcEngineEventHandlerOnSetRtmFlagResultJson implements AgoraSerializable {
   const RtcEngineEventHandlerOnSetRtmFlagResultJson(
       {this.connection, this.code});
 
@@ -4869,6 +5094,7 @@ class RtcEngineEventHandlerOnSetRtmFlagResultJson {
           Map<String, dynamic> json) =>
       _$RtcEngineEventHandlerOnSetRtmFlagResultJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$RtcEngineEventHandlerOnSetRtmFlagResultJsonToJson(this);
 }
@@ -4888,7 +5114,7 @@ extension RtcEngineEventHandlerOnSetRtmFlagResultJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MetadataObserverOnMetadataReceivedJson {
+class MetadataObserverOnMetadataReceivedJson implements AgoraSerializable {
   const MetadataObserverOnMetadataReceivedJson({this.metadata});
 
   @JsonKey(name: 'metadata')
@@ -4898,6 +5124,7 @@ class MetadataObserverOnMetadataReceivedJson {
           Map<String, dynamic> json) =>
       _$MetadataObserverOnMetadataReceivedJsonFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$MetadataObserverOnMetadataReceivedJsonToJson(this);
 }
@@ -4917,7 +5144,8 @@ extension MetadataObserverOnMetadataReceivedJsonBufferExt
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson {
+class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson
+    implements AgoraSerializable {
   const DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson(
       {this.state, this.reason, this.message});
 
@@ -4935,6 +5163,7 @@ class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJson {
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonToJson(
           this);
@@ -4955,7 +5184,8 @@ extension DirectCdnStreamingEventHandlerOnDirectCdnStreamingStateChangedJsonBuff
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson {
+class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson
+    implements AgoraSerializable {
   const DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson(
       {this.stats});
 
@@ -4967,6 +5197,7 @@ class DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJson {
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJsonFromJson(
           json);
 
+  @override
   Map<String, dynamic> toJson() =>
       _$DirectCdnStreamingEventHandlerOnDirectCdnStreamingStatsJsonToJson(this);
 }

--- a/lib/src/impl/agora_music_content_center_impl_json.dart
+++ b/lib/src/impl/agora_music_content_center_impl_json.dart
@@ -1,9 +1,10 @@
+import '/src/_serializable.dart';
 import '/src/agora_music_content_center.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'agora_music_content_center_impl_json.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class MusicCollectionJson {
+class MusicCollectionJson implements AgoraSerializable {
   /// @nodoc
   MusicCollectionJson(
       {required this.count,
@@ -32,5 +33,6 @@ class MusicCollectionJson {
       _$MusicCollectionJsonFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$MusicCollectionJsonToJson(this);
 }

--- a/lib/src/impl/json_converters.dart
+++ b/lib/src/impl/json_converters.dart
@@ -1,3 +1,4 @@
+import '/src/_serializable.dart';
 import '/src/agora_media_base.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -36,7 +37,7 @@ class _VideoFrameMetaInfoInternal implements VideoFrameMetaInfo {
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
-class _VideoFrameMetaInfoInternalJson {
+class _VideoFrameMetaInfoInternalJson implements AgoraSerializable {
   // ignore: non_constant_identifier_names
   const _VideoFrameMetaInfoInternalJson({this.KEY_FACE_CAPTURE});
   @JsonKey(name: 'KEY_FACE_CAPTURE')
@@ -49,6 +50,7 @@ class _VideoFrameMetaInfoInternalJson {
       _$VideoFrameMetaInfoInternalJsonFromJson(json);
 
   /// @nodoc
+  @override
   Map<String, dynamic> toJson() => _$VideoFrameMetaInfoInternalJsonToJson(this);
 }
 

--- a/tool/terra/renderers/api_interface_renderer.ts
+++ b/tool/terra/renderers/api_interface_renderer.ts
@@ -77,6 +77,7 @@ export default function ApiInterfaceRenderer(
       }) != undefined;
 
     let content = _trim(`
+        import '/src/_serializable.dart';
         import '/src/binding_forward_export.dart';
         ${
           isNeedImportGDartFile ? `part '${dartFileName(cxxFile)}.g.dart';` : ""

--- a/tool/terra/renderers/callapi_impl_renderer.ts
+++ b/tool/terra/renderers/callapi_impl_renderer.ts
@@ -335,6 +335,7 @@ ${defaultDartHeader}
 
 ${defaultIgnoreForFile}
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'call_api_impl_params_json.g.dart';
 

--- a/tool/terra/renderers/event_handler_impl_params_json_renderer.ts
+++ b/tool/terra/renderers/event_handler_impl_params_json_renderer.ts
@@ -62,6 +62,7 @@ ${defaultDartHeader}
 
 ${defaultIgnoreForFile}, prefer_is_empty
 
+import '/src/_serializable.dart';
 import '/src/binding_forward_export.dart';
 part 'event_handler_param_json.g.dart';
 

--- a/tool/terra/renderers/utils.ts
+++ b/tool/terra/renderers/utils.ts
@@ -148,7 +148,7 @@ export function renderJsonSerializable(
 
   let output = `
   @JsonSerializable(explicitToJson: true, includeIfNull: false)
-  class ${jsonClassName} {
+  class ${jsonClassName} implements AgoraSerializable {
     const ${jsonClassName}(
       ${initializeBlock}
     );
@@ -192,6 +192,7 @@ export function renderJsonSerializable(
 
     factory ${jsonClassName}.fromJson(Map<String, dynamic> json) => _$${jsonClassName}FromJson(json);
 
+    @override
     Map<String, dynamic> toJson() => _$${jsonClassName}ToJson(this);
   }
   `;


### PR DESCRIPTION
...so class instances will be shown as `Type(a: xx, b: yy)` instead of `Instance 'Type'` when parsed by readables (e.g. console).