### PR TITLE
Fix: resolve video black flicker on macOS

### DIFF
--- a/shared/darwin/TextureRenderer.mm
+++ b/shared/darwin/TextureRenderer.mm
@@ -198,9 +198,9 @@ public:
   // Use `dispatch_sync` because `copyPixelBuffer` API requires synchronous
   // return.
   dispatch_sync(self.pixelBufferSynchronizationQueue, ^{
-    // No need weak self because it's dispatch_sync.
-    pixelBuffer = self.latestPixelBuffer;
-    self.latestPixelBuffer = nil;
+    if (self.latestPixelBuffer) {
+        pixelBuffer = CVPixelBufferRetain(self.latestPixelBuffer);
+    }
   });
   return pixelBuffer;
 }


### PR DESCRIPTION
This PR fixes a critical UI issue where the video player would occasionally flicker black during playback on macOS. 

References **Internal Ticket**: CSP-39127