### PR TITLE
feat: add custom background color when using flutter texturing

### DIFF
--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -8,7 +8,7 @@ import '/src/render/agora_video_view.dart';
 import '/src/render/video_view_controller.dart';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' show Colors;
+import 'package:flutter/material.dart' show Color, Colors;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -398,10 +398,17 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
     });
   }
 
-  Widget _applyRenderMode(RenderModeType renderMode, Widget child) {
+  Widget _applyRenderMode(
+    RenderModeType renderMode,
+    Widget child, {
+    int? backgroundColor,
+  }) {
     if (renderMode == RenderModeType.renderModeFit) {
+      final color = backgroundColor != null
+          ? Color(backgroundColor & 0xFFFFFFFF)
+          : Colors.black;
       return Container(
-        color: Colors.black,
+        color: color,
         constraints: const BoxConstraints.expand(),
         child: FittedBox(
           fit: BoxFit.contain,
@@ -481,7 +488,11 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
             controller.canvas.renderMode ?? RenderModeType.renderModeHidden;
 
         if (controller.shouldHandlerRenderMode) {
-          result = _applyRenderMode(renderMode, result);
+          result = _applyRenderMode(
+            renderMode,
+            result,
+            backgroundColor: controller.canvas.backgroundColor,
+          );
           VideoMirrorModeType mirrorMode;
           if (controller.isLocalUid) {
             mirrorMode = controller.canvas.mirrorMode ??
@@ -497,7 +508,11 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
           result = _applyMirrorMode(mirrorMode, result, sourceType);
         } else {
           // Fit mode by default if does not need to handle render mode
-          result = _applyRenderMode(RenderModeType.renderModeFit, result);
+          result = _applyRenderMode(
+            RenderModeType.renderModeFit,
+            result,
+            backgroundColor: controller.canvas.backgroundColor,
+          );
         }
       }
     }


### PR DESCRIPTION
We use video streaming but needed the actual background of the video to be customizable so we can avoid having black bars (horizontal or vertical) when showing video in multiple screen formats.