### PR TITLE
Fix Apple SPM Agora SDK versions

### DIFF
--- a/ios/agora_rtc_engine/Package.swift
+++ b/ios/agora_rtc_engine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "agora-rtc-engine", targets: ["agora_rtc_engine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", .upToNextMajor(from: "4.6.2"))
+        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", exact: "4.6.2")
     ],
     targets: [
         .target(

--- a/ios/agora_rtc_engine/Package.swift
+++ b/ios/agora_rtc_engine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "agora-rtc-engine", targets: ["agora_rtc_engine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", .upToNextMajor(from: "4.5.2"))
+        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", .upToNextMajor(from: "4.6.2"))
     ],
     targets: [
         .target(
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS-4.5.2-build.1.zip",
-            checksum: "d5daaf4ef5a773c8710ac45fb72cc72b5a7757e3d63e3d58ced38fd9368de05e"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS2-4.6.2-build.1.zip",
+            checksum: "eba8f9fc5b3d93d9d083d0c3f16e6c98fcd993e49989fb851e6df2941ca29825"
         )
     ]
 )

--- a/macos/agora_rtc_engine/Package.swift
+++ b/macos/agora_rtc_engine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "agora-rtc-engine", targets: ["agora_rtc_engine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_macOS.git", .upToNextMajor(from: "4.5.2")),
+        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_macOS.git", .upToNextMajor(from: "4.6.2")),
     ],
     targets: [
         .target(
@@ -30,8 +30,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS-4.5.2-build.2.zip",
-            checksum: "2993bdaaa96a3e41a49cc830ccf98d58d099d3beb14f5d0c820540c0619049a7"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS2-4.6.2-build.1.zip",
+            checksum: "dbfe2db86b0cb2c1012202212248bd6588173020c357dc13fc5a6dcf0a7b97cf"
         )
     ]
 )

--- a/macos/agora_rtc_engine/Package.swift
+++ b/macos/agora_rtc_engine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "agora-rtc-engine", targets: ["agora_rtc_engine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_macOS.git", .upToNextMajor(from: "4.6.2")),
+        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_macOS.git", exact: "4.6.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- align iOS Package.swift with the 4.6.2 native SDK and AgoraIrisRTC_iOS2 wrapper used by the podspec
- align macOS Package.swift with the 4.6.2 native SDK and AgoraIrisRTC_macOS2 wrapper used by the podspec
- update binary target checksums for both wrapper archives

Fixes #2569.

## Validation
- swift package dump-package in ios/agora_rtc_engine
- swift package dump-package in macos/agora_rtc_engine
- computed checksums with swift package compute-checksum for the iOS and macOS wrapper ZIPs