### PR TITLE
fix: load prepare branch action from main

### DIFF
--- a/.github/actions/prepare_branch/action.yml
+++ b/.github/actions/prepare_branch/action.yml
@@ -43,8 +43,10 @@ runs:
         }
 
         # Check if target_branch exists as a remote branch
-        check_remote_branch "${{ inputs.target_branch }}"
-        if [ $? -ne 0 ]; then
+        if check_remote_branch "${{ inputs.target_branch }}"; then
+          echo "Target branch exists as a remote branch"
+          final_target_branch="${{ inputs.target_branch }}"
+        else
           echo "Target branch does not exist as a remote branch, treating as a commit/tag reference"
 
           # get pub_version from pubspec.yaml if inputs.pub_version is empty
@@ -60,10 +62,6 @@ runs:
 
           # push the new branch to the remote repository, set the result always as success even if the push failed
           git push -u origin HEAD:${final_target_branch} || true
-        else
-          echo "Target branch exists as a remote branch"
-          final_target_branch="${{ inputs.target_branch }}"
-          
         fi
 
         echo "final_target_branch=${final_target_branch}" >> $GITHUB_OUTPUT

--- a/.github/workflows/run_gen_code.yml
+++ b/.github/workflows/run_gen_code.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Prepare target branch
         id: prepare_target_branch
-        uses: ./.github/actions/prepare_branch
+        uses: AgoraIO-Extensions/Agora-Flutter-SDK/.github/actions/prepare_branch@main
         with:
           target_branch: ${{ inputs.target_branch || github.ref_name}}
           pub_version: ""

--- a/.github/workflows/run_update_deps.yml
+++ b/.github/workflows/run_update_deps.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Prepare target branch
         id: prepare_target_branch
-        uses: ./.github/actions/prepare_branch
+        uses: AgoraIO-Extensions/Agora-Flutter-SDK/.github/actions/prepare_branch@main
         with:
           target_branch: ${{ inputs.target_branch || github.ref_name }}
           pub_version: ${{ inputs.pub_version }}


### PR DESCRIPTION
## Summary

- load the shared prepare_branch composite action from main in update-deps and gen-code workflows
- keep target repository checkout and workflow inputs unchanged
- ensure commit/tag targets use the fixed branch probe even when the target checkout predates the fix

## Evidence

- run 33285122888 used workflow main at 3b6030a5 but loaded the stale local action from target checkout 5ee09b6c and failed before branch creation
- run 33284540221 and 33285122888 both parsed the exact 4.6.4-build.3 dependency matrix successfully
- YAML parse and git diff --check passed
- actionlint reported only pre-existing unrelated workflow findings