### PR TITLE
fix: handle commit refs in prepare branch action

### DIFF
--- a/.github/actions/prepare_branch/action.yml
+++ b/.github/actions/prepare_branch/action.yml
@@ -43,8 +43,10 @@ runs:
         }
 
         # Check if target_branch exists as a remote branch
-        check_remote_branch "${{ inputs.target_branch }}"
-        if [ $? -ne 0 ]; then
+        if check_remote_branch "${{ inputs.target_branch }}"; then
+          echo "Target branch exists as a remote branch"
+          final_target_branch="${{ inputs.target_branch }}"
+        else
           echo "Target branch does not exist as a remote branch, treating as a commit/tag reference"
 
           # get pub_version from pubspec.yaml if inputs.pub_version is empty
@@ -60,10 +62,6 @@ runs:
 
           # push the new branch to the remote repository, set the result always as success even if the push failed
           git push -u origin HEAD:${final_target_branch} || true
-        else
-          echo "Target branch exists as a remote branch"
-          final_target_branch="${{ inputs.target_branch }}"
-          
         fi
 
         echo "final_target_branch=${final_target_branch}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- evaluate the remote-branch probe directly in the if condition
- allow missing branch, commit, and tag refs to reach the existing special-branch creation path under bash -e
- preserve the existing-remote-branch behavior

## Evidence

- Rehoboam-triggered run 33284540221 parsed the Flutter 4.6.4 dependencies, then failed before branch creation because the probe returned 1 under bash -e
- focused local bare-remote check created special/6.6.4 from a commit ref and emitted final_target_branch=special/6.6.4
- YAML parse and git diff --check passed