### PR TITLE
fix(ios): convert NV12 textures with VideoToolbox

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -36,6 +36,8 @@
 		<string>audio</string>
 		<string>processing</string>
 	</array>
+    <key>FLTEnableImpeller</key>
+    <false/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
   s.platform = :ios, '9.0'
   s.swift_version = '5.0'
   s.libraries = 'stdc++'
+  s.frameworks = 'VideoToolbox'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/agora_rtc_engine/Package.swift
+++ b/ios/agora_rtc_engine/Package.swift
@@ -23,6 +23,9 @@ let package = Package(
             ],
             cSettings: [
                 .headerSearchPath("include/agora_rtc_engine")
+            ],
+            linkerSettings: [
+                .linkedFramework("VideoToolbox")
             ]
         ),
         .binaryTarget(

--- a/shared/darwin/AgoraTextureRenderPixelBufferConverter.mm
+++ b/shared/darwin/AgoraTextureRenderPixelBufferConverter.mm
@@ -4,7 +4,7 @@
 #import <VideoToolbox/VideoToolbox.h>
 
 @implementation AgoraTextureRenderPixelBufferConverter {
-  CFTypeRef _pixelTransferSession;
+  VTPixelTransferSessionRef _pixelTransferSession API_AVAILABLE(ios(16.0));
   CVPixelBufferPoolRef _bgraPixelBufferPool;
   size_t _bgraPixelBufferWidth;
   size_t _bgraPixelBufferHeight;
@@ -52,12 +52,12 @@
 }
 
 - (void)dealloc {
-  if (_pixelTransferSession) {
-    if (@available(iOS 16.0, *)) {
-      VTPixelTransferSessionInvalidate(
-          (VTPixelTransferSessionRef)_pixelTransferSession);
+  if (@available(iOS 16.0, *)) {
+    if (_pixelTransferSession) {
+      VTPixelTransferSessionInvalidate(_pixelTransferSession);
+      CFRelease(_pixelTransferSession);
+      _pixelTransferSession = nil;
     }
-    CFRelease(_pixelTransferSession);
   }
   if (_bgraPixelBufferPool) {
     CVPixelBufferPoolRelease(_bgraPixelBufferPool);
@@ -106,8 +106,7 @@
 
   BOOL converted = NO;
   if (@available(iOS 16.0, *)) {
-    VTPixelTransferSessionRef session =
-        (VTPixelTransferSessionRef)_pixelTransferSession;
+    VTPixelTransferSessionRef session = _pixelTransferSession;
     if (!session) {
       OSStatus sessionStatus =
           VTPixelTransferSessionCreate(kCFAllocatorDefault, &session);

--- a/shared/darwin/AgoraTextureRenderPixelBufferConverter.mm
+++ b/shared/darwin/AgoraTextureRenderPixelBufferConverter.mm
@@ -1,8 +1,10 @@
 #import "AgoraTextureRenderPixelBufferConverter.h"
 
 #import <CoreImage/CoreImage.h>
+#import <VideoToolbox/VideoToolbox.h>
 
 @implementation AgoraTextureRenderPixelBufferConverter {
+  CFTypeRef _pixelTransferSession;
   CVPixelBufferPoolRef _bgraPixelBufferPool;
   size_t _bgraPixelBufferWidth;
   size_t _bgraPixelBufferHeight;
@@ -50,6 +52,13 @@
 }
 
 - (void)dealloc {
+  if (_pixelTransferSession) {
+    if (@available(iOS 16.0, *)) {
+      VTPixelTransferSessionInvalidate(
+          (VTPixelTransferSessionRef)_pixelTransferSession);
+    }
+    CFRelease(_pixelTransferSession);
+  }
   if (_bgraPixelBufferPool) {
     CVPixelBufferPoolRelease(_bgraPixelBufferPool);
     _bgraPixelBufferPool = nil;
@@ -85,29 +94,49 @@
   }
 
   if (!_bgraPixelBufferPool) {
-    return CVPixelBufferRetain(sourcePixelBuffer);
+    return nil;
   }
 
   CVPixelBufferRef destPixelBuffer = nil;
   CVReturn status = CVPixelBufferPoolCreatePixelBuffer(
       kCFAllocatorDefault, _bgraPixelBufferPool, &destPixelBuffer);
   if (status != kCVReturnSuccess || !destPixelBuffer) {
-    return CVPixelBufferRetain(sourcePixelBuffer);
+    return nil;
   }
 
-  CIImage *image = [CIImage imageWithCVPixelBuffer:sourcePixelBuffer];
-  if (!image) {
+  BOOL converted = NO;
+  if (@available(iOS 16.0, *)) {
+    VTPixelTransferSessionRef session =
+        (VTPixelTransferSessionRef)_pixelTransferSession;
+    if (!session) {
+      OSStatus sessionStatus =
+          VTPixelTransferSessionCreate(kCFAllocatorDefault, &session);
+      if (sessionStatus != noErr) {
+        CVPixelBufferRelease(destPixelBuffer);
+        return nil;
+      }
+      _pixelTransferSession = session;
+    }
+    OSStatus transferStatus = VTPixelTransferSessionTransferImage(
+        session, sourcePixelBuffer, destPixelBuffer);
+    converted = transferStatus == noErr;
+  } else {
+    CIImage *image = [CIImage imageWithCVPixelBuffer:sourcePixelBuffer];
+    if (image) {
+      CGRect bounds = CGRectMake(0, 0, width, height);
+      [[AgoraTextureRenderPixelBufferConverter sharedConversionContext]
+          render:image
+                     toCVPixelBuffer:destPixelBuffer
+                              bounds:bounds
+                          colorSpace:[AgoraTextureRenderPixelBufferConverter
+                                         sharedRGBColorSpace]];
+      converted = YES;
+    }
+  }
+  if (!converted) {
     CVPixelBufferRelease(destPixelBuffer);
-    return CVPixelBufferRetain(sourcePixelBuffer);
+    return nil;
   }
-
-  CGRect bounds = CGRectMake(0, 0, width, height);
-  [[AgoraTextureRenderPixelBufferConverter sharedConversionContext]
-      render:image
-                         toCVPixelBuffer:destPixelBuffer
-                                  bounds:bounds
-                              colorSpace:[AgoraTextureRenderPixelBufferConverter
-                                             sharedRGBColorSpace]];
   return destPixelBuffer;
 }
 

--- a/shared/darwin/TextureRenderer.mm
+++ b/shared/darwin/TextureRenderer.mm
@@ -94,7 +94,9 @@ public:
     }
 
     __block CVPixelBufferRef previousPixelBuffer = nil;
+#if !defined(TARGET_OS_OSX) || !TARGET_OS_OSX
     __block BOOL didUpdatePixelBuffer = NO;
+#endif
     // Use `dispatch_sync` to avoid unnecessary context switch under common
     // non-contest scenarios;
     // Under rare contest scenarios, it will not block for too long since
@@ -104,29 +106,31 @@ public:
     // to check if the renderer is still valid before accessing its
     // properties.
     dispatch_sync(strongRenderer.pixelBufferSynchronizationQueue, ^{
+      previousPixelBuffer = strongRenderer.latestPixelBuffer;
       // There has been a bug since RTC 4.4.0 that the pixel buffer ref count is not updated correctly,
       // which will cause the flutter engine copy the wrong pixel buffer to the skia texture.
       // So we need to copy the pixel buffer directly to work around this issue for now, after the issue is fixed,
       // we can revert to the original code.
-      CVPixelBufferRef nextPixelBuffer = nil;
 #if defined(TARGET_OS_OSX) && TARGET_OS_OSX
-      nextPixelBuffer =
+      strongRenderer.latestPixelBuffer =
           [AgoraCVPixelBufferUtils copyCVPixelBuffer:pixelBuffer];
 #else
-      nextPixelBuffer =
+      CVPixelBufferRef nextPixelBuffer =
           [strongRenderer.pixelBufferConverter
               copyPixelBufferForFlutter:pixelBuffer];
-#endif
       if (!nextPixelBuffer) {
+        previousPixelBuffer = nil;
         return;
       }
-      previousPixelBuffer = strongRenderer.latestPixelBuffer;
       strongRenderer.latestPixelBuffer = nextPixelBuffer;
       didUpdatePixelBuffer = YES;
+#endif
     });
+#if !defined(TARGET_OS_OSX) || !TARGET_OS_OSX
     if (!didUpdatePixelBuffer) {
       return;
     }
+#endif
     if (previousPixelBuffer) {
       CVPixelBufferRelease(previousPixelBuffer);
     }

--- a/shared/darwin/TextureRenderer.mm
+++ b/shared/darwin/TextureRenderer.mm
@@ -94,6 +94,7 @@ public:
     }
 
     __block CVPixelBufferRef previousPixelBuffer = nil;
+    __block BOOL didUpdatePixelBuffer = NO;
     // Use `dispatch_sync` to avoid unnecessary context switch under common
     // non-contest scenarios;
     // Under rare contest scenarios, it will not block for too long since
@@ -103,20 +104,29 @@ public:
     // to check if the renderer is still valid before accessing its
     // properties.
     dispatch_sync(strongRenderer.pixelBufferSynchronizationQueue, ^{
-      previousPixelBuffer = strongRenderer.latestPixelBuffer;
       // There has been a bug since RTC 4.4.0 that the pixel buffer ref count is not updated correctly,
       // which will cause the flutter engine copy the wrong pixel buffer to the skia texture.
       // So we need to copy the pixel buffer directly to work around this issue for now, after the issue is fixed,
       // we can revert to the original code.
+      CVPixelBufferRef nextPixelBuffer = nil;
 #if defined(TARGET_OS_OSX) && TARGET_OS_OSX
-      strongRenderer.latestPixelBuffer =
+      nextPixelBuffer =
           [AgoraCVPixelBufferUtils copyCVPixelBuffer:pixelBuffer];
 #else
-      strongRenderer.latestPixelBuffer =
+      nextPixelBuffer =
           [strongRenderer.pixelBufferConverter
               copyPixelBufferForFlutter:pixelBuffer];
 #endif
+      if (!nextPixelBuffer) {
+        return;
+      }
+      previousPixelBuffer = strongRenderer.latestPixelBuffer;
+      strongRenderer.latestPixelBuffer = nextPixelBuffer;
+      didUpdatePixelBuffer = YES;
     });
+    if (!didUpdatePixelBuffer) {
+      return;
+    }
     if (previousPixelBuffer) {
       CVPixelBufferRelease(previousPixelBuffer);
     }


### PR DESCRIPTION
## Summary
- use `VTPixelTransferSession` to convert NV12 pixel buffers to BGRA on iOS 16 and later
- retain the Core Image conversion path for earlier iOS versions
- preserve the last valid texture frame when conversion returns `nil` and skip empty Flutter texture notifications
- link VideoToolbox for both CocoaPods and Swift Package Manager

## Validation
- Debug and Release Objective-C++ syntax checks with warnings treated as errors and an iOS 9 deployment target
- `ruby -c ios/agora_rtc_engine.podspec`
- `swift package dump-package --package-path ios/agora_rtc_engine`
- `flutter build ios --debug --no-codesign`
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 flutter build macos --debug`