### PR TITLE
fix: use Iris-owned Android session cleanup

### DIFF
--- a/android/src/main/java/io/agora/agora_rtc_ng/AgoraRtcNgPlugin.java
+++ b/android/src/main/java/io/agora/agora_rtc_ng/AgoraRtcNgPlugin.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
 import android.os.Build;
-import android.util.Log;
 import android.util.Rational;
 
 import androidx.annotation.NonNull;
@@ -12,7 +11,6 @@ import androidx.annotation.Nullable;
 
 import io.agora.iris.pip.AgoraPIPActivityProxy;
 import io.agora.iris.pip.AgoraPIPController;
-import io.agora.rtc2.RtcEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -25,69 +23,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AgoraRtcNgPlugin implements FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware {
-    private static final String TAG = "AgoraRtcNgPlugin";
-    @Nullable
-    private static Long cachedNativeRtcEngineHandle;
-    @Nullable
-    private static Boolean cachedNativeRtcEngineOwnedByFlutter;
-
     private MethodChannel channel;
     private WeakReference<FlutterPluginBinding> flutterPluginBindingRef;
     private VideoViewController videoViewController;
     private AgoraPIPController pipController;
     @Nullable
     private Context applicationContext;
-
-    private boolean hasCachedNativeRtcEngineHandle() {
-        return cachedNativeRtcEngineHandle != null && cachedNativeRtcEngineHandle != 0L;
-    }
-
-    private void cacheNativeRtcEngineHandle(@Nullable Number nativeHandle) {
-        if (nativeHandle == null || nativeHandle.longValue() == 0L) {
-            Log.i(TAG, "Clear cached native engine handle");
-            cachedNativeRtcEngineHandle = null;
-            return;
-        }
-
-        cachedNativeRtcEngineHandle = nativeHandle.longValue();
-        Log.i(TAG, "Cache native engine handle=" + cachedNativeRtcEngineHandle);
-    }
-
-    @NonNull
-    private Map<String, Object> buildAndroidInitResult() {
-        final Map<String, Object> result = new HashMap<>();
-        result.put("cachedNativeHandle",
-                cachedNativeRtcEngineHandle != null ? cachedNativeRtcEngineHandle : 0L);
-        result.put(
-                "destroyExistingEngine",
-                hasCachedNativeRtcEngineHandle()
-                        && Boolean.TRUE.equals(cachedNativeRtcEngineOwnedByFlutter));
-        Log.i(TAG, "androidInit cachedNativeHandle=" + result.get("cachedNativeHandle")
-                + ", destroyExistingEngine=" + result.get("destroyExistingEngine")
-                + ", ownedByFlutter=" + cachedNativeRtcEngineOwnedByFlutter);
-        return result;
-    }
-
-    private void clearCachedNativeEngineState() {
-        cacheNativeRtcEngineHandle(null);
-        cachedNativeRtcEngineOwnedByFlutter = null;
-    }
-
-    private boolean forceReleaseRtcEngineFromJava(long nativeHandle) {
-        if (nativeHandle == 0L) {
-            return false;
-        }
-
-        try {
-            Log.i(TAG, "Force release stale engine by Java destroy, handle=" + nativeHandle);
-            RtcEngine.destroy();
-            Log.i(TAG, "Force release stale engine success, handle=" + nativeHandle);
-            return true;
-        } catch (Throwable throwable) {
-            Log.e(TAG, "Force release stale engine failed, handle=" + nativeHandle, throwable);
-            return false;
-        }
-    }
 
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
@@ -127,34 +68,11 @@ public class AgoraRtcNgPlugin implements FlutterPlugin, MethodChannel.MethodCall
     public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
         if ("getAssetAbsolutePath".equals(call.method)) {
             getAssetAbsolutePath(call, result);
-        } else if ("androidCacheNativeEngineHandle".equals(call.method)) {
-            final Number nativeHandle = call.argument("nativeHandle");
-            final Boolean ownedByFlutter = call.argument("ownedByFlutter");
-            cacheNativeRtcEngineHandle(nativeHandle);
-            cachedNativeRtcEngineOwnedByFlutter =
-                    ownedByFlutter != null && ownedByFlutter;
-            Log.i(TAG, "androidCacheNativeEngineHandle ownedByFlutter="
-                    + cachedNativeRtcEngineOwnedByFlutter);
-            result.success(hasCachedNativeRtcEngineHandle());
-        } else if ("androidForceReleaseCachedNativeEngine".equals(call.method)) {
-            final long nativeHandle =
-                    cachedNativeRtcEngineHandle != null ? cachedNativeRtcEngineHandle : 0L;
-            if (nativeHandle == 0L || !Boolean.TRUE.equals(cachedNativeRtcEngineOwnedByFlutter)) {
-                Log.i(TAG, "Skip force release, handle=" + nativeHandle
-                        + ", ownedByFlutter=" + cachedNativeRtcEngineOwnedByFlutter);
-                result.success(false);
-                return;
-            }
-
-            result.success(forceReleaseRtcEngineFromJava(nativeHandle));
-        } else if ("androidClearNativeEngineHandle".equals(call.method)) {
-            clearCachedNativeEngineState();
-            result.success(true);
         } else if ("androidInit".equals(call.method)) {
             // dart ffi DynamicLibrary.open do not trigger JNI_OnLoad in iris, so we need call java
             // System.loadLibrary here to trigger the JNI_OnLoad explicitly.
             System.loadLibrary("AgoraRtcWrapper");
-            result.success(buildAndroidInitResult());
+            result.success(true);
         } else if (call.method.startsWith("pip")) {
             handlePipMethodCall(call, result);
         } else {

--- a/lib/src/impl/agora_rtc_engine_impl.dart
+++ b/lib/src/impl/agora_rtc_engine_impl.dart
@@ -441,97 +441,87 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
     // If previous initialization still in progess, skip it.
     if (_initializingCompleter != null &&
         !_initializingCompleter!.isCompleted) {
+      await _initializingCompleter!.future;
+      if (!_rtcEngineState.isInitialzed) {
+        await initialize(context);
+      }
       return;
     }
 
-    _initializingCompleter = Completer<void>();
-    _initializeCallOnce ??= AsyncMemoizer();
-    await _initializeCallOnce!.runOnce(() async {
-      engineMethodChannel = const MethodChannel('agora_rtc_ng');
+    final initializingCompleter = Completer<void>();
+    _initializingCompleter = initializingCompleter;
+    try {
+      _initializeCallOnce ??= AsyncMemoizer();
+      await _initializeCallOnce!.runOnce(() async {
+        engineMethodChannel = const MethodChannel('agora_rtc_ng');
 
-      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        final initResult =
-            await engineMethodChannel.invokeMethod<dynamic>('androidInit');
-        debugPrint(
-            '[RtcEngineImpl] androidInit result=$initResult, sharedNativeHandle=$_sharedNativeHandle');
-        if (_sharedNativeHandle == null && initResult is Map) {
-          final destroyExistingEngine =
-              initResult['destroyExistingEngine'] == true;
-          final cachedNativeHandle = initResult['cachedNativeHandle'];
-          if (destroyExistingEngine &&
-              cachedNativeHandle is int &&
-              cachedNativeHandle != 0) {
-            debugPrint(
-                '[RtcEngineImpl] force release stale cached engine before initialize: $cachedNativeHandle');
-            try {
-              await engineMethodChannel.invokeMethod(
-                'androidForceReleaseCachedNativeEngine',
-              );
-            } finally {
-              try {
-                await engineMethodChannel
-                    .invokeMethod('androidClearNativeEngineHandle');
-              } catch (e) {
-                // Best-effort stale engine cleanup on Android.
-              }
-            }
+        if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+          await engineMethodChannel.invokeMethod('androidInit');
+        }
+
+        engineMethodChannel.setMethodCallHandler((call) async {
+          try {
+            methodChannelHandlers[call.method]?.forEach((handler) async {
+              await handler(call);
+            });
+          } catch (e) {
+            assert(false, 'methodChannel error: $e');
           }
-        }
-      }
+        });
 
-      engineMethodChannel.setMethodCallHandler((call) async {
-        try {
-          methodChannelHandlers[call.method]?.forEach((handler) async {
-            await handler(call);
-          });
-        } catch (e) {
-          assert(false, 'methodChannel error: $e');
-        }
+        List<InitilizationArgProvider> args = [
+          if (_sharedNativeHandle != null)
+            SharedNativeHandleInitilizationArgProvider(_sharedNativeHandle!)
+        ];
+        assert(() {
+          if (_mockRtcEngineProvider != null) {
+            args.add(_mockRtcEngineProvider!);
+          }
+          return true;
+        }());
+
+        await irisMethodChannel.initilize(args);
+        await _initializeInternal(context);
       });
 
-      List<InitilizationArgProvider> args = [
-        if (_sharedNativeHandle != null)
-          SharedNativeHandleInitilizationArgProvider(_sharedNativeHandle!)
-      ];
-      assert(() {
-        if (_mockRtcEngineProvider != null) {
-          args.add(_mockRtcEngineProvider!);
+      await super.initialize(context);
+
+      await irisMethodChannel.invokeMethod(IrisMethodCall(
+        'RtcEngine_setAppType',
+        jsonEncode({'appType': 4}),
+      ));
+
+      _rtcEngineState.isInitialzed = true;
+      _isReleased = false;
+    } catch (e, s) {
+      final videoViewController = _globalVideoViewController;
+      if (videoViewController != null) {
+        try {
+          await videoViewController.detachVideoFrameBufferManager(
+              irisMethodChannel.getApiEngineHandle());
+        } catch (cleanupError) {
+          debugPrint(
+              '[RtcEngineImpl] initialize renderer rollback failed: $cleanupError');
+        } finally {
+          _globalVideoViewController = null;
         }
-        return true;
-      }());
-
-      await irisMethodChannel.initilize(args);
-      await _initializeInternal(context);
-    });
-
-    await super.initialize(context);
-
-    await irisMethodChannel.invokeMethod(IrisMethodCall(
-      'RtcEngine_setAppType',
-      jsonEncode({'appType': 4}),
-    ));
-
-    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      }
       try {
-        final nativeHandle = await getNativeHandle();
+        await irisMethodChannel.dispose();
+      } catch (cleanupError) {
         debugPrint(
-            '[RtcEngineImpl] cache current native handle after initialize: $nativeHandle');
-        await engineMethodChannel.invokeMethod(
-          'androidCacheNativeEngineHandle',
-          {
-            'nativeHandle': nativeHandle,
-            'ownedByFlutter': _sharedNativeHandle == null,
-          },
-        );
-      } catch (e) {
-        // Best-effort cache update on Android.
+            '[RtcEngineImpl] initialize Iris rollback failed: $cleanupError');
+      }
+      _initializeCallOnce = null;
+      Error.throwWithStackTrace(e, s);
+    } finally {
+      if (!initializingCompleter.isCompleted) {
+        initializingCompleter.complete();
+      }
+      if (identical(_initializingCompleter, initializingCompleter)) {
+        _initializingCompleter = null;
       }
     }
-
-    _rtcEngineState.isInitialzed = true;
-    _isReleased = false;
-    _initializingCompleter?.complete(null);
-    _initializingCompleter = null;
   }
 
   @internal
@@ -561,6 +551,7 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
 
     // If previous release still in progess, skip it.
     if (_releasingCompleter != null && !_releasingCompleter!.isCompleted) {
+      await _releasingCompleter!.future;
       return;
     }
 
@@ -568,39 +559,57 @@ class RtcEngineImpl extends rtc_engine_ex_binding.RtcEngineExImpl
       return;
     }
 
-    _releasingCompleter = Completer<void>();
-
-    _rtcEngineStateInternal?.dispose();
-    _rtcEngineStateInternal = null;
-
-    await _objectPool.clear();
-
-    await _globalVideoViewController
-        ?.detachVideoFrameBufferManager(irisMethodChannel.getApiEngineHandle());
-    _globalVideoViewController = null;
-
-    await irisMethodChannel.unregisterEventHandlers(_rtcEngineImplScopedKey);
-
+    final releasingCompleter = Completer<void>();
+    _releasingCompleter = releasingCompleter;
     try {
-      await super.release(sync: sync);
-    } finally {
-      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      Object? firstError;
+      StackTrace? firstStackTrace;
+
+      Future<void> runReleaseStep(Future<void> Function() step) async {
         try {
-          await engineMethodChannel
-              .invokeMethod('androidClearNativeEngineHandle');
-        } catch (e) {
-          // Best-effort cache clear on Android.
+          await step();
+        } catch (e, s) {
+          firstError ??= e;
+          firstStackTrace ??= s;
         }
       }
-    }
 
-    await irisMethodChannel.dispose();
-    _isReleased = true;
-    _releasingCompleter?.complete(null);
-    _releasingCompleter = null;
-    assert(_initializeCallOnce!.hasRun);
-    _initializeCallOnce = null;
-    _instance = null;
+      await runReleaseStep(() async {
+        try {
+          _rtcEngineStateInternal?.dispose();
+        } finally {
+          _rtcEngineStateInternal = null;
+        }
+      });
+      await runReleaseStep(_objectPool.clear);
+      await runReleaseStep(() async {
+        try {
+          await _globalVideoViewController?.detachVideoFrameBufferManager(
+              irisMethodChannel.getApiEngineHandle());
+        } finally {
+          _globalVideoViewController = null;
+        }
+      });
+      await runReleaseStep(() =>
+          irisMethodChannel.unregisterEventHandlers(_rtcEngineImplScopedKey));
+      await runReleaseStep(() => super.release(sync: sync));
+      await runReleaseStep(irisMethodChannel.dispose);
+
+      _isReleased = true;
+      _initializeCallOnce = null;
+      _instance = null;
+
+      if (firstError != null) {
+        Error.throwWithStackTrace(firstError!, firstStackTrace!);
+      }
+    } finally {
+      if (!releasingCompleter.isCompleted) {
+        releasingCompleter.complete();
+      }
+      if (identical(_releasingCompleter, releasingCompleter)) {
+        _releasingCompleter = null;
+      }
+    }
   }
 
   @override

--- a/lib/src/impl/platform/io/native_iris_api_engine_binding_delegate.dart
+++ b/lib/src/impl/platform/io/native_iris_api_engine_binding_delegate.dart
@@ -28,15 +28,30 @@ ffi.DynamicLibrary _loadLib() {
 }
 
 class NativeIrisApiEngineBindingsDelegate
-    extends PlatformBindingsDelegateInterface {
+    extends PlatformBindingsDelegateInterface
+    implements NativeCleanupCallbackProvider {
+  late final ffi.DynamicLibrary _dynamicLibrary;
   late final bindings.NativeIrisApiEngineBinding _binding;
   bindings.NativeIrisApiEngineBinding get binding => _binding;
 
   @override
   void initialize() {
-    _binding = bindings.NativeIrisApiEngineBinding(_loadLib());
+    _dynamicLibrary = _loadLib();
+    _binding = bindings.NativeIrisApiEngineBinding(_dynamicLibrary);
     _binding.enableUseJsonArray(1);
   }
+
+  @override
+  int get destroyNativeApiEngineAddress => _dynamicLibrary
+      .lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'DestroyIrisApiEngine')
+      .address;
+
+  @override
+  int get destroyIrisEventHandlerAddress => _dynamicLibrary
+      .lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'DestroyIrisEventHandler')
+      .address;
 
   @override
   CreateApiEngineResult createApiEngine(List<InitilizationArgProvider> args) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel: ^2.2.5
+  iris_method_channel: ^2.2.6
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,10 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: ^1.7.0
-  iris_method_channel: ^2.2.6
+  iris_method_channel:
+    git:
+      url: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter.git
+      ref: bbd3b262549318fd4cbc8afff011e3f1dec8007c
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/agora_rtc_engine_lifecycle_test.dart
+++ b/test/agora_rtc_engine_lifecycle_test.dart
@@ -1,0 +1,165 @@
+import 'package:agora_rtc_engine/src/agora_rtc_engine.dart';
+import 'package:agora_rtc_engine/src/agora_rtc_engine_ext.dart';
+import 'package:agora_rtc_engine/src/impl/agora_rtc_engine_impl.dart';
+import 'package:agora_rtc_engine/src/impl/platform/platform_bindings_provider.dart';
+import 'package:flutter/foundation.dart' show VoidCallback;
+import 'package:flutter/services.dart' show MethodChannel;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iris_method_channel/iris_method_channel.dart';
+
+class _FakeIrisMethodChannel extends IrisMethodChannel {
+  _FakeIrisMethodChannel({
+    this.initializeFailuresRemaining = 0,
+    this.disposeFailuresRemaining = 0,
+    this.rtcEngineInitializeFailuresRemaining = 0,
+  }) : super(createPlatformBindingsProvider());
+
+  int initializeFailuresRemaining;
+  int disposeFailuresRemaining;
+  int rtcEngineInitializeFailuresRemaining;
+  int initializeCalls = 0;
+  int disposeCalls = 0;
+  bool initialized = false;
+
+  @override
+  Future<InitilizationResult?> initilize(
+      List<InitilizationArgProvider> args) async {
+    initializeCalls++;
+    if (initializeFailuresRemaining > 0) {
+      initializeFailuresRemaining--;
+      throw StateError('initialize failed');
+    }
+    initialized = true;
+    return null;
+  }
+
+  @override
+  Future<CallApiResult> invokeMethod(IrisMethodCall methodCall) async {
+    if (methodCall.funcName == 'RtcEngine_initialize_0320339' &&
+        rtcEngineInitializeFailuresRemaining > 0) {
+      rtcEngineInitializeFailuresRemaining--;
+      return CallApiResult(irisReturnCode: -1, data: const {});
+    }
+    return CallApiResult(
+      irisReturnCode: 0,
+      data: {
+        'result': 0,
+        if (methodCall.funcName == 'CreateIrisRtcRendering')
+          'irisRtcRenderingHandle': 0,
+      },
+    );
+  }
+
+  @override
+  Future<void> unregisterEventHandlers(TypedScopedKey scopedKey) async {}
+
+  @override
+  int getApiEngineHandle() => initialized ? 1 : 0;
+
+  @override
+  VoidCallback addHotRestartListener(HotRestartListener listener) => () {};
+
+  @override
+  void removeHotRestartListener(HotRestartListener listener) {}
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+    initialized = false;
+    if (disposeFailuresRemaining > 0) {
+      disposeFailuresRemaining--;
+      throw StateError('dispose failed');
+    }
+  }
+}
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  const engineMethodChannel = MethodChannel('agora_rtc_ng');
+
+  const context = RtcEngineContext(appId: 'test-app-id');
+
+  setUp(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      engineMethodChannel,
+      (call) async => true,
+    );
+  });
+
+  tearDown(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      engineMethodChannel,
+      null,
+    );
+  });
+
+  test('initialize can retry after Iris initialization fails', () async {
+    final irisMethodChannel =
+        _FakeIrisMethodChannel(initializeFailuresRemaining: 1);
+    final engine = RtcEngineImpl.createForTesting(
+      irisMethodChannel: irisMethodChannel,
+    ) as RtcEngineImpl;
+
+    await expectLater(engine.initialize(context), throwsStateError);
+    await engine.initialize(context);
+
+    expect(irisMethodChannel.initializeCalls, 2);
+    expect(engine.isInitialzed, isTrue);
+    await engine.release();
+  });
+
+  test('concurrent initialize retries when the first attempt fails', () async {
+    final irisMethodChannel =
+        _FakeIrisMethodChannel(initializeFailuresRemaining: 1);
+    final engine = RtcEngineImpl.createForTesting(
+      irisMethodChannel: irisMethodChannel,
+    ) as RtcEngineImpl;
+
+    final firstInitialize = engine.initialize(context);
+    final secondInitialize = engine.initialize(context);
+
+    await expectLater(firstInitialize, throwsStateError);
+    await secondInitialize;
+
+    expect(irisMethodChannel.initializeCalls, 2);
+    expect(engine.isInitialzed, isTrue);
+    await engine.release();
+  });
+
+  test('initialize can proceed after Iris disposal reports an error', () async {
+    final irisMethodChannel =
+        _FakeIrisMethodChannel(disposeFailuresRemaining: 1);
+    final engine = RtcEngineImpl.createForTesting(
+      irisMethodChannel: irisMethodChannel,
+    ) as RtcEngineImpl;
+
+    await engine.initialize(context);
+    await expectLater(engine.release(), throwsStateError);
+    await engine.initialize(context).timeout(const Duration(seconds: 1));
+
+    expect(irisMethodChannel.initializeCalls, 2);
+    expect(engine.isInitialzed, isTrue);
+    await engine.release();
+  });
+
+  test('native initialization failure rolls back the Iris owner', () async {
+    final irisMethodChannel = _FakeIrisMethodChannel(
+      rtcEngineInitializeFailuresRemaining: 1,
+    );
+    final engine = RtcEngineImpl.createForTesting(
+      irisMethodChannel: irisMethodChannel,
+    ) as RtcEngineImpl;
+
+    await expectLater(
+      engine.initialize(context),
+      throwsA(isA<AgoraRtcException>()),
+    );
+
+    expect(irisMethodChannel.disposeCalls, 1);
+    expect(irisMethodChannel.initialized, isFalse);
+
+    await engine.initialize(context);
+    expect(irisMethodChannel.initializeCalls, 2);
+    await engine.release();
+  });
+}


### PR DESCRIPTION
## Summary\n- Remove Android cached native-handle and Java RtcEngine.destroy cleanup.\n- Depend on Iris-owned native session cleanup instead.\n- Make initialize/release retry and cleanup paths resilient to concurrent calls and failures.\n\n## Validation\n- flutter test test/agora_rtc_engine_lifecycle_test.dart\n- Android release build\n\n## Customer Test Dependency\n- Pins Iris directly to commit bbd3b262549318fd4cbc8afff011e3f1dec8007c from PR #140.\n- No pub.dev publication or tag is required for this PR.\n\n## Notes\n- No application configuration, token, device log, or test credential is included.