### PR TITLE
fix: eliminate video playback flicker during resolution changes

### DIFF
--- a/android/src/main/cpp/iris_rtc_rendering_android.cc
+++ b/android/src/main/cpp/iris_rtc_rendering_android.cc
@@ -701,7 +701,6 @@ class NativeTextureRenderer final
     env->DeleteLocalRef(j_caller_class);
 
     native_windows_ = ANativeWindow_fromSurface(env, surface_jni);
-    gl_context_ = std::make_shared<GLContext>(native_windows_);
 
     IrisRtcVideoFrameConfig config;
     config.uid = uid;
@@ -739,6 +738,13 @@ class NativeTextureRenderer final
       NotifySizeChangeCallback(video_frame->width, video_frame->height);
       width_ = video_frame->width;
       height_ = video_frame->height;
+
+      rendering_op_.reset();
+      gl_context_.reset();
+    }
+
+    if (!gl_context_) {
+      gl_context_ = std::make_shared<GLContext>(native_windows_);
     }
 
     if (!gl_context_->SetupSurface(native_windows_)) {


### PR DESCRIPTION
https://developer.android.com/reference/android/graphics/SurfaceTexture#setDefaultBufferSize(int,%20int)
> For OpenGL ES, the EGLSurface should be destroyed (via eglDestroySurface), made not-current (via eglMakeCurrent), and then recreated (via eglCreateWindowSurface) to ensure that the new default size has taken effect.

https://blog.csdn.net/wzw88486969/article/details/138485679