### PR TITLE
fix: unblock release dependency update workflow

### DIFF
--- a/.github/workflows/run_update_deps.yml
+++ b/.github/workflows/run_update_deps.yml
@@ -175,7 +175,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
-          branch: dev/${{ steps.prepare_target_branch.outputs.final_target_branch }}
+          branch: ${{ steps.prepare_target_branch.outputs.final_target_branch }}-dep-update
           base: ${{ steps.prepare_target_branch.outputs.final_target_branch }}
           delete-branch: true
           draft: false

--- a/tool/terra/prepare.sh
+++ b/tool/terra/prepare.sh
@@ -12,6 +12,11 @@ rm -rf yarn.lock
 echo "nodeLinker: node-modules" >> .yarnrc.yml
 echo "enableImmutableInstalls: false" >> .yarnrc.yml
 yarn set version berry
+cat >> .yarnrc.yml <<'EOF'
+approvedGitRepositories:
+  - "ssh://git@github.com/AgoraIO-Extensions/terra.git"
+  - "ssh://git@github.com/AgoraIO-Extensions/terra_shared_configs.git"
+EOF
 yarn
 
 popd


### PR DESCRIPTION
## Summary
- allow Yarn 4 to install Terra git dependencies during `tool/terra/prepare.sh`
- change generated dependency update PR branch to `${{ steps.prepare_target_branch.outputs.final_target_branch }}-dep-update`

## Verification
- stubbed `tool/terra/prepare.sh` run confirms generated `.yarnrc.yml` includes both `approvedGitRepositories` entries
- `git diff --check`

Note: a full local `corepack enable && bash tool/terra/prepare.sh` passed the previous YN0080 allowlist point, then stalled while fetching real git dependencies, so it was interrupted and generated ignored artifacts were cleaned.