### PR TITLE
feat: cherry-pick SurfaceTexture rendering and relax ffi constraint

### DIFF
--- a/android/src/main/cpp/iris_rtc_rendering_android.cc
+++ b/android/src/main/cpp/iris_rtc_rendering_android.cc
@@ -993,6 +993,92 @@ class NativeTextureRenderer final
   std::unique_ptr<RenderingOp> rendering_op_;
 };
 
+class NativeTextureSizeObserver final
+    : public agora::iris::VideoFrameObserverDelegate {
+ public:
+  explicit NativeTextureSizeObserver(
+      JNIEnv *env, jobject j_iris_renderer_obj,
+      agora::iris::IrisRtcRendering *iris_rtc_rendering, unsigned int uid,
+      const char *channel_id, int video_source_type, int video_view_setup_mode)
+      : jvm_(nullptr), iris_rtc_rendering_(iris_rtc_rendering), width_(0),
+        height_(0) {
+    env->GetJavaVM(&jvm_);
+    j_iris_renderer_obj_ = env->NewGlobalRef(j_iris_renderer_obj);
+    jclass j_caller_class = env->GetObjectClass(j_iris_renderer_obj_);
+    j_on_size_changed_method_ =
+        env->GetMethodID(j_caller_class, "onSizeChanged", "(II)V");
+    env->DeleteLocalRef(j_caller_class);
+
+    IrisRtcVideoFrameConfig config;
+    config.uid = uid;
+    config.video_source_type = video_source_type;
+    config.video_frame_format =
+        agora::media::base::VIDEO_PIXEL_FORMAT::VIDEO_PIXEL_DEFAULT;
+    if (channel_id) {
+      strcpy(config.channelId, channel_id);
+    } else {
+      strcpy(config.channelId, "");
+    }
+    config.video_view_setup_mode = video_view_setup_mode;
+    config.observed_frame_position =
+        agora::media::base::VIDEO_MODULE_POSITION::POSITION_POST_CAPTURER |
+        agora::media::base::VIDEO_MODULE_POSITION::POSITION_PRE_RENDERER;
+
+    if (iris_rtc_rendering_) {
+      delegate_id_ =
+          iris_rtc_rendering_->AddVideoFrameObserverDelegate(config, this);
+    }
+  }
+
+  ~NativeTextureSizeObserver() final {}
+
+  void OnVideoFrameReceived(const void *videoFrame,
+                            const IrisRtcVideoFrameConfig &config,
+                            bool resize) override {
+    const auto *video_frame =
+        static_cast<const agora::media::base::VideoFrame *>(videoFrame);
+
+    if (video_frame->width == 0 || video_frame->height == 0) { return; }
+
+    if (width_ != video_frame->width || height_ != video_frame->height) {
+      width_ = video_frame->width;
+      height_ = video_frame->height;
+      NotifySizeChangeCallback(width_, height_);
+    }
+  }
+
+  void Dispose() {
+    if (iris_rtc_rendering_) {
+      iris_rtc_rendering_->RemoveVideoFrameObserverDelegate(delegate_id_);
+      iris_rtc_rendering_ = nullptr;
+    }
+
+    if (j_iris_renderer_obj_) {
+      ::iris::AttachThreadScoped ats(jvm_);
+      ats.env()->DeleteGlobalRef(j_iris_renderer_obj_);
+      j_iris_renderer_obj_ = nullptr;
+    }
+  }
+
+  void NotifySizeChangeCallback(int width, int height) {
+    if (!j_iris_renderer_obj_) { return; }
+    ::iris::AttachThreadScoped ats(jvm_);
+    ats.env()->CallVoidMethod(j_iris_renderer_obj_, j_on_size_changed_method_,
+                              width, height);
+  }
+
+ private:
+  JavaVM *jvm_;
+  jobject j_iris_renderer_obj_;
+  jmethodID j_on_size_changed_method_;
+
+  agora::iris::IrisRtcRendering *iris_rtc_rendering_;
+  int width_;
+  int height_;
+
+  int delegate_id_;
+};
+
 }// namespace rendering
 }// namespace iris
 }// namespace agora
@@ -1015,6 +1101,21 @@ Java_io_agora_agora_1rtc_1ng_IrisRenderer_nativeStartRenderingToSurface(
   return reinterpret_cast<jlong>(renderer);
 }
 
+extern "C" JNIEXPORT jlong JNICALL
+Java_io_agora_agora_1rtc_1ng_IrisRenderer_nativeStartObservingTextureSize(
+    JNIEnv *env, jobject thiz, jlong buffer_manager_int_ptr, jlong uid,
+    jstring channel_id, jint video_source_type, jint video_view_setup_mode) {
+  auto *iris_rtc_rendering =
+      reinterpret_cast<agora::iris::IrisRtcRendering *>(buffer_manager_int_ptr);
+
+  auto *j_channel_id = env->GetStringUTFChars(channel_id, nullptr);
+  auto *observer = new NativeTextureSizeObserver(
+      env, thiz, iris_rtc_rendering, uid, j_channel_id, video_source_type,
+      video_view_setup_mode);
+  env->ReleaseStringUTFChars(channel_id, j_channel_id);
+  return reinterpret_cast<jlong>(observer);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_io_agora_agora_1rtc_1ng_IrisRenderer_nativeStopRenderingToSurface(
     JNIEnv *env, jobject thiz, jlong native_renderer_handle) {
@@ -1022,4 +1123,13 @@ Java_io_agora_agora_1rtc_1ng_IrisRenderer_nativeStopRenderingToSurface(
       reinterpret_cast<NativeTextureRenderer *>(native_renderer_handle);
   renderer->Dispose();
   delete renderer;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_agora_agora_1rtc_1ng_IrisRenderer_nativeStopObservingTextureSize(
+    JNIEnv *env, jobject thiz, jlong native_renderer_handle) {
+  auto *observer =
+      reinterpret_cast<NativeTextureSizeObserver *>(native_renderer_handle);
+  observer->Dispose();
+  delete observer;
 }

--- a/android/src/main/java/io/agora/agora_rtc_ng/IrisRenderer.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/IrisRenderer.java
@@ -4,7 +4,7 @@ import android.view.Surface;
 import androidx.annotation.Keep;
 
 /**
- * An IrisRenderer allow you to rendering the raw data to android Surface
+ * An IrisRenderer allows observing texture size changes and optionally rendering raw data to Surface.
  */
 public class IrisRenderer {
 
@@ -93,10 +93,24 @@ public class IrisRenderer {
         videoViewSetupMode);
   }
 
+  public void startObservingTextureSize() {
+    if (nativeRendererHandle != 0L) { return; }
+    nativeRendererHandle = nativeStartObservingTextureSize(
+        videoFrameManagerNativeHandle, uid, channelId, videoSourceType,
+        videoViewSetupMode);
+  }
+
   public void stopRenderingToSurface() {
     if (nativeRendererHandle == 0L) { return; }
 
     nativeStopRenderingToSurface(nativeRendererHandle);
+    nativeRendererHandle = 0L;
+  }
+
+  public void stopObservingTextureSize() {
+    if (nativeRendererHandle == 0L) { return; }
+
+    nativeStopObservingTextureSize(nativeRendererHandle);
     nativeRendererHandle = 0L;
   }
 
@@ -106,5 +120,13 @@ public class IrisRenderer {
                                                     int videoSourceType,
                                                     int videoViewSetupMode);
 
+  private native long nativeStartObservingTextureSize(long bufferManagerIntPtr,
+                                                      long uid,
+                                                      String channelId,
+                                                      int videoSourceType,
+                                                      int videoViewSetupMode);
+
   private native void nativeStopRenderingToSurface(long nativeRendererHandle);
+
+  private native void nativeStopObservingTextureSize(long nativeRendererHandle);
 }

--- a/android/src/main/java/io/agora/agora_rtc_ng/SurfaceTextureRenderTarget.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/SurfaceTextureRenderTarget.java
@@ -1,0 +1,76 @@
+package io.agora.agora_rtc_ng;
+
+import android.graphics.SurfaceTexture;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.HashMap;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.view.TextureRegistry;
+
+class SurfaceTextureRenderTarget {
+    private final TextureRegistry.SurfaceTextureEntry flutterTexture;
+    private final SimpleRef surfaceTextureRef;
+    private final MethodChannel methodChannel;
+    private final Handler handler;
+    private final SurfaceTexture flutterSurfaceTexture;
+    private final IrisRenderer irisRenderer;
+
+    SurfaceTextureRenderTarget(
+            TextureRegistry textureRegistry,
+            BinaryMessenger binaryMessenger,
+            long irisRtcRenderingHandle,
+            long uid,
+            String channelId,
+            int videoSourceType,
+            int videoViewSetupMode) {
+        this.handler = new Handler(Looper.getMainLooper());
+        this.flutterTexture = textureRegistry.createSurfaceTexture();
+        this.flutterSurfaceTexture = this.flutterTexture.surfaceTexture();
+        this.surfaceTextureRef = new SimpleRef(this.flutterSurfaceTexture);
+        this.methodChannel = new MethodChannel(
+                binaryMessenger,
+                "agora_rtc_engine/texture_render_" + flutterTexture.id());
+        this.irisRenderer = new IrisRenderer(
+                irisRtcRenderingHandle,
+                uid,
+                channelId,
+                videoSourceType,
+                videoViewSetupMode);
+        this.irisRenderer.setCallback(new IrisRenderer.Callback() {
+            @Override
+            public void onSizeChanged(int width, int height) {
+                final SurfaceTexture st = SurfaceTextureRenderTarget.this.flutterSurfaceTexture;
+                if (st != null) {
+                    st.setDefaultBufferSize(width, height);
+                }
+
+                handler.post(() -> methodChannel.invokeMethod(
+                        "onSizeChanged",
+                        new HashMap<String, Integer>() {{
+                            put("width", width);
+                            put("height", height);
+                        }}));
+            }
+        });
+        this.irisRenderer.startObservingTextureSize();
+    }
+
+    long getTextureId() {
+        return flutterTexture.id();
+    }
+
+    long getSurfaceTextureHandle() {
+        return surfaceTextureRef.getNativeHandle();
+    }
+
+    void dispose() {
+        methodChannel.setMethodCallHandler(null);
+        irisRenderer.stopObservingTextureSize();
+        irisRenderer.setCallback(null);
+        surfaceTextureRef.releaseRef();
+        flutterTexture.release();
+    }
+}

--- a/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/VideoViewController.java
@@ -1,6 +1,7 @@
 package io.agora.agora_rtc_ng;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -99,6 +100,7 @@ class PlatformRenderPool {
 }
 
 public class VideoViewController implements MethodChannel.MethodCallHandler {
+    private static final String TAG = "AgoraSurfaceTexture";
 
     private final TextureRegistry textureRegistry;
     private final BinaryMessenger binaryMessenger;
@@ -107,6 +109,8 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
     private final PlatformRenderPool pool;
 
     private final Map<Long, TextureRenderer> textureRendererMap = new HashMap<>();
+    private final Map<Long, SurfaceTextureRenderTarget> surfaceTextureRenderTargetMap =
+            new HashMap<>();
 
     VideoViewController(TextureRegistry textureRegistry, BinaryMessenger binaryMessenger) {
         this.textureRegistry = textureRegistry;
@@ -169,6 +173,48 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
         return false;
     }
 
+    private Map<String, Long> createSurfaceTextureRenderTarget(
+            long irisRtcRenderingHandle,
+            long uid,
+            String channelId,
+            int videoSourceType,
+            int videoViewSetupMode) {
+        final SurfaceTextureRenderTarget renderTarget =
+                new SurfaceTextureRenderTarget(
+                        textureRegistry,
+                        binaryMessenger,
+                        irisRtcRenderingHandle,
+                        uid,
+                        channelId,
+                        videoSourceType,
+                        videoViewSetupMode);
+        final long textureId = renderTarget.getTextureId();
+        surfaceTextureRenderTargetMap.put(textureId, renderTarget);
+
+        Log.i(TAG, "create target textureId=" + textureId
+                + " surfaceTextureHandle=" + renderTarget.getSurfaceTextureHandle());
+
+        return new HashMap<String, Long>() {
+            {
+                put("textureId", textureId);
+                put("surfaceTextureHandle", renderTarget.getSurfaceTextureHandle());
+            }
+        };
+    }
+
+    private boolean destroySurfaceTextureRenderTarget(long textureId) {
+        final SurfaceTextureRenderTarget renderTarget =
+                surfaceTextureRenderTargetMap.get(textureId);
+        if (renderTarget != null) {
+            Log.i(TAG, "destroy target textureId=" + textureId);
+            renderTarget.dispose();
+            surfaceTextureRenderTargetMap.remove(textureId);
+            return true;
+        }
+
+        return false;
+    }
+
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
         switch (call.method) {
@@ -216,6 +262,28 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
                 result.success(success);
                 break;
             }
+            case "createSurfaceTextureRenderTarget": {
+                final Map<?, ?> args = (Map<?, ?>) call.arguments;
+                @SuppressWarnings("ConstantConditions") final long irisRtcRenderingHandle = getLong(args.get("irisRtcRenderingHandle"));
+                @SuppressWarnings("ConstantConditions") final long uid = getLong(args.get("uid"));
+                final String channelId = (String) args.get("channelId");
+                final int videoSourceType = (int) args.get("videoSourceType");
+                final int videoViewSetupMode = (int) args.get("videoViewSetupMode");
+                final Map<String, Long> response = createSurfaceTextureRenderTarget(
+                        irisRtcRenderingHandle,
+                        uid,
+                        channelId,
+                        videoSourceType,
+                        videoViewSetupMode);
+                result.success(response);
+                break;
+            }
+            case "destroySurfaceTextureRenderTarget": {
+                final long textureId = getLong(call.arguments);
+                final boolean success = destroySurfaceTextureRenderTarget(textureId);
+                result.success(success);
+                break;
+            }
             case "dispose": {
                 disposeAllRenderers();
                 result.success(true);
@@ -233,6 +301,12 @@ public class VideoViewController implements MethodChannel.MethodCallHandler {
             textureRenderer.dispose();
         }
         textureRendererMap.clear();
+
+        for (final SurfaceTextureRenderTarget renderTarget :
+                surfaceTextureRenderTargetMap.values()) {
+            renderTarget.dispose();
+        }
+        surfaceTextureRenderTargetMap.clear();
     }
 
     /**

--- a/example/lib/examples/advanced/media_player/media_player.dart
+++ b/example/lib/examples/advanced/media_player/media_player.dart
@@ -2,6 +2,7 @@ import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:agora_rtc_engine_example/config/agora.config.dart' as config;
 import 'package:agora_rtc_engine_example/components/example_actions_widget.dart';
 import 'package:agora_rtc_engine_example/components/log_sink.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// MediaPlayer Example
@@ -15,6 +16,7 @@ class MediaPlayer extends StatefulWidget {
 class _State extends State<MediaPlayer> {
   late final RtcEngineEx _engine;
   bool _isReadyPreview = false;
+  bool _useFlutterTexture = false;
 
   late MediaPlayerController _mediaPlayerController;
 
@@ -62,38 +64,7 @@ class _State extends State<MediaPlayer> {
     await _engine.release();
   }
 
-  Future<void> _initEngine() async {
-    _engine = createAgoraRtcEngineEx();
-    _mediaPlayerController = MediaPlayerController(
-        rtcEngine: _engine, canvas: const VideoCanvas(uid: 0));
-    await _engine.initialize(RtcEngineContext(
-      appId: config.appId,
-      channelProfile: ChannelProfileType.channelProfileLiveBroadcasting,
-    ));
-
-    _engine.registerEventHandler(RtcEngineEventHandler(
-      onError: (ErrorCodeType err, String msg) {
-        logSink.log('[onError] err: $err, msg: $msg');
-      },
-      onJoinChannelSuccess: (RtcConnection connection, int elapsed) {
-        logSink.log(
-            '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');
-        setState(() {
-          isJoined = true;
-        });
-      },
-      onLeaveChannel: (RtcConnection connection, RtcStats stats) {
-        logSink.log(
-            '[onLeaveChannel] connection: ${connection.toJson()} stats: ${stats.toJson()}');
-        setState(() {
-          isJoined = false;
-        });
-      },
-    ));
-
-    _mediaPlayerController = MediaPlayerController(
-        rtcEngine: _engine, canvas: const VideoCanvas(uid: 0));
-    await _mediaPlayerController.initialize();
+  void _registerPlayerSourceObserver() {
     _mediaPlayerController.registerPlayerSourceObserver(
       MediaPlayerSourceObserver(
         onCompleted: () {
@@ -107,12 +78,10 @@ class _State extends State<MediaPlayer> {
             _duration = await _mediaPlayerController.getDuration();
             _isUrlOpened = true;
             _isPlaying = false;
-            // _isStop = false;
             _isPause = false;
           } else if (state == MediaPlayerState.playerStateStopped) {
             _isUrlOpened = false;
             _isPlaying = false;
-            // _isStop = true;
             _isPause = false;
             _seekPos = 0;
             _isMuted = false;
@@ -140,6 +109,46 @@ class _State extends State<MediaPlayer> {
         },
       ),
     );
+  }
+
+  Future<void> _initMediaPlayerController() async {
+    _mediaPlayerController = MediaPlayerController(
+      rtcEngine: _engine,
+      canvas: const VideoCanvas(uid: 0),
+      useFlutterTexture: _useFlutterTexture,
+    );
+    await _mediaPlayerController.initialize();
+    _registerPlayerSourceObserver();
+  }
+
+  Future<void> _initEngine() async {
+    _engine = createAgoraRtcEngineEx();
+    await _engine.initialize(RtcEngineContext(
+      appId: config.appId,
+      channelProfile: ChannelProfileType.channelProfileLiveBroadcasting,
+    ));
+
+    _engine.registerEventHandler(RtcEngineEventHandler(
+      onError: (ErrorCodeType err, String msg) {
+        logSink.log('[onError] err: $err, msg: $msg');
+      },
+      onJoinChannelSuccess: (RtcConnection connection, int elapsed) {
+        logSink.log(
+            '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');
+        setState(() {
+          isJoined = true;
+        });
+      },
+      onLeaveChannel: (RtcConnection connection, RtcStats stats) {
+        logSink.log(
+            '[onLeaveChannel] connection: ${connection.toJson()} stats: ${stats.toJson()}');
+        setState(() {
+          isJoined = false;
+        });
+      },
+    ));
+
+    await _initMediaPlayerController();
 
     setState(() {
       _isReadyPreview = true;
@@ -169,6 +178,12 @@ class _State extends State<MediaPlayer> {
     );
   }
 
+  bool get _canToggleFlutterTexture =>
+      !_isUrlOpened &&
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
   @override
   Widget build(BuildContext context) {
     return ExampleActionsWidget(
@@ -176,6 +191,7 @@ class _State extends State<MediaPlayer> {
         if (!_isReadyPreview) return Container();
         if (_isUrlOpened) {
           return AgoraVideoView(
+            key: ValueKey(_useFlutterTexture),
             controller: _mediaPlayerController,
           );
         }
@@ -228,6 +244,26 @@ class _State extends State<MediaPlayer> {
                 ),
               ],
             ),
+            if (_canToggleFlutterTexture) ...[
+              const SizedBox(
+                height: 20,
+              ),
+              Row(
+                children: [
+                  const Text('Rendered by Flutter texture: '),
+                  Switch(
+                    value: _useFlutterTexture,
+                    onChanged: (changed) async {
+                      setState(() {
+                        _useFlutterTexture = changed;
+                      });
+                      await _mediaPlayerController.dispose();
+                      await _initMediaPlayerController();
+                    },
+                  ),
+                ],
+              ),
+            ],
             const SizedBox(
               height: 20,
             ),

--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -137,9 +137,23 @@ class _State extends State<JoinChannelVideo> {
     );
 
     _engine.registerEventHandler(_rtcEngineEventHandler);
+    await _applyDebugRenderParameters();
 
     await _engine.enableVideo();
     await _engine.startPreview();
+  }
+
+  Future<void> _applyDebugRenderParameters() async {
+    await _engine.setParameters(
+      '{"rtc.video.enable_sr":{"mode":2,"enabled":false}}',
+    );
+    await _engine.setParameters('{"rtc.video.avsync": false}');
+    await _engine.setParameters('{"rtc.video.playout_delay_min": 0}');
+    await _engine.setParameters('{"rtc.video.decoder_out_byte_frame": false}');
+    await _engine.setParameters('{"rtc.video.enable_pvc":false}');
+    await _engine.setParameters('{"rtc.video.enable_local_sr":false}');
+    await _engine
+        .setParameters('{"che.video.android.hwdec_texture.copy_enable":false}');
   }
 
   Future<void> _updateRemoteVideoController(

--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -89,13 +89,15 @@ extension RtcEngineExt on RtcEngine {
 
   Future<void> setupVideoView(Object viewHandle, VideoCanvas videoCanvas,
       {RtcConnection? connection}) async {
-    Object view = viewHandle;
+    Object? view = viewHandle;
     if (kIsWeb) {
       view = 0;
+    } else if (viewHandle == kNullViewHandle) {
+      view = videoCanvas.view;
     }
 
     VideoCanvas newVideoCanvas = VideoCanvas(
-      view: view as int,
+      view: view as int?,
       renderMode: videoCanvas.renderMode,
       mirrorMode: videoCanvas.mirrorMode,
       uid: videoCanvas.uid,

--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '/src/agora_base.dart';
 import '/src/agora_media_base.dart';
 import '/src/agora_rtc_engine.dart';
@@ -7,8 +9,6 @@ import '/src/impl/agora_rtc_renderer.dart';
 
 import '/src/render/agora_video_view.dart';
 import '/src/render/video_view_controller.dart';
-
-import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show Colors;
@@ -213,6 +213,7 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   final int _viewId;
 
   TextureRenderDisposable? _renderDisposable;
+  SurfaceTextureRenderTargetDisposable? _surfaceTextureRenderTargetDisposable;
 
   @override
   int get textureWidth => _controller.textureWidth;
@@ -250,7 +251,13 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   bool get shouldHandlerRenderMode => _controller.shouldHandlerRenderMode;
 
   @override
-  int getTextureId() => _renderDisposable?.textureId ?? kTextureNotInit;
+  int getTextureId() {
+    if (_controller.shouldUseSdkSurfaceTextureRender) {
+      return _surfaceTextureRenderTargetDisposable?.textureId ??
+          kTextureNotInit;
+    }
+    return _renderDisposable?.textureId ?? kTextureNotInit;
+  }
 
   @override
   void addInitializedCompletedListener(VoidCallback listener) =>
@@ -278,6 +285,19 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
 
   @override
   Future<void> initializeRender() async {
+    if (_controller.shouldUseSdkSurfaceTextureRender) {
+      if (_surfaceTextureRenderTargetDisposable != null &&
+          !_surfaceTextureRenderTargetDisposable!.isDisposed) {
+        return;
+      }
+      _surfaceTextureRenderTargetDisposable =
+          await SurfaceTextureRenderTargetDisposable.create(
+        _controller,
+        _viewId,
+      );
+      return;
+    }
+
     if (_renderDisposable != null && !_renderDisposable!.isDisposed) {
       return;
     }
@@ -286,6 +306,8 @@ class _VideoViewControllerInternal with VideoViewControllerBaseMixin {
   }
 
   Future<void> disposeTextureRender() async {
+    await _surfaceTextureRenderTargetDisposable?.dispose();
+    _surfaceTextureRenderTargetDisposable = null;
     await _renderDisposable?.dispose();
     _renderDisposable = null;
   }
@@ -358,6 +380,9 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
     }
     final textureId = controller.getTextureId();
     if (textureId != kTextureNotInit) {
+      if (controller._controller.shouldUseSdkSurfaceTextureRender) {
+        await controller._controller.setupSdkSurfaceTextureRender();
+      }
       if (controller.textureWidth != 0 && controller.textureHeight != 0) {
         _width = controller.textureWidth;
         _height = controller.textureHeight;
@@ -391,8 +416,11 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
       return;
     }
     if (!oldWidget.controller.isSame(widget.controller)) {
+      await _controllerInternal?.disposeRenderInternal();
       await _controllerInternal?.disposeTextureRender();
       await _initialize();
+    } else if (_controllerInternal!._controller.shouldUseSdkSurfaceTextureRender) {
+      await _controllerInternal!._controller.setupSdkSurfaceTextureRender();
     }
   }
 
@@ -409,11 +437,19 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
   void dispose() {
     _isDisposed = true;
     methodChannel?.setMethodCallHandler(null);
-    if (_controllerInternal != null) {
-      _controllerInternal?.disposeTextureRender();
-      _controllerInternal = null;
+
+    final controllerInternal = _controllerInternal;
+    _controllerInternal = null;
+    if (controllerInternal != null) {
+      unawaited(_disposeTextureWidget(controllerInternal));
     }
     super.dispose();
+  }
+
+  Future<void> _disposeTextureWidget(
+      _VideoViewControllerInternal controllerInternal) async {
+    await controllerInternal.disposeRenderInternal();
+    await controllerInternal.disposeTextureRender();
   }
 
   @override

--- a/lib/src/impl/agora_video_view_impl.dart
+++ b/lib/src/impl/agora_video_view_impl.dart
@@ -419,7 +419,8 @@ class _AgoraRtcRenderTextureState extends State<AgoraRtcRenderTexture>
       await _controllerInternal?.disposeRenderInternal();
       await _controllerInternal?.disposeTextureRender();
       await _initialize();
-    } else if (_controllerInternal!._controller.shouldUseSdkSurfaceTextureRender) {
+    } else if (_controllerInternal!
+        ._controller.shouldUseSdkSurfaceTextureRender) {
       await _controllerInternal!._controller.setupSdkSurfaceTextureRender();
     }
   }

--- a/lib/src/impl/media_player_controller_impl.dart
+++ b/lib/src/impl/media_player_controller_impl.dart
@@ -341,6 +341,19 @@ class MediaPlayerControllerImpl
   int getVideoSourceType() => VideoSourceType.videoSourceMediaPlayer.value();
 
   @override
+  int getSurfaceTextureObserverId() => getMediaPlayerId();
+
+  @override
+  Future<void> bindSdkSurfaceTextureTarget(int surfaceTextureHandle) {
+    return setView(surfaceTextureHandle);
+  }
+
+  @override
+  Future<void> unbindSdkSurfaceTextureTarget() {
+    return setView(0);
+  }
+
+  @override
   Future<void> initialize() async {
     _mediaPlayer = await rtcEngine.createMediaPlayer();
     _initState.isInitialzed = true;

--- a/lib/src/impl/platform/global_video_view_controller_platform.dart
+++ b/lib/src/impl/platform/global_video_view_controller_platform.dart
@@ -30,8 +30,15 @@ abstract class GlobalVideoViewControllerPlatfrom {
           int videoSourceType, int videoViewSetupMode) =>
       SynchronousFuture(kTextureNotInit);
 
+  Future<Map<String, int>?> createSurfaceTextureRenderTarget(
+          int uid, String channelId, int videoSourceType, int videoViewSetupMode) =>
+      SynchronousFuture(null);
+
   /// Call `IrisVideoFrameBufferManager.DisableVideoFrameBuffer` in the native side
   Future<void> destroyTextureRender(int textureId) => SynchronousFuture(null);
+
+  Future<void> destroySurfaceTextureRenderTarget(int textureId) =>
+      SynchronousFuture(null);
 
   /// Increase the ref count of the native view(`UIView` in iOS, `SurfaceView` or `TextureView` in Android) of the `platformViewId`.
   Future<void> addPlatformRenderRef(int platformViewId) =>

--- a/lib/src/impl/platform/global_video_view_controller_platform.dart
+++ b/lib/src/impl/platform/global_video_view_controller_platform.dart
@@ -30,8 +30,8 @@ abstract class GlobalVideoViewControllerPlatfrom {
           int videoSourceType, int videoViewSetupMode) =>
       SynchronousFuture(kTextureNotInit);
 
-  Future<Map<String, int>?> createSurfaceTextureRenderTarget(
-          int uid, String channelId, int videoSourceType, int videoViewSetupMode) =>
+  Future<Map<String, int>?> createSurfaceTextureRenderTarget(int uid,
+          String channelId, int videoSourceType, int videoViewSetupMode) =>
       SynchronousFuture(null);
 
   /// Call `IrisVideoFrameBufferManager.DisableVideoFrameBuffer` in the native side

--- a/lib/src/impl/platform/io/global_video_view_controller_platform_io.dart
+++ b/lib/src/impl/platform/io/global_video_view_controller_platform_io.dart
@@ -119,6 +119,31 @@ class GlobalVideoViewControllerIO extends GlobalVideoViewControllerPlatfrom {
     return textureId ?? kTextureNotInit;
   }
 
+  @override
+  Future<Map<String, int>?> createSurfaceTextureRenderTarget(
+      int uid,
+      String channelId,
+      int videoSourceType,
+      int videoViewSetupMode) async {
+    final renderTarget = await methodChannel
+        .invokeMapMethod<String, dynamic>('createSurfaceTextureRenderTarget', {
+      'irisRtcRenderingHandle': _irisRtcRenderingHandle,
+      'uid': uid,
+      'channelId': channelId,
+      'videoSourceType': videoSourceType,
+      'videoViewSetupMode': videoViewSetupMode,
+    });
+    if (renderTarget == null) {
+      return null;
+    }
+
+    return {
+      'textureId': int.parse(renderTarget['textureId'].toString()),
+      'surfaceTextureHandle':
+          int.parse(renderTarget['surfaceTextureHandle'].toString()),
+    };
+  }
+
   /// Call `IrisVideoFrameBufferManager.DisableVideoFrameBuffer` in the native side
   @override
   Future<void> destroyTextureRender(int textureId) async {
@@ -127,6 +152,12 @@ class GlobalVideoViewControllerIO extends GlobalVideoViewControllerPlatfrom {
     }
 
     await methodChannel.invokeMethod('destroyTextureRender', textureId);
+  }
+
+  @override
+  Future<void> destroySurfaceTextureRenderTarget(int textureId) async {
+    await methodChannel.invokeMethod(
+        'destroySurfaceTextureRenderTarget', textureId);
   }
 
   /// Increase the ref count of the native view(`UIView` in iOS, `SurfaceView` or `TextureView` in Android) of the `platformViewId`.

--- a/lib/src/impl/platform/io/global_video_view_controller_platform_io.dart
+++ b/lib/src/impl/platform/io/global_video_view_controller_platform_io.dart
@@ -120,11 +120,8 @@ class GlobalVideoViewControllerIO extends GlobalVideoViewControllerPlatfrom {
   }
 
   @override
-  Future<Map<String, int>?> createSurfaceTextureRenderTarget(
-      int uid,
-      String channelId,
-      int videoSourceType,
-      int videoViewSetupMode) async {
+  Future<Map<String, int>?> createSurfaceTextureRenderTarget(int uid,
+      String channelId, int videoSourceType, int videoViewSetupMode) async {
     final renderTarget = await methodChannel
         .invokeMapMethod<String, dynamic>('createSurfaceTextureRenderTarget', {
       'irisRtcRenderingHandle': _irisRtcRenderingHandle,

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -13,6 +13,40 @@ import 'package:meta/meta.dart' show internal;
 const int kTextureNotInit = -1;
 const int kInvalidPlatformViewId = -1;
 
+class SurfaceTextureRenderTargetDisposable {
+  SurfaceTextureRenderTargetDisposable._(
+      this._controller, this._viewId, this.textureId);
+
+  final VideoViewControllerBaseMixin _controller;
+  final int _viewId;
+  final int textureId;
+  bool _isDisposed = false;
+
+  static Future<SurfaceTextureRenderTargetDisposable> create(
+    VideoViewControllerBaseMixin controller,
+    int viewId,
+  ) async {
+    final renderTarget = await controller._acquireSurfaceTextureRenderTarget(
+      viewId,
+    );
+    return SurfaceTextureRenderTargetDisposable._(
+      controller,
+      viewId,
+      renderTarget['textureId']!,
+    );
+  }
+
+  bool get isDisposed => _isDisposed;
+
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    await _controller._releaseSurfaceTextureRenderTarget(_viewId);
+  }
+}
+
 class TextureRenderDisposable {
   TextureRenderDisposable._(this._controller, this._viewId);
 
@@ -77,6 +111,7 @@ extension VideoViewControllerBaseExt on VideoViewControllerBase {
 
 mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
   int _textureId = kTextureNotInit;
+  int _sdkTextureTargetHandle = kNullViewHandle;
   int _viewHandle = kNullViewHandle;
   int _platformViewId = kInvalidPlatformViewId;
 
@@ -118,6 +153,9 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
   @override
   int getTextureId() => _textureId;
 
+  @internal
+  int getSdkTextureTargetHandle() => _sdkTextureTargetHandle;
+
   @override
   int getViewHandle() => _viewHandle;
 
@@ -129,6 +167,7 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     assert(oldController is VideoViewControllerBaseMixin);
     final oldControllerMixin = oldController as VideoViewControllerBaseMixin;
     _textureId = oldControllerMixin.getTextureId();
+    _sdkTextureTargetHandle = oldControllerMixin.getSdkTextureTargetHandle();
     _viewHandle = oldControllerMixin.getViewHandle();
     _platformViewId = oldControllerMixin.getPlatformViewId();
   }
@@ -181,6 +220,82 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     VideoRenderingPerformanceMonitor.instance.stopMonitoring(textureId);
   }
 
+  @internal
+  bool get shouldUseSdkSurfaceTextureRender {
+    return defaultTargetPlatform == TargetPlatform.android && useFlutterTexture;
+  }
+
+  Future<void> setupSdkSurfaceTextureRender() async {
+    if (!shouldUseSdkSurfaceTextureRender ||
+        _sdkTextureTargetHandle == kNullViewHandle) {
+      return;
+    }
+
+    debugPrint(
+      '[AgoraSurfaceTexture] bind '
+      'uid=${canvas.uid} '
+      'remote=${canvas.uid != 0} '
+      'textureId=$_textureId '
+      'surfaceTextureHandle=$_sdkTextureTargetHandle',
+    );
+
+    final newCanvas = VideoCanvas(
+      uid: canvas.uid,
+      subviewUid: canvas.subviewUid,
+      view: _sdkTextureTargetHandle,
+      backgroundColor: canvas.backgroundColor,
+      renderMode: canvas.renderMode,
+      mirrorMode: canvas.mirrorMode,
+      setupMode: canvas.setupMode,
+      sourceType: canvas.sourceType,
+      mediaPlayerId: canvas.mediaPlayerId,
+      cropArea: canvas.cropArea,
+      enableAlphaMask: canvas.enableAlphaMask,
+      position: canvas.position,
+    );
+
+    await rtcEngine.globalVideoViewController
+        ?.setupVideoView(kNullViewHandle, newCanvas, connection: connection);
+  }
+
+  Future<Map<String, int>> _acquireSurfaceTextureRenderTarget(int viewId) async {
+    if (!shouldUseSdkSurfaceTextureRender) {
+      return {
+        'textureId': kTextureNotInit,
+        'surfaceTextureHandle': kNullViewHandle,
+      };
+    }
+
+    if (_activeViewIds.contains(viewId) && _textureId != kTextureNotInit) {
+      return {
+        'textureId': _textureId,
+        'surfaceTextureHandle': _sdkTextureTargetHandle,
+      };
+    }
+
+    _activeViewIds.add(viewId);
+
+    if (_textureId == kTextureNotInit ||
+        _sdkTextureTargetHandle == kNullViewHandle) {
+      final renderTarget = await rtcEngine.globalVideoViewController
+          ?.createSurfaceTextureRenderTarget(
+        canvas.uid!,
+        connection?.channelId ?? '',
+        canvas.sourceType?.value() ?? getVideoSourceType(),
+        canvas.setupMode?.value() ??
+            VideoViewSetupMode.videoViewSetupReplace.value(),
+      );
+      _textureId = renderTarget?['textureId'] ?? kTextureNotInit;
+      _sdkTextureTargetHandle =
+          renderTarget?['surfaceTextureHandle'] ?? kNullViewHandle;
+    }
+
+    return {
+      'textureId': _textureId,
+      'surfaceTextureHandle': _sdkTextureTargetHandle,
+    };
+  }
+
   Future<void> _releaseTextureRender(int viewId) async {
     if (!shouldUseFlutterTexture) {
       return;
@@ -202,9 +317,35 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     }
   }
 
+  Future<void> _releaseSurfaceTextureRenderTarget(int viewId) async {
+    if (!shouldUseSdkSurfaceTextureRender) {
+      return;
+    }
+
+    if (!_activeViewIds.contains(viewId)) {
+      return;
+    }
+
+    _activeViewIds.remove(viewId);
+
+    if (_activeViewIds.isEmpty && _textureId != kTextureNotInit) {
+      debugPrint(
+        '[AgoraSurfaceTexture] release target '
+        'textureId=$_textureId '
+        'surfaceTextureHandle=$_sdkTextureTargetHandle',
+      );
+      await rtcEngine.globalVideoViewController
+          ?.destroySurfaceTextureRenderTarget(_textureId);
+      _textureId = kTextureNotInit;
+      _sdkTextureTargetHandle = kNullViewHandle;
+      _textureWidth = 0;
+      _textureHeight = 0;
+    }
+  }
+
   @protected
   Future<void> disposeRenderInternal() async {
-    if (shouldUseFlutterTexture) {
+    if (shouldUseFlutterTexture && !shouldUseSdkSurfaceTextureRender) {
       // Stop performance monitoring for this texture
       if (_textureId != kTextureNotInit) {
         _unregisterPerformanceStats(_textureId);
@@ -241,6 +382,31 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
           ?.setupVideoView(_viewHandle, newCanvas, connection: connection);
 
       _viewHandle = kNullViewHandle;
+    }
+
+    if (_sdkTextureTargetHandle != kNullViewHandle) {
+      debugPrint(
+        '[AgoraSurfaceTexture] unbind '
+        'uid=${canvas.uid} '
+        'remote=${canvas.uid != 0} '
+        'textureId=$_textureId '
+        'surfaceTextureHandle=$_sdkTextureTargetHandle',
+      );
+      final newCanvas = VideoCanvas(
+        view: _sdkTextureTargetHandle,
+        renderMode: canvas.renderMode,
+        mirrorMode: canvas.mirrorMode,
+        uid: canvas.uid,
+        sourceType: canvas.sourceType,
+        cropArea: canvas.cropArea,
+        setupMode: VideoViewSetupMode.videoViewSetupRemove,
+        mediaPlayerId: canvas.mediaPlayerId,
+      );
+
+      await rtcEngine.globalVideoViewController
+          ?.setupVideoView(kNullViewHandle, newCanvas, connection: connection);
+
+      _sdkTextureTargetHandle = kNullViewHandle;
     }
 
     // We need to ensure the platform view is valid before calling setupVideoView since

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -269,7 +269,8 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
         ?.setupVideoView(kNullViewHandle, newCanvas, connection: connection);
   }
 
-  Future<Map<String, int>> _acquireSurfaceTextureRenderTarget(int viewId) async {
+  Future<Map<String, int>> _acquireSurfaceTextureRenderTarget(
+      int viewId) async {
     if (!shouldUseSdkSurfaceTextureRender) {
       return {
         'textureId': kTextureNotInit,

--- a/lib/src/impl/video_view_controller_impl.dart
+++ b/lib/src/impl/video_view_controller_impl.dart
@@ -225,6 +225,15 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
     return defaultTargetPlatform == TargetPlatform.android && useFlutterTexture;
   }
 
+  @protected
+  int getSurfaceTextureObserverId() => canvas.uid!;
+
+  @protected
+  Future<void> bindSdkSurfaceTextureTarget(int surfaceTextureHandle) async {}
+
+  @protected
+  Future<void> unbindSdkSurfaceTextureTarget() async {}
+
   Future<void> setupSdkSurfaceTextureRender() async {
     if (!shouldUseSdkSurfaceTextureRender ||
         _sdkTextureTargetHandle == kNullViewHandle) {
@@ -238,6 +247,8 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
       'textureId=$_textureId '
       'surfaceTextureHandle=$_sdkTextureTargetHandle',
     );
+
+    await bindSdkSurfaceTextureTarget(_sdkTextureTargetHandle);
 
     final newCanvas = VideoCanvas(
       uid: canvas.uid,
@@ -279,7 +290,7 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
         _sdkTextureTargetHandle == kNullViewHandle) {
       final renderTarget = await rtcEngine.globalVideoViewController
           ?.createSurfaceTextureRenderTarget(
-        canvas.uid!,
+        getSurfaceTextureObserverId(),
         connection?.channelId ?? '',
         canvas.sourceType?.value() ?? getVideoSourceType(),
         canvas.setupMode?.value() ??
@@ -405,6 +416,8 @@ mixin VideoViewControllerBaseMixin implements VideoViewControllerBase {
 
       await rtcEngine.globalVideoViewController
           ?.setupVideoView(kNullViewHandle, newCanvas, connection: connection);
+
+      await unbindSdkSurfaceTextureTarget();
 
       _sdkTextureTargetHandle = kNullViewHandle;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   json_annotation: ^4.4.0
-  ffi: ^1.1.2
+  ffi: '>=1.1.2 <3.0.0'
   async: ^2.11.0
   meta: ^1.7.0
   iris_method_channel: ^2.2.4

--- a/test_shard/iris_tester/pubspec.yaml
+++ b/test_shard/iris_tester/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  ffi: '>=1.1.2'
+  ffi: '>=1.1.2 <3.0.0'
   js: ^0.6.3
 
 dev_dependencies:


### PR DESCRIPTION
Changes:
- Cherry-pick the Android SurfaceTexture rendering and media player Flutter texture support from PR #2621.
- Preserve the existing lifecycle/performance handling while releasing SDK SurfaceTexture targets correctly.
- Relax direct ffi constraints in the root plugin and iris_tester to `>=1.1.2 <3.0.0`, allowing ffi 2.x on newer Dart/Flutter versions.

Verification:
- Flutter 3.24.5 targeted analyze: passed
- Flutter 3.24.5 selected unit tests: passed
- Android debug APK build: passed