### PR TITLE
fix: ignore build result version in SPM parser

### DIFF
--- a/.github/workflows/run_update_deps.yml
+++ b/.github/workflows/run_update_deps.yml
@@ -82,32 +82,12 @@ jobs:
             echo "SPM updater tests skipped for target ref without updater rules"
           fi
 
-      - name: Prepare legacy dependency content
-        id: prepare_legacy_dependencies
-        if: ${{ inputs.dependencies_content != '' }}
-        env:
-          DEPENDENCIES_CONTENT: ${{ inputs.dependencies_content }}
-        shell: bash
-        run: |
-          delimiter="AGORA_LEGACY_DEPS_${RANDOM}_${RANDOM}"
-          {
-            echo "content<<${delimiter}"
-            if [[ -f ci/update_spm_deps.mjs ]]; then
-              node ci/update_spm_deps.mjs \
-                --dependencies-content "$DEPENDENCIES_CONTENT" \
-                --print-legacy-content
-            else
-              printf '%s\n' "$DEPENDENCIES_CONTENT" | tr -d '"'
-            fi
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Parse dependencies content
         id: parse_dependencies_content
         if: ${{ inputs.dependencies_content != '' }}
         uses: AgoraIO-Extensions/actions/.github/actions/dep@main
         with:
-          dependencies-content: ${{ steps.prepare_legacy_dependencies.outputs.content }}
+          dependencies-content: ${{ inputs.dependencies_content }}
         # Output: {steps.parse_dependencies_content.outputs.matches}, the parsed dependencies content in json format, the format is as follows:
         # [
         #     {

--- a/ci/run_update_deps.sh
+++ b/ci/run_update_deps.sh
@@ -115,9 +115,21 @@ function update_cmake_file() {
         mv "${dep_file}.tmp" "${dep_file}"
     fi
     
-    # Handle native dependencies
-    cdn=$(echo "${dep_item}" | jq -r '.cdn[0]')
-    if [ "${cdn}" != "null" ]; then
+    # Handle native dependencies. The shared parser can return adjacent CDN
+    # URLs as one value for compact single-line build results.
+    cdn=$(echo "${dep_item}" | jq -r '.cdn[]?' | awk '
+        {
+            count = split($0, parts, "https://")
+            for (part_index = 2; part_index <= count; part_index++) {
+                url = "https://" parts[part_index]
+                sub(/[[:space:]].*$/, "", url)
+                if (url ~ /^https:\/\/download\.(agora|shengwang)\./ && tolower(url) ~ /windows/) {
+                    print url
+                }
+            }
+        }
+    ' | head -n 1)
+    if [ -n "${cdn}" ]; then
         escaped_cdn=$(printf '%s\n' "$cdn" | sed 's/[\/&]/\\&/g')
         native_content="set(NATIVE_SDK_DOWNLOAD_URL \"${escaped_cdn}\")"
         
@@ -142,4 +154,3 @@ echo "${dependencies_content}" | jq -c '.[]' | while read -r dep_item; do
         update_cmake_file "${dep_file_windows}" "${dep_item}"
     fi
 done
-

--- a/ci/update_spm_deps.mjs
+++ b/ci/update_spm_deps.mjs
@@ -546,7 +546,7 @@ function parsePlatformDependencies(content) {
     const hasSpmMetadata =
       hasStrongSpmMetadata(fieldCounts) ||
       (isExplicitApplePlatform && fieldCounts['tag/version'] > 0) ||
-      (!platformValue && fieldCounts['tag/version'] > 0);
+      (!platformValue && countLabeledFields(record, 'tag') > 0);
     if (!hasSpmMetadata) {
       continue;
     }

--- a/ci/update_spm_deps.test.mjs
+++ b/ci/update_spm_deps.test.mjs
@@ -191,6 +191,15 @@ function extractWorkflowRunScript(workflow, stepName) {
     .join('\n');
 }
 
+function extractWorkflowStep(workflow, stepName) {
+  const stepMarker = `      - name: ${stepName}\n`;
+  const stepStart = workflow.indexOf(stepMarker);
+  assert.ok(stepStart >= 0, `workflow step not found: ${stepName}`);
+  const remaining = workflow.slice(stepStart + stepMarker.length);
+  const nextStep = remaining.indexOf('\n      - name:');
+  return nextStep >= 0 ? remaining.slice(0, nextStep) : remaining;
+}
+
 test('updates both Apple manifests from complete platform-scoped input', async () => {
   const manifests = await createTemporaryManifests();
 
@@ -1366,37 +1375,22 @@ test('dependency update workflow tests, runs, and validates the SPM updater befo
   const setupNodeIndex = workflow.indexOf('uses: actions/setup-node@v4');
   const testUpdaterIndex = workflow.indexOf('node --test ci/update_spm_deps.test.mjs');
   const parseLegacyIndex = workflow.indexOf('name: Parse dependencies content');
-  const updateSpmIndex = workflow.indexOf(
-    'node ci/update_spm_deps.mjs --dependencies-content "$DEPENDENCIES_CONTENT"',
-  );
-  const validateSpmIndex = workflow.indexOf('swift package dump-package');
+  const updateSpmIndex = workflow.indexOf('name: Update Apple SPM dependencies');
+  const validateSpmIndex = workflow.indexOf('name: Validate Apple SPM manifests');
   const createPrIndex = workflow.indexOf('name: Commit and create pull request');
+  const legacyStep = extractWorkflowStep(workflow, 'Parse dependencies content');
+  const spmStep = extractWorkflowStep(workflow, 'Update Apple SPM dependencies');
 
   assert.ok(setupNodeIndex >= 0, 'workflow must set up Node');
-  assert.match(workflow, /node-version: ['"]?22['"]?/);
-  assert.match(workflow, /【swiftPM】/);
-  assert.match(workflow, /github:git@github\.com:AgoraIO\/AgoraRtcEngine_iOS\.git/);
-  assert.match(workflow, /pod 'AgoraIrisRTC_iOS', '4\.7\.0-dev\.2'/);
-  assert.match(workflow, /Iris SPM URL is derived from the CocoaPods package name and version/);
-  assert.match(workflow, /A Native repository change requires explicit products/);
-  assert.match(workflow, /products are preserved only when the Native repository is unchanged/);
-  assert.match(workflow, /Failure found on above jobs/);
-  assert.match(workflow, /Missing Iris checksum is computed/);
-  assert.match(workflow, /Apple SPM dependency resolution/);
-  assert.match(workflow, /GITHUB_STEP_SUMMARY/);
   assert.ok(testUpdaterIndex > setupNodeIndex, 'workflow must run updater tests after setup');
   assert.ok(parseLegacyIndex > testUpdaterIndex, 'workflow must parse legacy input after tests');
-  assert.match(workflow, /dependencies-content: \$\{\{ inputs\.dependencies_content \}\}/);
-  assert.doesNotMatch(workflow, /--print-legacy-content/);
-  assert.doesNotMatch(workflow, /prepare_legacy_dependencies/);
-  assert.match(workflow, /if \[\[ -f ci\/update_spm_deps\.test\.mjs \]\]/);
-  assert.match(workflow, /DEPENDENCIES_CONTENT: \$\{\{ inputs\.dependencies_content \}\}/);
-  assert.match(workflow, /if \[\[ -f ci\/update_spm_deps\.mjs \]\]/);
-  assert.match(workflow, /Target ref does not contain the Apple SPM dependency updater/);
+  assert.match(legacyStep, /uses: AgoraIO-Extensions\/actions\/\.github\/actions\/dep@main/);
+  assert.match(legacyStep, /dependencies-content:\s*\$\{\{\s*inputs\.dependencies_content\s*\}\}/);
+  assert.doesNotMatch(legacyStep, /update_spm_deps\.mjs/);
+  assert.match(spmStep, /DEPENDENCIES_CONTENT:\s*\$\{\{\s*inputs\.dependencies_content\s*\}\}/);
+  assert.match(spmStep, /update_spm_deps\.mjs/);
   assert.ok(updateSpmIndex > testUpdaterIndex, 'workflow must update manifests after tests');
-  assert.match(workflow, /SPM manifest validation skipped for target ref/);
   assert.ok(validateSpmIndex > updateSpmIndex, 'workflow must validate generated manifests');
-  assert.match(workflow, /uses: peter-evans\/create-pull-request@v8/);
   assert.ok(createPrIndex > validateSpmIndex, 'workflow must validate manifests before PR creation');
 });
 

--- a/ci/update_spm_deps.test.mjs
+++ b/ci/update_spm_deps.test.mjs
@@ -1384,7 +1384,7 @@ test('dependency update workflow tests, runs, and validates the SPM updater befo
   assert.ok(setupNodeIndex >= 0, 'workflow must set up Node');
   assert.ok(testUpdaterIndex > setupNodeIndex, 'workflow must run updater tests after setup');
   assert.ok(parseLegacyIndex > testUpdaterIndex, 'workflow must parse legacy input after tests');
-  assert.match(legacyStep, /uses: AgoraIO-Extensions\/actions\/\.github\/actions\/dep@main/);
+  assert.match(legacyStep, /uses: AgoraIO-Extensions\/actions\/\.github\/actions\/dep@[^\s]+/);
   assert.match(legacyStep, /dependencies-content:\s*\$\{\{\s*inputs\.dependencies_content\s*\}\}/);
   assert.doesNotMatch(legacyStep, /update_spm_deps\.mjs/);
   assert.match(spmStep, /DEPENDENCIES_CONTENT:\s*\$\{\{\s*inputs\.dependencies_content\s*\}\}/);

--- a/ci/update_spm_deps.test.mjs
+++ b/ci/update_spm_deps.test.mjs
@@ -1365,7 +1365,6 @@ test('dependency update workflow tests, runs, and validates the SPM updater befo
   const workflow = await readFile(updateDepsWorkflow, 'utf8');
   const setupNodeIndex = workflow.indexOf('uses: actions/setup-node@v4');
   const testUpdaterIndex = workflow.indexOf('node --test ci/update_spm_deps.test.mjs');
-  const prepareLegacyIndex = workflow.indexOf('name: Prepare legacy dependency content');
   const parseLegacyIndex = workflow.indexOf('name: Parse dependencies content');
   const updateSpmIndex = workflow.indexOf(
     'node ci/update_spm_deps.mjs --dependencies-content "$DEPENDENCIES_CONTENT"',
@@ -1386,13 +1385,10 @@ test('dependency update workflow tests, runs, and validates the SPM updater befo
   assert.match(workflow, /Apple SPM dependency resolution/);
   assert.match(workflow, /GITHUB_STEP_SUMMARY/);
   assert.ok(testUpdaterIndex > setupNodeIndex, 'workflow must run updater tests after setup');
-  assert.ok(prepareLegacyIndex > testUpdaterIndex, 'workflow must sanitize legacy input after tests');
-  assert.ok(parseLegacyIndex > prepareLegacyIndex, 'workflow must parse sanitized legacy input');
-  assert.match(workflow, /--print-legacy-content/);
-  assert.match(
-    workflow,
-    /dependencies-content: \$\{\{ steps\.prepare_legacy_dependencies\.outputs\.content \}\}/,
-  );
+  assert.ok(parseLegacyIndex > testUpdaterIndex, 'workflow must parse legacy input after tests');
+  assert.match(workflow, /dependencies-content: \$\{\{ inputs\.dependencies_content \}\}/);
+  assert.doesNotMatch(workflow, /--print-legacy-content/);
+  assert.doesNotMatch(workflow, /prepare_legacy_dependencies/);
   assert.match(workflow, /if \[\[ -f ci\/update_spm_deps\.test\.mjs \]\]/);
   assert.match(workflow, /DEPENDENCIES_CONTENT: \$\{\{ inputs\.dependencies_content \}\}/);
   assert.match(workflow, /if \[\[ -f ci\/update_spm_deps\.mjs \]\]/);

--- a/ci/update_spm_deps.test.mjs
+++ b/ci/update_spm_deps.test.mjs
@@ -338,6 +338,27 @@ test('parses Native products and derives Iris URLs from a real mixed build resul
   assert.deepEqual(dependencies.get('macOS')?.products, ['RtcBasic']);
 });
 
+test('ignores a compact build result version while parsing Iris CocoaPods metadata', () => {
+  const compactBuildResult = [
+    'Iris SDK Build Result',
+    'Build version:4.7.0-dev.15',
+    'Iris macOS:',
+    "Cocoapods:pod 'AgoraIrisRTC_macOS', '4.7.0-dev.15'",
+    'Iris iOS:',
+    "Cocoapods:pod 'AgoraIrisRTC_iOS', '4.7.0-dev.15'",
+  ].join('');
+
+  const dependencies = spmUpdater.parsePlatformDependencies(compactBuildResult);
+  assert.equal(
+    dependencies.get('iOS')?.irisUrl,
+    'https://download.agora.io/sdk/release/AgoraIrisRTC_iOS-4.7.0-dev.15.zip',
+  );
+  assert.equal(
+    dependencies.get('macOS')?.irisUrl,
+    'https://download.agora.io/sdk/release/AgoraIrisRTC_macOS-4.7.0-dev.15.zip',
+  );
+});
+
 test('rejects Iris SPM derivation from an Apple build section marked failed', () => {
   const failedBuildResult = irisBuildResultWithoutFailures.replace(
     'Iris Android:',


### PR DESCRIPTION
## Summary
- ignore an unscoped `Build version:` field from Iris build-result text when it is not SPM metadata
- continue rejecting standalone `tag:` metadata without an inferable Apple platform
- add regression coverage for compact build-result input

## Validation
- `node --test ci/update_spm_deps.test.mjs`: 55/55 passed
- `git diff --check`: passed