### PR TITLE
ci: support multi-version example builds with SwiftPM

### DIFF
--- a/.github/workflows/on_pr_internal.yml
+++ b/.github/workflows/on_pr_internal.yml
@@ -16,14 +16,16 @@ jobs:
         id: check_permission_by_secret
         # perform secret check & put boolean result as an output
         shell: bash
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          MY_APP_ID: ${{ secrets.MY_APP_ID }}
         run: |
-          APP_ID="${{ secrets.APP_ID }}"
-          if [ ! -z "${APP_ID}" ]; then
+          if [ -n "$APP_ID" ] && [ -n "$MY_APP_ID" ]; then
             echo "has_permission=1" >> $GITHUB_OUTPUT;
-            echo "secrets.APP_ID is not empty, PR opened by the internal contributors"
+            echo "App ID secrets are available, PR opened by the internal contributors"
           else
             echo "has_permission=-1" >> $GITHUB_OUTPUT;
-            echo "secrets.APP_ID is empty, PR opened by the external contributors"
+            echo "App ID secrets are unavailable, PR opened by the external contributors"
           fi
 
   build_example:
@@ -36,6 +38,7 @@ jobs:
       issue_number: ${{ github.event.pull_request.number }}
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
+      MY_APP_ID: ${{ secrets.MY_APP_ID }}
       BUILD_PROVISION_PROFILE_UUID: ${{ secrets.BUILD_PROVISION_PROFILE_UUID }}
       BUILD_PROVISION_PROFILE_NAME: ${{ secrets.BUILD_PROVISION_PROFILE_NAME }}
       BUILD_PROVISION_PROFILE_TEAMID: ${{ secrets.BUILD_PROVISION_PROFILE_TEAMID }}
@@ -54,4 +57,3 @@ jobs:
     uses: ./.github/workflows/run_test.yml
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
-            

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -31,7 +31,7 @@ on:
         required: false
         default: 'stable'
       flutter_version:
-        description: 'Target Flutter version, e.g. 3.24.5, 3.24.x, commit hash, or leave empty to use the latest release version of specified channel by flutter_version(default)'
+        description: 'Target Flutter version(s), separated by comma, e.g. "3.24.5, 3.44.8"'
         type: string
         required: false
         # we should use the latest stable version for building example later, however, the android build will fail with the latest stable version, so we fixed use the 3.24.5 version here for now
@@ -67,7 +67,7 @@ on:
         required: false
         default: 'stable'
       flutter_version:
-        description: 'Target Flutter version, e.g. 3.24.5, 3.24.x, commit hash, or leave empty to use the latest release version of specified channel by flutter_version(default)'
+        description: 'Target Flutter version(s), separated by comma, e.g. "3.24.5, 3.44.8"'
         type: string
         required: false
         # we should use the latest stable version for building example later, however, the android build will fail with the latest stable version, so we fixed use the 3.24.5 version here for now
@@ -127,35 +127,55 @@ jobs:
           echo "final jsonlized platforms: $platforms"
           echo "platforms=$platforms" >> $GITHUB_OUTPUT
 
+  build-matrix:
+    runs-on: ubuntu-latest
+    needs: split-platforms
+    outputs:
+      include: ${{ steps.build-matrix.outputs.include }}
+    steps:
+      - id: build-matrix
+        env:
+          platforms: ${{ needs.split-platforms.outputs.platforms }}
+          flutter_versions: ${{ inputs.flutter_version }}
+        run: |
+          set -euo pipefail
+
+          versions=$(printf '%s' "$flutter_versions" | sed 's/ //g' | tr ',' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          if [ "$(echo "$versions" | jq 'length')" -eq 0 ]; then
+            echo "::error::At least one Flutter version is required"
+            exit 1
+          fi
+
+          include=$(jq -c -n \
+            --argjson platforms "$platforms" \
+            --argjson versions "$versions" \
+            '
+              {
+                android: "macos-latest",
+                web:     "ubuntu-latest",
+                windows: "windows-latest",
+                ios:     "macos-latest",
+                macos:   "macos-latest"
+              } as $runners
+              | [ $platforms[] as $p
+                  | $versions[] as $v
+                  | { platform: $p,
+                      version: $v,
+                      os: $runners[$p],
+                      primary: ($v == $versions[0]) }
+                  | select(.os != null) ]
+            ')
+
+          echo "final include: $include"
+          echo "include=$include" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ${{ matrix.os }}
-    needs: split-platforms
+    needs: build-matrix
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        platform: ${{ fromJson(needs.split-platforms.outputs.platforms) }}
-        exclude:
-          - os: ubuntu-latest
-            platform: android
-          - os: ubuntu-latest
-            platform: ios
-          - os: ubuntu-latest
-            platform: macos
-          - os: ubuntu-latest
-            platform: windows
-          - os: macos-latest
-            platform: windows
-          - os: macos-latest
-            platform: web
-          - os: windows-latest
-            platform: android
-          - os: windows-latest
-            platform: ios
-          - os: windows-latest
-            platform: macos
-          - os: windows-latest
-            platform: web
+        include: ${{ fromJson(needs.build-matrix.outputs.include) }}
     env:
         platform: ${{ matrix.platform }}
         extra_build_options: ${{ inputs.extra_build_options }}
@@ -247,7 +267,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
-          flutter-version: ${{ inputs.flutter_version }}
+          flutter-version: ${{ matrix.version }}
           cache: true
 
       - name: Build
@@ -479,8 +499,8 @@ jobs:
           # get build_timestamp
           build_timestamp=$(date +%Y%m%d%H%M%S)
 
-          # generate artifact_name
-          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
+          flutter_version_slug="$(printf '%s' "${{ matrix.version }}" | tr -c '[:alnum:].' '-')"
+          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_flutter${flutter_version_slug}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
           echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload build artifacts
@@ -492,6 +512,7 @@ jobs:
 
       - name: Setup download url
         id: setup_output
+        if: ${{ matrix.primary }}
         shell: bash
         run: |
           # see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -183,7 +183,7 @@ jobs:
             --argjson app_ids "$app_ids" \
             '
               {
-                android: "macos-latest",
+                android: "ubuntu-latest",
                 web:     "ubuntu-latest",
                 windows: "windows-latest",
                 ios:     "macos-latest",
@@ -203,7 +203,7 @@ jobs:
           echo "include=$include" >> $GITHUB_OUTPUT
 
   build:
-    name: build (${{ matrix.platform }}, Flutter ${{ matrix.version }}, ${{ matrix.app_id_secret }})
+    name: build (${{ matrix.platform }}, Flutter ${{ matrix.version }}, ${{ matrix.app_id_secret }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-matrix
     strategy:

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -170,6 +170,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          path: agora_rtc_engine
           ref: ${{ inputs.target_branch || github.ref_name }}
           fetch-depth: '1'
           lfs: 'true'
@@ -184,7 +185,7 @@ jobs:
 
       - name: Install compatible Bundler for iOS
         if: ${{ matrix.platform == 'ios' }}
-        working-directory: example/ios
+        working-directory: agora_rtc_engine/example/ios
         run: |
           # Install Bundler 2.7.x which is compatible with fastlane
           gem install bundler:2.7.2
@@ -197,7 +198,7 @@ jobs:
 
       - name: Setup signing key for iOS
         if: ${{ matrix.platform == 'ios' }}
-        working-directory: example/ios
+        working-directory: agora_rtc_engine/example/ios
         env:
           DEFAULT_BUILD_PROVISION_PROFILE_NAME: ${{ secrets.BUILD_PROVISION_PROFILE_NAME }}
           DEFAULT_BUILD_PROVISION_PROFILE_TEAMID: ${{ secrets.BUILD_PROVISION_PROFILE_TEAMID }}
@@ -253,7 +254,7 @@ jobs:
         env:
           DEFAULT_BUILD_APP_ID: ${{ secrets.APP_ID }}
         shell: bash
-        working-directory: example
+        working-directory: agora_rtc_engine/example
         run: |
           # show flutter version
           flutter --version && which flutter
@@ -470,6 +471,7 @@ jobs:
       - name: Generate artifact name
         id: generate_artifact_name
         shell: bash
+        working-directory: agora_rtc_engine
         run: |
           # get pub_version from pubspec.yaml
           pub_version=$(grep 'version: ' pubspec.yaml | sed -e 's,.*: \(.*\),\1,')
@@ -485,7 +487,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.generate_artifact_name.outputs.artifact_name }}
-          path: output
+          path: agora_rtc_engine/output
           if-no-files-found: error
 
       - name: Setup download url

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -195,9 +195,7 @@ jobs:
                   | { platform: $p,
                       version: $v,
                       app_id_secret: $a,
-                      app_id_slug: ($a | ascii_downcase),
-                      os: $runners[$p],
-                      primary: ($v == $versions[0] and $a == $app_ids[0]) }
+                      os: $runners[$p] }
                   | select(.os != null) ]
             ')
 
@@ -205,6 +203,7 @@ jobs:
           echo "include=$include" >> $GITHUB_OUTPUT
 
   build:
+    name: build (${{ matrix.platform }}, Flutter ${{ matrix.version }}, ${{ matrix.app_id_secret }})
     runs-on: ${{ matrix.os }}
     needs: build-matrix
     strategy:
@@ -215,12 +214,6 @@ jobs:
         platform: ${{ matrix.platform }}
         extra_build_options: ${{ inputs.extra_build_options }}
         extra_build_arguments: ${{ inputs.extra_build_arguments }}
-    outputs:
-      artifact_nightly_link_android: ${{ steps.setup_output.outputs.artifact_nightly_link_android }}
-      artifact_nightly_link_ios: ${{ steps.setup_output.outputs.artifact_nightly_link_ios }}
-      artifact_nightly_link_macos: ${{ steps.setup_output.outputs.artifact_nightly_link_macos }}
-      artifact_nightly_link_windows: ${{ steps.setup_output.outputs.artifact_nightly_link_windows }}
-      artifact_nightly_link_web: ${{ steps.setup_output.outputs.artifact_nightly_link_web }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -546,7 +539,7 @@ jobs:
           build_timestamp=$(date +%Y%m%d%H%M%S)
 
           flutter_version_slug="$(printf '%s' "${{ matrix.version }}" | tr -c '[:alnum:].' '-')"
-          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_flutter${flutter_version_slug}_${{ matrix.app_id_slug }}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
+          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_flutter${flutter_version_slug}_${{ matrix.app_id_secret }}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
           echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload build artifacts
@@ -556,20 +549,30 @@ jobs:
           path: agora_rtc_engine/output
           if-no-files-found: error
 
-      - name: Setup download url
-        id: setup_output
-        if: ${{ matrix.primary }}
-        shell: bash
-        run: |
-          # see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
-          current_platform="${{ matrix.platform }}"
-          echo "artifact_nightly_link_${current_platform}=https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ steps.generate_artifact_name.outputs.artifact_name }}.zip" >> $GITHUB_OUTPUT
-
   comment:
     runs-on: ubuntu-latest
     if: ${{ inputs.issue_number != null && !cancelled() }}
     needs: [build]
     steps:
+      - name: Generate artifact links
+        id: artifact-links
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          artifact_names=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" --paginate --jq '.artifacts[] | select(.expired == false) | .name')
+          {
+            echo 'links<<EOF'
+            if [ -n "$artifact_names" ]; then
+              while IFS= read -r artifact_name; do
+                echo "- [$artifact_name](https://nightly.link/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/${artifact_name}.zip)"
+              done <<< "$artifact_names"
+            else
+              echo '- No build artifacts were uploaded'
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -579,10 +582,6 @@ jobs:
               https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             Build Results:
-              - ${{ needs.build.outputs.artifact_nightly_link_android }}
-              - ${{ needs.build.outputs.artifact_nightly_link_ios }}
-              - ${{ needs.build.outputs.artifact_nightly_link_macos }}
-              - ${{ needs.build.outputs.artifact_nightly_link_windows }}
-              - ${{ needs.build.outputs.artifact_nightly_link_web }}
+            ${{ steps.artifact-links.outputs.links }}
 
             > This comment is commented by bot, do not edit it directly

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -38,6 +38,15 @@ on:
         # Here is the error log:
         # Caused by: org.gradle.api.GradleException: You are applying Flutter's app_plugin_loader Gradle plugin imperatively using the apply script method, which is not possible anymore. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/to/flutter-gradle-plugin-apply
         default: '3.24.5'
+      app_id_secrets:
+        description: 'App ID secret(s) used for builds'
+        type: choice
+        required: false
+        default: 'MY_APP_ID'
+        options:
+          - 'MY_APP_ID'
+          - 'APP_ID'
+          - 'MY_APP_ID, APP_ID'
   workflow_call:
     inputs:
       target_platforms:
@@ -74,8 +83,15 @@ on:
         # Here is the error log:
         # Caused by: org.gradle.api.GradleException: You are applying Flutter's app_plugin_loader Gradle plugin imperatively using the apply script method, which is not possible anymore. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/to/flutter-gradle-plugin-apply
         default: '3.24.5'
+      app_id_secrets:
+        description: 'App ID secret(s) used for builds, separated by comma'
+        type: string
+        required: false
+        default: 'MY_APP_ID'
     secrets:
       APP_ID:
+        required: false
+      MY_APP_ID:
         required: true
       BUILD_PROVISION_PROFILE_UUID:
         required: true
@@ -137,6 +153,7 @@ jobs:
         env:
           platforms: ${{ needs.split-platforms.outputs.platforms }}
           flutter_versions: ${{ inputs.flutter_version }}
+          app_id_secrets: ${{ inputs.app_id_secrets }}
         run: |
           set -euo pipefail
 
@@ -146,9 +163,24 @@ jobs:
             exit 1
           fi
 
+          app_ids=$(printf '%s' "$app_id_secrets" | sed 's/ //g' | tr ',' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          if [ "$(echo "$app_ids" | jq 'length')" -eq 0 ]; then
+            echo "::error::At least one App ID secret is required"
+            exit 1
+          fi
+          if [ "$(echo "$app_ids" | jq '[.[] | select(. != "MY_APP_ID" and . != "APP_ID")] | length')" -ne 0 ]; then
+            echo "::error::App ID secrets must be MY_APP_ID or APP_ID"
+            exit 1
+          fi
+          if [ "$(echo "$app_ids" | jq 'length')" -ne "$(echo "$app_ids" | jq 'unique | length')" ]; then
+            echo "::error::App ID secrets must not contain duplicates"
+            exit 1
+          fi
+
           include=$(jq -c -n \
             --argjson platforms "$platforms" \
             --argjson versions "$versions" \
+            --argjson app_ids "$app_ids" \
             '
               {
                 android: "macos-latest",
@@ -159,10 +191,13 @@ jobs:
               } as $runners
               | [ $platforms[] as $p
                   | $versions[] as $v
+                  | $app_ids[] as $a
                   | { platform: $p,
                       version: $v,
+                      app_id_secret: $a,
+                      app_id_slug: ($a | ascii_downcase),
                       os: $runners[$p],
-                      primary: ($v == $versions[0]) }
+                      primary: ($v == $versions[0] and $a == $app_ids[0]) }
                   | select(.os != null) ]
             ')
 
@@ -272,10 +307,21 @@ jobs:
 
       - name: Build
         env:
-          DEFAULT_BUILD_APP_ID: ${{ secrets.APP_ID }}
+          BUILD_APP_ID: ${{ secrets.APP_ID }}
+          BUILD_MY_APP_ID: ${{ secrets.MY_APP_ID }}
         shell: bash
         working-directory: agora_rtc_engine/example
         run: |
+          if [ "${{ matrix.app_id_secret }}" == "MY_APP_ID" ]; then
+            DEFAULT_BUILD_APP_ID="$BUILD_MY_APP_ID"
+          else
+            DEFAULT_BUILD_APP_ID="$BUILD_APP_ID"
+          fi
+          if [ -z "$DEFAULT_BUILD_APP_ID" ]; then
+            echo "::error::Selected secret ${{ matrix.app_id_secret }} is empty"
+            exit 1
+          fi
+
           # show flutter version
           flutter --version && which flutter
 
@@ -500,7 +546,7 @@ jobs:
           build_timestamp=$(date +%Y%m%d%H%M%S)
 
           flutter_version_slug="$(printf '%s' "${{ matrix.version }}" | tr -c '[:alnum:].' '-')"
-          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_flutter${flutter_version_slug}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
+          artifact_name="agora_rtc_engine_example_${{ matrix.platform }}_flutter${flutter_version_slug}_${{ matrix.app_id_slug }}_${pub_version}_${build_timestamp}_${{ github.run_id }}"
           echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload build artifacts

--- a/.github/workflows/run_build_example.yml
+++ b/.github/workflows/run_build_example.yml
@@ -185,7 +185,7 @@ jobs:
               {
                 android: "ubuntu-latest",
                 web:     "ubuntu-latest",
-                windows: "windows-latest",
+                windows: "windows-2022",
                 ios:     "macos-latest",
                 macos:   "macos-latest"
               } as $runners


### PR DESCRIPTION
## Summary
- check out the repository as `agora_rtc_engine` so Flutter 3.44 SwiftPM uses the Dart package identity
- accept comma-separated Flutter versions and build every requested platform/version pair
- default example builds to `secrets.MY_APP_ID`, with `APP_ID` or both secrets selectable
- build each selected App ID as a separate matrix job and include its source in the artifact name
- display platform, Flutter version, App ID source, and runner image in each job name
- run Android and Web on Ubuntu, iOS and macOS on macOS, and Windows on pinned `windows-2022`
- query all artifacts after the matrix finishes and include every uploaded artifact in one PR comment
- reuse the multi-version matrix pattern from Agora-Flutter-RTM-SDK#239

## Validation
- multi-version iOS run: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/32354454901
  - Flutter 3.24.5: SwiftPM disabled, 54.3 MB IPA built
  - Flutter 3.44.8: SwiftPM enabled, 30.0 MB IPA built
- dual App ID iOS run: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/32356432869
  - Flutter 3.44.8 + `MY_APP_ID`: passed, separate artifact uploaded
  - Flutter 3.44.8 + `APP_ID`: passed, separate artifact uploaded
  - App IDs remained masked in build logs
- full matrix run: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/32358796920
  - matrix generation passed with five platforms x two Flutter versions x two App IDs = 20 unique jobs
- Windows 3.24.5 follow-up run: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/32359813952
  - matrix passed and selected `windows-2022`; the build was externally canceled during `flutter pub get`, before compilation
  - this matches the existing Windows runner choice in `run_test.yml`
- local runner distribution check: Ubuntu 8, macOS 8, Windows 4
- artifact-link generator included every artifact from the dual App ID run
- YAML parse and `git diff --check` passed

## Baseline note
- `node --test ci/update_spm_deps.test.mjs` is 53/54 on current main because the existing assertion expects `RtcBasic` while the merged iOS manifest now preserves `RtcBasic,AINS`; this PR does not change that test.