### PR TITLE
feat(web): migrate web bindings to dart:js_interop for WebAssembly (dart2wasm) support

### DIFF
--- a/lib/src/impl/agora_pip_controller_impl.dart
+++ b/lib/src/impl/agora_pip_controller_impl.dart
@@ -1,3 +1,3 @@
 export '/src/impl/platform/agora_pip_controller_expect.dart'
     if (dart.library.io) '/src/impl/platform/io/agora_pip_controller_actual_io.dart'
-    if (dart.library.js) '/src/impl/platform/web/agora_pip_controller_actual_web.dart';
+    if (dart.library.js_interop) '/src/impl/platform/web/agora_pip_controller_actual_web.dart';

--- a/lib/src/impl/platform/global_video_view_controller.dart
+++ b/lib/src/impl/platform/global_video_view_controller.dart
@@ -1,5 +1,5 @@
 export 'global_video_view_controller_expect.dart'
     if (dart.library.io) 'io/global_video_view_controller_actual_io.dart'
-    if (dart.library.js) 'web/global_video_view_controller_actual_web.dart';
+    if (dart.library.js_interop) 'web/global_video_view_controller_actual_web.dart';
 
 export 'global_video_view_controller_platform.dart';

--- a/lib/src/impl/platform/io/native_iris_api_engine_bindings.dart
+++ b/lib/src/impl/platform/io/native_iris_api_engine_bindings.dart
@@ -530,7 +530,7 @@ abstract class IrisLogLevel {
   static const int LOG_LEVEL_OFF = 6;
 }
 
-class EventParam extends ffi.Struct {
+final class EventParam extends ffi.Struct {
   external ffi.Pointer<ffi.Int8> event;
 
   external ffi.Pointer<ffi.Int8> data;
@@ -548,7 +548,7 @@ class EventParam extends ffi.Struct {
   external int buffer_count;
 }
 
-class IrisCEventHandler extends ffi.Struct {
+final class IrisCEventHandler extends ffi.Struct {
   external Func_Event OnEvent;
 }
 
@@ -560,7 +560,7 @@ typedef Func_Event = ffi
 ///
 /// NOTE: If the agora::media::base::VideoFrame is updated, make sure this struct be up to date.
 /// TODO(littlegnal): maybe we can use terra to generate the C projection.
-class IrisCVideoFrame extends ffi.Struct {
+final class IrisCVideoFrame extends ffi.Struct {
   /// The agora::media::base::VideoFrame.type, but convert it to int type
   @ffi.Int32()
   external int type;
@@ -606,7 +606,7 @@ class IrisCVideoFrame extends ffi.Struct {
   external ffi.Pointer<ffi.Uint8> alphaBuffer;
 }
 
-class IrisRtcVideoFrameConfig extends ffi.Struct {
+final class IrisRtcVideoFrameConfig extends ffi.Struct {
   /// int value of agora::rtc::VIDEO_SOURCE_TYPE
   @ffi.Int32()
   external int video_source_type;
@@ -653,7 +653,7 @@ abstract class IRIS_VIDEO_PROCESS_ERR {
   static const int ERR_FRAM_TYPE_NOT_MATCHING = 6;
 }
 
-class IrisVideoFrameBufferConfig extends ffi.Struct {
+final class IrisVideoFrameBufferConfig extends ffi.Struct {
   @ffi.Int32()
   external int type;
 
@@ -691,7 +691,7 @@ abstract class IrisVideoSourceType {
   static const int kVideoSourceTypeUnknown = 100;
 }
 
-class IrisCVideoFrameBuffer extends ffi.Struct {
+final class IrisCVideoFrameBuffer extends ffi.Struct {
   @ffi.Int32()
   external int type;
 
@@ -713,7 +713,7 @@ typedef Func_VideoFrame = ffi.Pointer<
         ffi.Void Function(ffi.Pointer<IrisVideoFrame>,
             ffi.Pointer<IrisVideoFrameBufferConfig>, ffi.Int32)>>;
 
-class IrisVideoFrame extends ffi.Struct {
+final class IrisVideoFrame extends ffi.Struct {
   @ffi.Int32()
   external int type;
 

--- a/lib/src/impl/platform/platform_bindings_provider.dart
+++ b/lib/src/impl/platform/platform_bindings_provider.dart
@@ -1,3 +1,3 @@
 export 'platform_bindings_provider_expect.dart'
     if (dart.library.io) 'io/platform_bindings_provider_actual_io.dart'
-    if (dart.library.js) 'web/platform_bindings_provider_actual_web.dart';
+    if (dart.library.js_interop) 'web/platform_bindings_provider_actual_web.dart';

--- a/lib/src/impl/platform/web/iris_web_rtc_bindings_js.dart
+++ b/lib/src/impl/platform/web/iris_web_rtc_bindings_js.dart
@@ -1,20 +1,16 @@
-@JS()
-library iris_web_rtc;
+import 'dart:js_interop';
 
 import 'package:iris_method_channel/iris_method_channel_bindings_web.dart';
-import 'package:js/js.dart';
 
 @JS('IrisWebRtc.initIrisRtc')
 external void initIrisRtc(
     IrisApiEngine irisApiEngine, InitIrisRtcOptions? options);
 
-@JS('InitIrisRtcOptions')
-@anonymous
-class InitIrisRtcOptions {
-  // Must have an unnamed factory constructor with named arguments.
-  external factory InitIrisRtcOptions(
-      {Object? agoraRTC, Object? irisRtcEngine});
+extension type InitIrisRtcOptions._(JSObject _) implements JSObject {
+  // An external factory with only named arguments creates a JS object
+  // literal (the `dart:js_interop` equivalent of `@anonymous`).
+  external factory InitIrisRtcOptions({JSAny? agoraRTC, JSAny? irisRtcEngine});
 
-  external Object get agoraRTC;
-  external Object get irisRtcEngine;
+  external JSAny? get agoraRTC;
+  external JSAny? get irisRtcEngine;
 }

--- a/lib/src/impl/platform/web/js_iris_api_engine_binding_delegate.dart
+++ b/lib/src/impl/platform/web/js_iris_api_engine_binding_delegate.dart
@@ -23,7 +23,7 @@ class IrisApiEngineBindingsDelegateJS
     assert(() {
       if (args.isNotEmpty) {
         final arg = args[0].provide(irisApiEngineHandle)();
-        options = InitIrisRtcOptions(irisRtcEngine: arg);
+        options = InitIrisRtcOptions(irisRtcEngine: arg as JSAny?);
       }
 
       return true;
@@ -54,21 +54,23 @@ class IrisApiEngineBindingsDelegateJS
   ) async {
     final nApiEnginePtr = apiEnginePtr() as js.IrisApiEngine;
 
-    List<Object> buffer = [];
-    List<int> lenOfBuffer = [];
+    // The binding's array members are `JSArray` (required for dart2wasm,
+    // where Dart lists are not JS arrays), so convert each element here.
+    final buffer = <JSAny?>[];
+    final lenOfBuffer = <JSNumber>[];
     int bufferCount = 0;
     if (methodCall.buffers != null) {
       bufferCount += methodCall.buffers!.length;
       for (final rb in methodCall.buffers!) {
-        buffer.add(rb);
-        lenOfBuffer.add(rb.length);
+        buffer.add(rb.toJS);
+        lenOfBuffer.add(rb.length.toJS);
       }
     }
     if (methodCall.rawBufferParams != null) {
       bufferCount += methodCall.rawBufferParams!.length;
       for (final rb in methodCall.rawBufferParams!) {
-        buffer.add(rb.intPtr());
-        lenOfBuffer.add(rb.length);
+        buffer.add(rb.intPtr() as JSAny?);
+        lenOfBuffer.add(rb.length.toJS);
       }
     }
 
@@ -77,8 +79,8 @@ class IrisApiEngineBindingsDelegateJS
       data: methodCall.params,
       data_size: methodCall.params.length,
       result: '',
-      buffer: buffer,
-      length: lenOfBuffer,
+      buffer: buffer.toJS,
+      length: lenOfBuffer.toJS,
       buffer_count: bufferCount,
     );
 
@@ -87,11 +89,8 @@ class IrisApiEngineBindingsDelegateJS
       return CallApiResult(irisReturnCode: 0, data: const {'result': 0});
     }
 
-    final jsPromise = (js.callIrisApi(nApiEnginePtr, nParam) as JSAny).dartify()
-        as Future<dynamic>;
-
-    final jsResult = await jsPromise;
-    final js.CallIrisApiResult irisApiResult = jsResult as js.CallIrisApiResult;
+    final js.CallIrisApiResult irisApiResult =
+        await js.callIrisApi(nApiEnginePtr, nParam).toDart;
 
     return irisApiResult.toCallApiResult();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,10 @@ version: 6.6.3
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/tree/main
 environment:
-  sdk: '>=2.17.0 <4.0.0'
-  flutter: '>=3.7.0'
+  # dart:js_interop extension types (wasm-compatible web bindings) require
+  # Dart >= 3.3.
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 dependencies:
   flutter:
     sdk: flutter
@@ -17,7 +19,12 @@ dependencies:
   ffi: ^1.1.2
   async: ^2.11.0
   meta: ^1.7.0
-  iris_method_channel: ^2.2.4
+  # workplacearcade fork of iris_method_channel 2.2.5 with dart:js_interop
+  # (wasm-compatible) web bindings.
+  iris_method_channel:
+    git:
+      url: https://github.com/workplacearcade/iris_method_channel_flutter.git
+      ref: wasm-support-2.2.5
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:


### PR DESCRIPTION
## Problem

`flutter build web --wasm` builds compile successfully but Agora is broken at runtime: the platform implementation is selected via conditional imports of the form

```dart
export 'platform_bindings_provider_expect.dart'
    if (dart.library.io) 'io/platform_bindings_provider_actual_io.dart'
    if (dart.library.js) 'web/platform_bindings_provider_actual_web.dart';
```

and under dart2wasm **both** `dart.library.io` and `dart.library.js` are false (wasm exposes `dart.library.js_interop` instead), so the stub is exported and `createAgoraRtcEngine()` throws `UnimplementedError: Unimplemented createPlatformBindingsProvider` — every video/audio session fails in a wasm build. Since it's a silent wrong-import selection rather than a compile error, apps typically discover it only in production.

## Changes (web-only Dart; no native code touched)

- Conditional imports `dart.library.js` → `dart.library.js_interop` (true under both dart2js and dart2wasm) in `platform_bindings_provider.dart`, `global_video_view_controller.dart`, and `agora_pip_controller_impl.dart`. One web implementation then serves both compilers, including the dart2js fallback that `--wasm` builds ship for non-wasmGC browsers.
- `web/iris_web_rtc_bindings_js.dart`: legacy `package:js` `@JS()`/`@anonymous` class → `dart:js_interop` extension type with an object-literal factory (`package:js` is unavailable under dart2wasm).
- `web/js_iris_api_engine_binding_delegate.dart`: adapted to the migrated iris_method_channel bindings — `EventParam` buffers built as `JSArray` (`Uint8List.toJS` / `JSNumber`; raw handle objects cast to `JSAny`), and `callIrisApi` awaited via `JSPromise.toDart` instead of the `dartify()`-Promise cast (which doesn't work under dart2wasm).
- `pubspec.yaml`: SDK floor `>=3.3.0` (`dart:js_interop` extension types); ffigen-generated `ffi.Struct` subclasses gain `final` per Dart 3 class modifiers (io-only, no behavior change).

The remaining web files (`global_video_view_controller_platform_web.dart`, etc.) already use `dart:js_interop`/`package:web` and are untouched.

## Why draft — depends on the iris_method_channel companion PR

This change requires the matching web-bindings migration in iris_method_channel: **AgoraIO-Extensions/iris_method_channel_flutter#132**. Until that lands, this PR's `pubspec.yaml` temporarily points `iris_method_channel` at our fork branch carrying that exact patch (so CI and consumers can build/verify today):

```yaml
  iris_method_channel:
    git:
      url: https://github.com/workplacearcade/iris_method_channel_flutter.git
      ref: wasm-support-2.2.5
```

**Once #132 is accepted and released on pub.dev, we will update this PR's `pubspec.yaml` to the official `iris_method_channel` release** (e.g. `^2.3.0`) and mark the PR ready for review.

## Testing

- `dart analyze lib` clean (errors/warnings).
- End-to-end smoke test in a production Flutter app (this branch + iris-web-rtc 0.8.1, headless Chrome with fake media devices): under **both** the wasm and dart2js runtimes, `createAgoraRtcEngine` → `initialize` → `registerEventHandler` → `enableAudio` → `joinChannel` succeed and the JS→Dart event path delivers typed events (e.g. `onError errJoinChannelRejected` for an intentionally empty token). dart2js behavior is unchanged.