### PR TITLE
fix: Undefined name 'platformViewRegistry'. (#2273)

### DIFF
--- a/lib/src/impl/platform/web/global_video_view_controller_platform_web.dart
+++ b/lib/src/impl/platform/web/global_video_view_controller_platform_web.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:ui' as ui;
+import 'dart:ui_web' as ui;
 
 import '/agora_rtc_engine.dart';
 import '/src/impl/platform/global_video_view_controller_platform.dart';
@@ -49,7 +49,6 @@ class GlobalVideoViewControllerWeb extends GlobalVideoViewControllerPlatfrom {
   GlobalVideoViewControllerWeb(
       IrisMethodChannel irisMethodChannel, RtcEngine rtcEngine)
       : super(irisMethodChannel, rtcEngine) {
-    // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory(_platformRendererViewType,
         (int viewId) {
       final view = _View(viewId);


### PR DESCRIPTION
The ui.platformViewRegistry (currently deprecated) will be removed on the next flutter stable release.

Which throws:
`Error: Undefined name 'platformViewRegistry'.`

The solution is to use `dart:ui_web` instead of `dart:ui`, both available in flutter.