### PR TITLE
ci: verify iOS Iris SPM linkage on release/6.5

### DIFF
--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -361,6 +361,11 @@ jobs:
               echo "=== Release build settings ==="
               xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -configuration Release -sdk iphoneos -showBuildSettings 2>&1 \
                 | grep -E 'COPY_PHASE_STRIP|DEAD_CODE_STRIPPING|STRIP_STYLE|STRIP_INSTALLED_PRODUCT|STRIP_SWIFT_SYMBOLS|LD_GENERATE_MAP_FILE|LD_MAP_FILE_PATH|OTHER_LDFLAGS' || true
+              echo "=== Archive Iris symbols ==="
+              archive_app="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
+              find "$archive_app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+              nm -gU "$archive_app/Runner" 2>/dev/null \
+                | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
               echo "=== IPA layout and Iris symbols ==="
               ipa="$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)"
               inspect_dir="$(mktemp -d)"

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -284,7 +284,7 @@ jobs:
               echo "=== plugin integration state ==="
               grep -o '"swift_package_manager_enabled"[^}]*}' .flutter-plugins-dependencies || true
               echo "=== Iris dependency lock ==="
-              grep -A8 -B1 '^  iris_method_channel:' ../pubspec.lock || true
+              grep -A8 -B1 '^  iris_method_channel:' pubspec.lock || true
               echo "=== generated Swift package ==="
               sed -n '1,180p' ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift 2>/dev/null || true
               echo "=== source revision ==="
@@ -362,9 +362,9 @@ jobs:
               xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -configuration Release -sdk iphoneos -showBuildSettings 2>&1 \
                 | grep -E 'COPY_PHASE_STRIP|DEAD_CODE_STRIPPING|STRIP_STYLE|STRIP_INSTALLED_PRODUCT|STRIP_SWIFT_SYMBOLS|LD_GENERATE_MAP_FILE|LD_MAP_FILE_PATH|OTHER_LDFLAGS' || true
               echo "=== IPA layout and Iris symbols ==="
-              ipa="build/ios/ipa/$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit | xargs -I{} basename {})"
+              ipa="$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)"
               inspect_dir="$(mktemp -d)"
-              unzip -q "build/ios/ipa/$ipa" -d "$inspect_dir"
+              unzip -q "$ipa" -d "$inspect_dir"
               app="$inspect_dir/Payload/Runner.app"
               find "$app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
               while IFS= read -r -d '' binary; do

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -275,6 +275,24 @@ jobs:
           # install dependencies
           flutter pub get
 
+          if [ "$platform" == "ios" ]; then
+            mkdir -p ../output
+            {
+              echo "=== Flutter diagnostics ==="
+              flutter --version
+              flutter config --list
+              echo "=== plugin integration state ==="
+              grep -o '"swift_package_manager_enabled"[^}]*}' .flutter-plugins-dependencies || true
+              echo "=== Iris dependency lock ==="
+              grep -A8 -B1 '^  iris_method_channel:' ../pubspec.lock || true
+              echo "=== generated Swift package ==="
+              sed -n '1,180p' ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift 2>/dev/null || true
+              echo "=== source revision ==="
+              git -C .. rev-parse HEAD
+              git -C .. status --short
+            } | tee ../output/ios-build-diagnostics.txt
+          fi
+
           # prepare build command, android: apk, ios: ipa, macos: macos, windows: (empty), web: web
           build_command=""
                     
@@ -337,6 +355,28 @@ jobs:
 
           # run build command
           $build_command $build_options $build_arguments
+
+          if [ "$platform" == "ios" ]; then
+            {
+              echo "=== Release build settings ==="
+              xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -configuration Release -sdk iphoneos -showBuildSettings 2>&1 \
+                | grep -E 'COPY_PHASE_STRIP|DEAD_CODE_STRIPPING|STRIP_STYLE|STRIP_INSTALLED_PRODUCT|STRIP_SWIFT_SYMBOLS|LD_GENERATE_MAP_FILE|LD_MAP_FILE_PATH|OTHER_LDFLAGS' || true
+              echo "=== IPA layout and Iris symbols ==="
+              ipa="build/ios/ipa/$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit | xargs -I{} basename {})"
+              inspect_dir="$(mktemp -d)"
+              unzip -q "build/ios/ipa/$ipa" -d "$inspect_dir"
+              app="$inspect_dir/Payload/Runner.app"
+              find "$app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+              while IFS= read -r -d '' binary; do
+                hits=$(nm -gU "$binary" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true)
+                if [ -n "$hits" ]; then
+                  echo "[$binary]"
+                  echo "$hits"
+                fi
+              done < <(find "$app" -type f -perm -111 -print0)
+              rm -rf "$inspect_dir"
+            } | tee -a ../output/ios-build-diagnostics.txt
+          fi
 
           # create output directory if it doesn't exist
           if [ ! -d "../output" ]; then

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -353,6 +353,21 @@ jobs:
           echo "🚀 Command: $build_command $build_options $build_arguments"
           echo "========================================="
 
+          if [ "$platform" == "ios" ]; then
+            flutter build ios --release --no-codesign \
+              --dart-define=TEST_APP_ID="$DEFAULT_BUILD_APP_ID" \
+              --dart-define=TEST_TOKEN= \
+              --dart-define=TEST_CHANNEL_ID=testapi \
+              --dart-define=INTERNAL_TESTING=true
+            {
+              echo "=== Standard Release build Iris symbols ==="
+              standard_app="build/ios/iphoneos/Runner.app"
+              find "$standard_app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+              nm -gU "$standard_app/Runner" 2>/dev/null \
+                | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
+            } | tee -a ../output/ios-build-diagnostics.txt
+          fi
+
           # run build command
           $build_command $build_options $build_arguments
 

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -43,6 +43,11 @@ on:
         type: boolean
         required: false
         default: false
+      iris_method_channel_ref:
+        description: 'Temporary git ref for iris_method_channel matrix builds'
+        type: string
+        required: false
+        default: ''
   workflow_call:
     inputs:
       target_platforms:
@@ -84,6 +89,11 @@ on:
         type: boolean
         required: false
         default: false
+      iris_method_channel_ref:
+        description: 'Temporary git ref for iris_method_channel matrix builds'
+        type: string
+        required: false
+        default: ''
     secrets:
       APP_ID:
         required: true
@@ -266,6 +276,7 @@ jobs:
       - name: Build
         env:
           DEFAULT_BUILD_APP_ID: ${{ secrets.APP_ID }}
+          IRIS_METHOD_CHANNEL_REF: ${{ inputs.iris_method_channel_ref }}
         shell: bash
         working-directory: example
         run: |
@@ -273,6 +284,9 @@ jobs:
           flutter --version && which flutter
 
           # install dependencies
+          if [ -n "$IRIS_METHOD_CHANNEL_REF" ]; then
+            ruby -e 'path = "../pubspec.yaml"; text = File.read(path); ref = ENV.fetch("IRIS_METHOD_CHANNEL_REF"); pattern = /(iris_method_channel:\s+git:\s+url:\s+\S+\s+ref:\s+)\S+/; abort "iris_method_channel ref not found" unless text.match?(pattern); File.write(path, text.sub(pattern, "\\1#{ref}"))'
+          fi
           flutter pub get
 
           if [ "$platform" == "ios" ]; then

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -363,19 +363,40 @@ jobs:
               echo "=== Standard Release build Iris symbols ==="
               standard_app="build/ios/iphoneos/Runner.app"
               find "$standard_app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+              file "$standard_app/Runner"
+              dwarfdump --uuid "$standard_app/Runner"
               nm -gU "$standard_app/Runner" 2>/dev/null \
                 | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
             } | tee -a ../output/ios-build-diagnostics.txt
+            cp "build/ios/iphoneos/Runner.app/Runner" ../output/standard-build-Runner
           fi
 
           # run build command
-          $build_command $build_options $build_arguments
+          if [ "$platform" == "ios" ]; then
+            $build_command $build_options $build_arguments -v 2>&1 \
+              | tee ../output/ios-archive-build.log
+          else
+            $build_command $build_options $build_arguments
+          fi
 
           if [ "$platform" == "ios" ]; then
             {
+              echo "=== Archive link, dSYM, and strip commands ==="
+              grep -E '(^|[[:space:]])(Ld|Strip|GenerateDSYMFile)([[:space:]]|$)|/strip([[:space:]]|$)|xcodebuild.*(-archivePath|archive|-exportArchive)' \
+                ../output/ios-archive-build.log || true
               echo "=== Release build settings ==="
               xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -configuration Release -sdk iphoneos -showBuildSettings 2>&1 \
                 | grep -E 'COPY_PHASE_STRIP|DEAD_CODE_STRIPPING|STRIP_STYLE|STRIP_INSTALLED_PRODUCT|STRIP_SWIFT_SYMBOLS|LD_GENERATE_MAP_FILE|LD_MAP_FILE_PATH|OTHER_LDFLAGS' || true
+              echo "=== All Runner Mach-O files after Archive ==="
+              while IFS= read -r -d '' binary; do
+                if file "$binary" | grep -q 'Mach-O'; then
+                  echo "[$binary]"
+                  ls -l "$binary"
+                  dwarfdump --uuid "$binary" || true
+                  nm -gU "$binary" 2>/dev/null \
+                    | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
+                fi
+              done < <(find build/ios "$HOME/Library/Developer/Xcode/DerivedData" -type f -name Runner -print0 2>/dev/null)
               echo "=== Archive Iris symbols ==="
               archive_app="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
               find "$archive_app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -43,11 +43,6 @@ on:
         type: boolean
         required: false
         default: false
-      iris_method_channel_ref:
-        description: 'Temporary git ref for iris_method_channel matrix builds'
-        type: string
-        required: false
-        default: ''
   workflow_call:
     inputs:
       target_platforms:
@@ -89,11 +84,6 @@ on:
         type: boolean
         required: false
         default: false
-      iris_method_channel_ref:
-        description: 'Temporary git ref for iris_method_channel matrix builds'
-        type: string
-        required: false
-        default: ''
     secrets:
       APP_ID:
         required: true
@@ -276,7 +266,6 @@ jobs:
       - name: Build
         env:
           DEFAULT_BUILD_APP_ID: ${{ secrets.APP_ID }}
-          IRIS_METHOD_CHANNEL_REF: ${{ inputs.iris_method_channel_ref }}
         shell: bash
         working-directory: example
         run: |
@@ -284,9 +273,6 @@ jobs:
           flutter --version && which flutter
 
           # install dependencies
-          if [ -n "$IRIS_METHOD_CHANNEL_REF" ]; then
-            ruby -e 'path = "../pubspec.yaml"; text = File.read(path); ref = ENV.fetch("IRIS_METHOD_CHANNEL_REF"); pattern = /(iris_method_channel:\s+git:\s+url:\s+\S+\s+ref:\s+)\S+/; abort "iris_method_channel ref not found" unless text.match?(pattern); File.write(path, text.sub(pattern, "\\1#{ref}"))'
-          fi
           flutter pub get
 
           if [ "$platform" == "ios" ]; then

--- a/.github/workflows/run_ios_dependency_matrix.yml
+++ b/.github/workflows/run_ios_dependency_matrix.yml
@@ -1,0 +1,45 @@
+name: 'run: iOS dependency matrix'
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to build'
+        type: string
+        required: true
+        default: 'release/6.5'
+      flutter_version:
+        description: 'Flutter version'
+        type: string
+        required: true
+        default: '3.44.4'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: pods-pods
+            disable_swift_package_manager: true
+            iris_method_channel_ref: 2.2.5
+          - name: pods-iris-spm-static
+            disable_swift_package_manager: false
+            iris_method_channel_ref: 2.2.5
+          - name: pods-iris-spm-dynamic
+            disable_swift_package_manager: false
+            iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
+          # Enable after agora_rtc_engine/Package.swift is restored:
+          # - name: spm-spm-dynamic
+          #   disable_swift_package_manager: false
+          #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
+    name: ${{ matrix.name }}
+    uses: ./.github/workflows/run_build_example.yml
+    with:
+      target_platforms: ios
+      target_branch: ${{ inputs.target_branch }}
+      flutter_channel: stable
+      flutter_version: ${{ inputs.flutter_version }}
+      disable_swift_package_manager: ${{ matrix.disable_swift_package_manager }}
+      iris_method_channel_ref: ${{ matrix.iris_method_channel_ref }}
+    secrets: inherit

--- a/.github/workflows/run_ios_dependency_matrix.yml
+++ b/.github/workflows/run_ios_dependency_matrix.yml
@@ -22,17 +22,11 @@ jobs:
         include:
           - name: agora_rtc_engine-cocoapods-iris_method_channel-cocoapods
             disable_swift_package_manager: true
-            iris_method_channel_ref: 2.2.5
-          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-static
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm
             disable_swift_package_manager: false
-            iris_method_channel_ref: 2.2.5
-          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-dynamic
-            disable_swift_package_manager: false
-            iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
           # Enable after agora_rtc_engine/Package.swift is restored:
-          # - name: agora_rtc_engine-spm-iris_method_channel-spm-dynamic
+          # - name: agora_rtc_engine-spm-iris_method_channel-spm
           #   disable_swift_package_manager: false
-          #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
     name: ${{ matrix.name }}
     uses: ./.github/workflows/run_build_example.yml
     with:
@@ -41,5 +35,4 @@ jobs:
       flutter_channel: stable
       flutter_version: ${{ inputs.flutter_version }}
       disable_swift_package_manager: ${{ matrix.disable_swift_package_manager }}
-      iris_method_channel_ref: ${{ matrix.iris_method_channel_ref }}
     secrets: inherit

--- a/.github/workflows/run_ios_dependency_matrix.yml
+++ b/.github/workflows/run_ios_dependency_matrix.yml
@@ -20,17 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: pods-pods
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-cocoapods
             disable_swift_package_manager: true
             iris_method_channel_ref: 2.2.5
-          - name: pods-iris-spm-static
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-static
             disable_swift_package_manager: false
             iris_method_channel_ref: 2.2.5
-          - name: pods-iris-spm-dynamic
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-dynamic
             disable_swift_package_manager: false
             iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
           # Enable after agora_rtc_engine/Package.swift is restored:
-          # - name: spm-spm-dynamic
+          # - name: agora_rtc_engine-spm-iris_method_channel-spm-dynamic
           #   disable_swift_package_manager: false
           #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
     name: ${{ matrix.name }}

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -474,6 +474,95 @@ jobs:
         env:
           IOS_SIMULATOR_SDK_VERSION: 18.0
 
+  ios_dependency_linkage_matrix:
+    name: iOS dependency linkage - ${{ matrix.name }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-cocoapods
+            disable_swift_package_manager: true
+            iris_method_channel_ref: 2.2.5
+            expect_framework: false
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-static
+            disable_swift_package_manager: false
+            iris_method_channel_ref: 2.2.5
+            expect_framework: false
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-dynamic
+            disable_swift_package_manager: false
+            iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
+            expect_framework: true
+          # Enable after agora_rtc_engine/Package.swift is restored:
+          # - name: agora_rtc_engine-spm-iris_method_channel-spm-dynamic
+          #   disable_swift_package_manager: false
+          #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
+          #   expect_framework: true
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.4'
+          cache: true
+      - name: Configure Swift Package Manager
+        run: |
+          if [ "${{ matrix.disable_swift_package_manager }}" = "true" ]; then
+            flutter config --no-enable-swift-package-manager
+          else
+            flutter config --enable-swift-package-manager
+          fi
+          flutter config --list
+      - name: Select iris_method_channel revision
+        env:
+          IRIS_METHOD_CHANNEL_REF: ${{ matrix.iris_method_channel_ref }}
+        run: |
+          ruby -e 'path = "pubspec.yaml"; text = File.read(path); ref = ENV.fetch("IRIS_METHOD_CHANNEL_REF"); pattern = /(iris_method_channel:\s+git:\s+url:\s+\S+\s+ref:\s+)\S+/; abort "iris_method_channel ref not found" unless text.match?(pattern); File.write(path, text.sub(pattern, "\\1#{ref}"))'
+      - name: Resolve dependencies
+        run: flutter pub get
+        working-directory: example
+      - name: Build iOS app without signing
+        run: flutter build ios --release --no-codesign
+        working-directory: example
+      - name: Archive iOS app without signing
+        run: |
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination generic/platform=iOS \
+            -archivePath build/ios/archive/Runner.xcarchive \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            archive
+        working-directory: example
+      - name: Check Iris framework and symbols
+        env:
+          EXPECT_FRAMEWORK: ${{ matrix.expect_framework }}
+        working-directory: example
+        run: |
+          set -euo pipefail
+          app="build/ios/iphoneos/Runner.app"
+          archive_app="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
+          framework="$app/Frameworks/iris-method-channel.framework/iris-method-channel"
+          archive_framework="$archive_app/Frameworks/iris-method-channel.framework/iris-method-channel"
+          echo "=== Runner.app layout ==="
+          find "$app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+          echo "=== Runner symbols ==="
+          nm -gU "$app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
+          echo "=== Archive symbols ==="
+          nm -gU "$archive_app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
+          if [ "$EXPECT_FRAMEWORK" = "true" ]; then
+            test -f "$framework"
+            test -f "$archive_framework"
+            for symbol in Iris_InitDartApiDL Iris_Dispose Iris_OnEvent Iris_RegisterDartPort Iris_UnregisterDartPort; do
+              nm -gU "$framework" | grep -q "_$symbol"
+              nm -gU "$archive_framework" | grep -q "_$symbol"
+            done
+          fi
+
   build_ios_canary:
     name: Build iOS (latest stable canary)
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -475,7 +475,7 @@ jobs:
           IOS_SIMULATOR_SDK_VERSION: 18.0
 
   ios_dependency_linkage_matrix:
-    name: iOS dependency linkage - ${{ matrix.name }}
+    name: iOS dependency linkage - ${{ matrix.name }} (expected ${{ matrix.expected_result }})
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       fail-fast: false
@@ -484,20 +484,24 @@ jobs:
           - name: agora_rtc_engine-cocoapods-iris_method_channel-cocoapods
             disable_swift_package_manager: true
             iris_method_channel_ref: 2.2.5
-            expect_framework: false
+            expected_result: pass
+            symbol_binary: Frameworks/iris_method_channel.framework/iris_method_channel
           - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-static
             disable_swift_package_manager: false
             iris_method_channel_ref: 2.2.5
-            expect_framework: false
+            expected_result: fail
+            symbol_binary: ''
           - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-dynamic
             disable_swift_package_manager: false
             iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
-            expect_framework: true
+            expected_result: pass
+            symbol_binary: Frameworks/iris-method-channel.framework/iris-method-channel
           # Enable after agora_rtc_engine/Package.swift is restored:
           # - name: agora_rtc_engine-spm-iris_method_channel-spm-dynamic
           #   disable_swift_package_manager: false
           #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
-          #   expect_framework: true
+          #   expected_result: pass
+          #   symbol_binary: Frameworks/iris-method-channel.framework/iris-method-channel
     runs-on: macos-latest
     timeout-minutes: 120
     steps:
@@ -538,29 +542,76 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             archive
         working-directory: example
-      - name: Check Iris framework and symbols
+      - name: Verify expected Iris linkage result
         env:
-          EXPECT_FRAMEWORK: ${{ matrix.expect_framework }}
+          EXPECTED_RESULT: ${{ matrix.expected_result }}
+          SYMBOL_BINARY: ${{ matrix.symbol_binary }}
         working-directory: example
         run: |
           set -euo pipefail
           app="build/ios/iphoneos/Runner.app"
           archive_app="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
-          framework="$app/Frameworks/iris-method-channel.framework/iris-method-channel"
-          archive_framework="$archive_app/Frameworks/iris-method-channel.framework/iris-method-channel"
+
+          symbols=(
+            Iris_InitDartApiDL
+            Iris_Dispose
+            Iris_OnEvent
+            Iris_RegisterDartPort
+            Iris_UnregisterDartPort
+          )
+
+          assert_symbols() {
+            local binary="$1"
+            local output
+            test -f "$binary" || {
+              echo "::error::Missing expected binary: $binary"
+              return 1
+            }
+            output="$(nm -gU "$binary")"
+            for symbol in "${symbols[@]}"; do
+              grep -qE "[[:space:]]_$symbol$" <<< "$output" || {
+                echo "::error::$binary is missing _$symbol"
+                return 1
+              }
+            done
+            echo "All expected Iris symbols found in $binary"
+            grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' <<< "$output"
+          }
+
+          find_symbol_owner() {
+            local bundle="$1"
+            local binary
+            for binary in "$bundle/Runner" "$bundle"/Frameworks/*.framework/*; do
+              [ -f "$binary" ] || continue
+              if nm -gU "$binary" 2>/dev/null \
+                | grep -qE 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)'; then
+                echo "$binary"
+                return 0
+              fi
+            done
+            return 1
+          }
+
           echo "=== Runner.app layout ==="
           find "$app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
+          echo "=== Archive layout ==="
+          find "$archive_app/Frameworks" -maxdepth 1 -type d -iname '*iris*' -print 2>/dev/null || true
           echo "=== Runner symbols ==="
           nm -gU "$app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
           echo "=== Archive symbols ==="
           nm -gU "$archive_app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
-          if [ "$EXPECT_FRAMEWORK" = "true" ]; then
-            test -f "$framework"
-            test -f "$archive_framework"
-            for symbol in Iris_InitDartApiDL Iris_Dispose Iris_OnEvent Iris_RegisterDartPort Iris_UnregisterDartPort; do
-              nm -gU "$framework" | grep -q "_$symbol"
-              nm -gU "$archive_framework" | grep -q "_$symbol"
-            done
+
+          if [ "$EXPECTED_RESULT" = "pass" ]; then
+            assert_symbols "$app/$SYMBOL_BINARY"
+            assert_symbols "$archive_app/$SYMBOL_BINARY"
+            echo "::notice::Expected passing linkage verified before and after Archive"
+          else
+            assert_symbols "$app/Runner"
+            if owner="$(find_symbol_owner "$archive_app")"; then
+              echo "::error::Expected the known SPM static failure, but Archive still exports Iris symbols from $owner"
+              exit 1
+            fi
+            echo "::notice::Expected SPM static failure reproduced: Archive removed the Iris symbols"
           fi
 
   build_ios_canary:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -581,7 +581,7 @@ jobs:
           nm -gU "$archive_app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
           echo "=== Current project linkage configuration ==="
           grep -n 'use_frameworks!' ios/Podfile || true
-          package_swift="$(find ios/Flutter/ephemeral/Packages -path '*iris_method_channel*/Package.swift' -print -quit 2>/dev/null || true)"
+          package_swift="$(find -L ios/Flutter/ephemeral/Packages -path '*iris_method_channel*/Package.swift' -print -quit 2>/dev/null || true)"
           if [ -n "$package_swift" ]; then
             if grep -q 'type:[[:space:]]*\.dynamic' "$package_swift"; then
               echo "iris_method_channel SwiftPM product type: dynamic"

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -475,7 +475,7 @@ jobs:
           IOS_SIMULATOR_SDK_VERSION: 18.0
 
   ios_dependency_linkage_matrix:
-    name: iOS dependency linkage - ${{ matrix.name }} (expected ${{ matrix.expected_result }})
+    name: iOS dependency linkage - ${{ matrix.name }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       fail-fast: false
@@ -483,25 +483,11 @@ jobs:
         include:
           - name: agora_rtc_engine-cocoapods-iris_method_channel-cocoapods
             disable_swift_package_manager: true
-            iris_method_channel_ref: 2.2.5
-            expected_result: pass
-            symbol_binary: Frameworks/iris_method_channel.framework/iris_method_channel
-          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-static
+          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm
             disable_swift_package_manager: false
-            iris_method_channel_ref: 2.2.5
-            expected_result: fail
-            symbol_binary: ''
-          - name: agora_rtc_engine-cocoapods-iris_method_channel-spm-dynamic
-            disable_swift_package_manager: false
-            iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
-            expected_result: pass
-            symbol_binary: Frameworks/iris-method-channel.framework/iris-method-channel
           # Enable after agora_rtc_engine/Package.swift is restored:
-          # - name: agora_rtc_engine-spm-iris_method_channel-spm-dynamic
+          # - name: agora_rtc_engine-spm-iris_method_channel-spm
           #   disable_swift_package_manager: false
-          #   iris_method_channel_ref: fix/iris-method-channel-spm-symbol-retain
-          #   expected_result: pass
-          #   symbol_binary: Frameworks/iris-method-channel.framework/iris-method-channel
     runs-on: macos-latest
     timeout-minutes: 120
     steps:
@@ -518,11 +504,6 @@ jobs:
             flutter config --enable-swift-package-manager
           fi
           flutter config --list
-      - name: Select iris_method_channel revision
-        env:
-          IRIS_METHOD_CHANNEL_REF: ${{ matrix.iris_method_channel_ref }}
-        run: |
-          ruby -e 'path = "pubspec.yaml"; text = File.read(path); ref = ENV.fetch("IRIS_METHOD_CHANNEL_REF"); pattern = /(iris_method_channel:\s+git:\s+url:\s+\S+\s+ref:\s+)\S+/; abort "iris_method_channel ref not found" unless text.match?(pattern); File.write(path, text.sub(pattern, "\\1#{ref}"))'
       - name: Resolve dependencies
         run: flutter pub get
         working-directory: example
@@ -542,10 +523,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             archive
         working-directory: example
-      - name: Verify expected Iris linkage result
-        env:
-          EXPECTED_RESULT: ${{ matrix.expected_result }}
-          SYMBOL_BINARY: ${{ matrix.symbol_binary }}
+      - name: Verify current iris_method_channel linkage
         working-directory: example
         run: |
           set -euo pipefail
@@ -581,10 +559,11 @@ jobs:
           find_symbol_owner() {
             local bundle="$1"
             local binary
+            local output
             for binary in "$bundle/Runner" "$bundle"/Frameworks/*.framework/*; do
               [ -f "$binary" ] || continue
-              if nm -gU "$binary" 2>/dev/null \
-                | grep -qE 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)'; then
+              output="$(nm -gU "$binary" 2>/dev/null)" || continue
+              if grep -qE '[[:space:]]_Iris_InitDartApiDL$' <<< "$output"; then
                 echo "$binary"
                 return 0
               fi
@@ -600,19 +579,34 @@ jobs:
           nm -gU "$app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
           echo "=== Archive symbols ==="
           nm -gU "$archive_app/Runner" 2>/dev/null | grep -E 'Iris_(InitDartApiDL|Dispose|OnEvent|RegisterDartPort|UnregisterDartPort)' || true
-
-          if [ "$EXPECTED_RESULT" = "pass" ]; then
-            assert_symbols "$app/$SYMBOL_BINARY"
-            assert_symbols "$archive_app/$SYMBOL_BINARY"
-            echo "::notice::Expected passing linkage verified before and after Archive"
-          else
-            assert_symbols "$app/Runner"
-            if owner="$(find_symbol_owner "$archive_app")"; then
-              echo "::error::Expected the known SPM static failure, but Archive still exports Iris symbols from $owner"
-              exit 1
+          echo "=== Current project linkage configuration ==="
+          grep -n 'use_frameworks!' ios/Podfile || true
+          package_swift="$(find ios/Flutter/ephemeral/Packages -path '*iris_method_channel*/Package.swift' -print -quit 2>/dev/null || true)"
+          if [ -n "$package_swift" ]; then
+            if grep -q 'type:[[:space:]]*\.dynamic' "$package_swift"; then
+              echo "iris_method_channel SwiftPM product type: dynamic"
+            elif grep -q 'type:[[:space:]]*\.static' "$package_swift"; then
+              echo "iris_method_channel SwiftPM product type: static"
+            else
+              echo "iris_method_channel SwiftPM product type: automatic"
             fi
-            echo "::notice::Expected SPM static failure reproduced: Archive removed the Iris symbols"
+          else
+            echo "iris_method_channel is not integrated through SwiftPM in this build"
           fi
+
+          app_owner="$(find_symbol_owner "$app")" || {
+            echo "::error::The current PR build does not export Iris_InitDartApiDL from any App-visible binary"
+            exit 1
+          }
+          archive_owner="$(find_symbol_owner "$archive_app")" || {
+            echo "::error::The current PR Archive does not export Iris_InitDartApiDL from any App-visible binary"
+            exit 1
+          }
+
+          assert_symbols "$app_owner"
+          assert_symbols "$archive_owner"
+          echo "::notice::Current PR linkage verified before Archive in $app_owner"
+          echo "::notice::Current PR linkage verified after Archive in $archive_owner"
 
   build_ios_canary:
     name: Build iOS (latest stable canary)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,7 @@ dependencies:
   ffi: '>=2.0.0 <3.0.0'
   async: ^2.11.0
   meta: ^1.7.0
-  iris_method_channel:
-    git:
-      url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
-      ref: fix/iris-method-channel-spm-symbol-retain
+  iris_method_channel: 2.2.5
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   iris_method_channel:
     git:
       url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
-      ref: fix/iris-method-channel-spm-symbol-retain
+      ref: 2.2.5
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   iris_method_channel:
     git:
       url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
-      ref: 2.2.5
+      ref: fix/iris-method-channel-spm-symbol-retain
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: '>=2.0.0 <3.0.0'
   async: ^2.11.0
   meta: ^1.7.0
-  iris_method_channel: 2.2.5
+  iris_method_channel: ^2.2.5
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   ffi: '>=2.0.0 <3.0.0'
   async: ^2.11.0
   meta: ^1.7.0
-  iris_method_channel: ^2.2.5
+  iris_method_channel:
+    git:
+      url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
+      ref: fix/iris-method-channel-spm-symbol-retain
   js: ^0.6.3
   web: '>=0.3.0 <2.0.0'
 dev_dependencies:


### PR DESCRIPTION
## Summary
- switch the example dependency to the Iris SwiftPM symbol-retention branch for validation
- add iOS build/archive symbol diagnostics
- add a CocoaPods/SPM linkage matrix to PR tests
- keep a manual IPA matrix for signed package validation

## Validation
- Flutter 3.44.4
- unsigned `flutter build ios --release --no-codesign`
- unsigned Xcode Archive
- Iris framework and symbol checks for the dynamic SwiftPM case