### PR TITLE
test: log local video events in video example

### DIFF
--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -76,6 +76,10 @@ class _State extends State<JoinChannelVideo> {
       onError: (ErrorCodeType err, String msg) {
         logSink.log('[onError] err: $err, msg: $msg');
       },
+      onLocalVideoEvent: (VideoSourceType source, LocalVideoEventType event) {
+        logSink.log(
+            '[onLocalVideoEvent] source: $source, event: $event, value: ${event.value()}');
+      },
       onJoinChannelSuccess: (RtcConnection connection, int elapsed) {
         logSink.log(
             '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');


### PR DESCRIPTION
## Summary

- handle `onLocalVideoEvent` in the basic JoinChannelVideo example
- log the video source, event enum, and numeric event value so QA can identify focal-length events `5` and `6`

## Testing

- `dart format example/lib/examples/basic/join_channel_video/join_channel_video.dart`
- `flutter test test/local_video_event_type_test.dart` (1 passed)
- `flutter test` (8 passed)
- `cd example && flutter analyze lib/examples/basic/join_channel_video/join_channel_video.dart` (no issues)
- `cd example && flutter test test/widget_test.dart` (existing failure: the baseline test expects a `Running on:` text that `example/lib/main.dart` no longer renders)

## Scope

- no generated SDK API changes
- no release label or release action