### PR TITLE
revert: "fix: Undefined name 'platformViewRegistry'."

### DIFF
--- a/lib/src/impl/platform/web/global_video_view_controller_platform_web.dart
+++ b/lib/src/impl/platform/web/global_video_view_controller_platform_web.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:ui_web' as ui;
+import 'dart:ui' as ui;
 
 import '/agora_rtc_engine.dart';
 import '/src/impl/platform/global_video_view_controller_platform.dart';
@@ -49,6 +49,7 @@ class GlobalVideoViewControllerWeb extends GlobalVideoViewControllerPlatfrom {
   GlobalVideoViewControllerWeb(
       IrisMethodChannel irisMethodChannel, RtcEngine rtcEngine)
       : super(irisMethodChannel, rtcEngine) {
+    // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory(_platformRendererViewType,
         (int viewId) {
       final view = _View(viewId);


### PR DESCRIPTION
revert AgoraIO-Extensions/Agora-Flutter-SDK#2273

@arthurbcd 

I've investigated the test failures and discovered a complex situation:
- Initially, when running tests on the external PR, only the base branch was checked out (not including the commit in question: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/14608607680/job/40982332098). This led to a false positive in our test results.

- Further testing revealed multiple test failures on the main branch. To address this, I attempted to:
  - First, pin the minimum Flutter SDK version to 3.13.0 (which includes the ui-web fix https://github.com/flutter/engine/commit/f37e78ca2d089e62924b9141887965bfa1204e8e)
  - However, this still resulted in numerous test failures
 
- Given these issues, I've decided to:
  - Revert the problematic commit for now
  - Create a new issue to track this problem and work on a proper solution