### PR TITLE
feat: release agora_rtc_engine 6.6.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,12 +58,12 @@ dependencies {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
     // iris dependencies start
-    api 'io.agora.rtc:iris-rtc:4.6.2-build.1'
+    api 'io.agora.rtc:iris-rtc:4.6.4-build.3'
     // iris dependencies end
 
     // native dependencies start
-    api 'io.agora.rtc:full-screen-sharing:4.6.2.70'
-    api 'io.agora.rtc:agora-special-full:4.6.2.70'
+    api 'cn.shengwang.rtc:agora-full-preview:4.6.4-build.3'
+    api 'cn.shengwang.rtc:full-screen-sharing-special:4.6.4-build.3'
     // native dependencies end
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,12 +58,12 @@ dependencies {
     api fileTree(dir: "libs", include: ["*.jar"])
   } else {
     // iris dependencies start
-    api 'io.agora.rtc:iris-rtc:4.6.4-build.3'
+    api 'io.agora.rtc:iris-rtc:4.6.4-build.4'
     // iris dependencies end
 
     // native dependencies start
-    api 'cn.shengwang.rtc:agora-full-preview:4.6.4-build.3'
-    api 'cn.shengwang.rtc:full-screen-sharing-special:4.6.4-build.3'
+    api 'io.agora.rtc:full-sdk:4.6.4'
+    api 'io.agora.rtc:full-screen-sharing:4.6.4'
     // native dependencies end
   }
 }

--- a/ci/update_spm_deps.mjs
+++ b/ci/update_spm_deps.mjs
@@ -539,7 +539,8 @@ function parsePlatformDependencies(content) {
   ];
 
   for (const record of records) {
-    const fieldCounts = countSpmFields(record);
+    const spmRecord = record.replace(/Build\s+version(?=\s*[:=])/gi, 'Build-version');
+    const fieldCounts = countSpmFields(spmRecord);
     const platformValues = parseLabeledValues(record, 'platform');
     const platformValue = platformValues[0] ?? null;
     const isExplicitApplePlatform = /^(?:iOS|macOS)$/i.test(platformValue ?? '');
@@ -560,7 +561,7 @@ function parsePlatformDependencies(content) {
       ? (platformValue.toLowerCase() === 'ios' ? 'iOS' : 'macOS')
       : null;
     const githubValue = parseLabeledValues(record, 'github')[0] ?? null;
-    const versionValue = parseLabeledValues(record, 'tag|version')[0] ?? null;
+    const versionValue = parseLabeledValues(spmRecord, 'tag|version')[0] ?? null;
     const products = fieldCounts.products > 0 ? parseProducts(record) : undefined;
     const irisUrlValue = parseIrisUrlValues(record)[0] ?? null;
     const checksumValue =

--- a/ci/update_spm_deps.test.mjs
+++ b/ci/update_spm_deps.test.mjs
@@ -368,6 +368,20 @@ test('ignores a compact build result version while parsing Iris CocoaPods metada
   );
 });
 
+test('ignores a compact build result version when Native SPM metadata follows', () => {
+  const dependencies = spmUpdater.parsePlatformDependencies([
+    'Iris SDK Build ResultBuild version:4.6.4-build.4',
+    "Iris macOS:Cocoapods:pod 'AgoraIrisRTC_macOS', '4.6.4-build.4'",
+    "Iris iOS:Cocoapods:pod 'AgoraIrisRTC_iOS', '4.6.4-build.4'",
+    " pod 'AgoraRtcEngine_iOS', '4.6.4'",
+    ' github:git@github.com:AgoraIO/AgoraRtcEngine_iOS.git | tag:4.6.4',
+    " implementation 'io.agora.rtc:full-sdk:4.6.4'",
+  ].join(''));
+
+  assert.equal(dependencies.get('iOS')?.version, '4.6.4');
+  assert.equal(dependencies.get('iOS')?.irisPodVersion, '4.6.4-build.4');
+});
+
 test('rejects Iris SPM derivation from an Apple build section marked failed', () => {
   const failedBuildResult = irisBuildResultWithoutFailures.replace(
     'Iris Android:',

--- a/example/lib/examples/advanced/camera_capturer_configuration/camera_capturer_configuration.dart
+++ b/example/lib/examples/advanced/camera_capturer_configuration/camera_capturer_configuration.dart
@@ -1,0 +1,260 @@
+import 'package:agora_rtc_engine/agora_rtc_engine.dart' as agora;
+import 'package:agora_rtc_engine_example/components/example_actions_widget.dart';
+import 'package:agora_rtc_engine_example/components/log_sink.dart';
+import 'package:agora_rtc_engine_example/components/remote_video_views_widget.dart';
+import 'package:agora_rtc_engine_example/config/agora.config.dart' as config;
+import 'package:flutter/material.dart';
+
+/// CameraCapturerConfiguration Example
+class CameraCapturerConfiguration extends StatefulWidget {
+  /// Construct the [CameraCapturerConfiguration]
+  const CameraCapturerConfiguration({Key? key}) : super(key: key);
+
+  @override
+  State<CameraCapturerConfiguration> createState() => _State();
+}
+
+class _State extends State<CameraCapturerConfiguration>
+    with KeepRemoteVideoViewsMixin {
+  late final agora.RtcEngine _engine;
+  late final agora.RtcEngineEventHandler _eventHandler;
+  late final TextEditingController _channelIdController;
+  late final TextEditingController _uidController;
+  late final TextEditingController _widthController;
+  late final TextEditingController _heightController;
+  late final TextEditingController _fpsController;
+  agora.CameraDirection _cameraDirection = agora.CameraDirection.cameraFront;
+  agora.CameraFocalLengthType _cameraFocalLengthType =
+      agora.CameraFocalLengthType.cameraFocalLengthDefault;
+  bool _followEncodeDimensionRatio = true;
+  bool _isReady = false;
+  bool _isJoined = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _channelIdController = TextEditingController(text: config.channelId);
+    _uidController = TextEditingController(text: config.uid.toString());
+    _widthController = TextEditingController(text: '960');
+    _heightController = TextEditingController(text: '540');
+    _fpsController = TextEditingController(text: '15');
+    _initEngine();
+  }
+
+  @override
+  void dispose() {
+    _channelIdController.dispose();
+    _uidController.dispose();
+    _widthController.dispose();
+    _heightController.dispose();
+    _fpsController.dispose();
+    _dispose();
+    super.dispose();
+  }
+
+  Future<void> _dispose() async {
+    _engine.unregisterEventHandler(_eventHandler);
+    await _engine.leaveChannel();
+    await _engine.release();
+  }
+
+  Future<void> _initEngine() async {
+    _engine = agora.createAgoraRtcEngine();
+    await _engine.initialize(agora.RtcEngineContext(
+      appId: config.appId,
+      channelProfile: agora.ChannelProfileType.channelProfileLiveBroadcasting,
+    ));
+
+    _eventHandler = agora.RtcEngineEventHandler(
+      onError: (agora.ErrorCodeType err, String msg) {
+        logSink.log('[onError] err: $err, msg: $msg');
+      },
+      onLocalVideoEvent:
+          (agora.VideoSourceType source, agora.LocalVideoEventType event) {
+        logSink.log(
+            '[onLocalVideoEvent] source: $source, event: $event, value: ${event.value()}');
+      },
+      onJoinChannelSuccess: (agora.RtcConnection connection, int elapsed) {
+        logSink.log(
+            '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');
+        setState(() => _isJoined = true);
+      },
+      onLeaveChannel: (agora.RtcConnection connection, agora.RtcStats stats) {
+        logSink.log(
+            '[onLeaveChannel] connection: ${connection.toJson()} stats: ${stats.toJson()}');
+        setState(() => _isJoined = false);
+      },
+    );
+    _engine.registerEventHandler(_eventHandler);
+
+    await _engine.enableVideo();
+
+    setState(() => _isReady = true);
+  }
+
+  Future<void> _joinChannel() async {
+    final cameraConfig = agora.CameraCapturerConfiguration(
+      cameraDirection: _cameraDirection,
+      cameraFocalLengthType: _cameraFocalLengthType,
+      followEncodeDimensionRatio: _followEncodeDimensionRatio,
+      format: agora.VideoFormat(
+        width: int.tryParse(_widthController.text) ?? 960,
+        height: int.tryParse(_heightController.text) ?? 540,
+        fps: int.tryParse(_fpsController.text) ?? 15,
+      ),
+    );
+    logSink.log('[setCameraCapturerConfiguration] ${cameraConfig.toJson()}');
+    await _engine.setCameraCapturerConfiguration(cameraConfig);
+    await _engine.startPreview();
+
+    await _engine.joinChannel(
+      token: config.token,
+      channelId: _channelIdController.text,
+      uid: int.tryParse(_uidController.text) ?? 0,
+      options: const agora.ChannelMediaOptions(
+        clientRoleType: agora.ClientRoleType.clientRoleBroadcaster,
+      ),
+    );
+  }
+
+  Future<void> _leaveChannel() async {
+    await _engine.leaveChannel();
+    await _engine.stopPreview();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ExampleActionsWidget(
+      displayContentBuilder: (context, isLayoutHorizontal) {
+        if (!_isReady) return Container();
+
+        return Stack(
+          children: [
+            agora.AgoraVideoView(
+              controller: agora.VideoViewController(
+                rtcEngine: _engine,
+                canvas: const agora.VideoCanvas(uid: 0),
+              ),
+            ),
+            Align(
+              alignment: Alignment.topLeft,
+              child: RemoteVideoViewsWidget(
+                key: keepRemoteVideoViewsKey,
+                rtcEngine: _engine,
+                channelId: _channelIdController.text,
+              ),
+            ),
+          ],
+        );
+      },
+      actionsBuilder: (context, isLayoutHorizontal) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _channelIdController,
+              decoration: const InputDecoration(hintText: 'Channel ID'),
+              enabled: !_isJoined,
+            ),
+            TextField(
+              controller: _uidController,
+              decoration: const InputDecoration(
+                hintText: 'UID for joinChannel (default: 0)',
+                labelText: 'UID',
+              ),
+              keyboardType: TextInputType.number,
+              enabled: !_isJoined,
+            ),
+            const Text('Camera direction:'),
+            DropdownButton<agora.CameraDirection>(
+              value: _cameraDirection,
+              items: agora.CameraDirection.values
+                  .map((direction) => DropdownMenuItem(
+                        value: direction,
+                        child: Text(direction.name),
+                      ))
+                  .toList(),
+              onChanged: _isJoined
+                  ? null
+                  : (direction) {
+                      setState(() => _cameraDirection = direction!);
+                    },
+            ),
+            const Text('Camera focal length type:'),
+            DropdownButton<agora.CameraFocalLengthType>(
+              value: _cameraFocalLengthType,
+              items: agora.CameraFocalLengthType.values
+                  .map((type) => DropdownMenuItem(
+                        value: type,
+                        child: Text(type.name),
+                      ))
+                  .toList(),
+              onChanged: _isJoined
+                  ? null
+                  : (type) {
+                      setState(() => _cameraFocalLengthType = type!);
+                    },
+            ),
+            Row(
+              children: [
+                const Expanded(child: Text('Follow encode dimension ratio')),
+                Switch(
+                  value: _followEncodeDimensionRatio,
+                  onChanged: _isJoined
+                      ? null
+                      : (value) {
+                          setState(() => _followEncodeDimensionRatio = value);
+                        },
+                ),
+              ],
+            ),
+            const Text('Capture format:'),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _widthController,
+                    decoration: const InputDecoration(labelText: 'Width'),
+                    keyboardType: TextInputType.number,
+                    enabled: !_isJoined,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _heightController,
+                    decoration: const InputDecoration(labelText: 'Height'),
+                    keyboardType: TextInputType.number,
+                    enabled: !_isJoined,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _fpsController,
+                    decoration: const InputDecoration(labelText: 'FPS'),
+                    keyboardType: TextInputType.number,
+                    enabled: !_isJoined,
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _isReady
+                        ? (_isJoined ? _leaveChannel : _joinChannel)
+                        : null,
+                    child: Text('${_isJoined ? 'Leave' : 'Join'} channel'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/example/lib/examples/advanced/index.dart
+++ b/example/lib/examples/advanced/index.dart
@@ -21,6 +21,7 @@ import 'package:flutter/foundation.dart';
 
 import 'audio_effect_mixing/audio_effect_mixing.dart';
 import 'audio_spectrum/audio_spectrum.dart';
+import 'camera_capturer_configuration/camera_capturer_configuration.dart';
 import 'channel_media_relay/channel_media_relay.dart';
 import 'device_manager/device_manager.dart';
 import 'enable_virtualbackground/enable_virtualbackground.dart';
@@ -38,6 +39,11 @@ import 'voice_changer/voice_changer.dart';
 /// Data source for advanced examples
 final advanced = [
   {'name': 'Advanced'},
+  if (!kIsWeb && Platform.isAndroid)
+    {
+      'name': 'CameraCapturerConfiguration',
+      'widget': const CameraCapturerConfiguration()
+    },
   if (!kIsWeb)
     {'name': 'AudioEffectMixing', 'widget': const AudioEffectMixing()},
   if (!kIsWeb)

--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -76,6 +76,10 @@ class _State extends State<JoinChannelVideo> {
       onError: (ErrorCodeType err, String msg) {
         logSink.log('[onError] err: $err, msg: $msg');
       },
+      onLocalVideoEvent: (VideoSourceType source, LocalVideoEventType event) {
+        logSink.log(
+            '[onLocalVideoEvent] source: $source, event: $event, value: ${event.value()}');
+      },
       onJoinChannelSuccess: (RtcConnection connection, int elapsed) {
         logSink.log(
             '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');

--- a/example/lib/examples/basic/join_channel_video/join_channel_video.dart
+++ b/example/lib/examples/basic/join_channel_video/join_channel_video.dart
@@ -76,10 +76,6 @@ class _State extends State<JoinChannelVideo> {
       onError: (ErrorCodeType err, String msg) {
         logSink.log('[onError] err: $err, msg: $msg');
       },
-      onLocalVideoEvent: (VideoSourceType source, LocalVideoEventType event) {
-        logSink.log(
-            '[onLocalVideoEvent] source: $source, event: $event, value: ${event.value()}');
-      },
       onJoinChannelSuccess: (RtcConnection connection, int elapsed) {
         logSink.log(
             '[onJoinChannelSuccess] connection: ${connection.toJson()} elapsed: $elapsed');

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -25,11 +25,11 @@ Pod::Spec.new do |s|
     s.dependency 'AgoraRtcEngine_iOS', '4.6.0'
   else
     # iris dependencies start
-    s.dependency 'AgoraIrisRTC_iOS2', '4.6.2-build.1'
+    s.dependency 'AgoraIrisRTC_iOS', '4.6.4-build.3'
     # iris dependencies end
 
     # native dependencies start
-    s.dependency 'AgoraVideo_Special_iOS', '4.6.2.70'
+    s.dependency 'AgoraRtcEngine_iOS_Preview', '4.6.4-build.3'
     # native dependencies end
   end
   

--- a/ios/agora_rtc_engine.podspec
+++ b/ios/agora_rtc_engine.podspec
@@ -25,11 +25,11 @@ Pod::Spec.new do |s|
     s.dependency 'AgoraRtcEngine_iOS', '4.6.0'
   else
     # iris dependencies start
-    s.dependency 'AgoraIrisRTC_iOS', '4.6.4-build.3'
+    s.dependency 'AgoraIrisRTC_iOS', '4.6.4-build.4'
     # iris dependencies end
 
     # native dependencies start
-    s.dependency 'AgoraRtcEngine_iOS_Preview', '4.6.4-build.3'
+    s.dependency 'AgoraRtcEngine_iOS', '4.6.4'
     # native dependencies end
   end
   

--- a/ios/agora_rtc_engine/Package.swift
+++ b/ios/agora_rtc_engine/Package.swift
@@ -43,8 +43,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS2-4.6.2-build.1.zip",
-            checksum: "eba8f9fc5b3d93d9d083d0c3f16e6c98fcd993e49989fb851e6df2941ca29825"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS-4.6.4-build.3.zip",
+            checksum: "bb19fda48f0cde9246495c46e385874a58d0afde04d7a49021927c1bcb10f148"
         )
     ]
 )

--- a/ios/agora_rtc_engine/Package.swift
+++ b/ios/agora_rtc_engine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "agora-rtc-engine", targets: ["agora_rtc_engine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", exact: "4.6.2"),
+        .package(url: "https://github.com/AgoraIO/AgoraRtcEngine_iOS.git", exact: "4.6.4"),
     ],
     targets: [
         .target(
@@ -43,8 +43,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS-4.6.4-build.3.zip",
-            checksum: "bb19fda48f0cde9246495c46e385874a58d0afde04d7a49021927c1bcb10f148"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_iOS-4.6.4-build.4.zip",
+            checksum: "38213d00a1e6581c1d2e82fb587270f29b10d91273885de3a24424fb782a061b"
         )
     ]
 )

--- a/lib/src/agora_base.dart
+++ b/lib/src/agora_base.dart
@@ -3538,6 +3538,14 @@ enum LocalVideoEventType {
   /// (4): A system internal error occurs during screen capture (Android only).
   @JsonValue(4)
   localVideoEventTypeScreenCaptureSystemInternalError,
+
+  /// @nodoc
+  @JsonValue(5)
+  localVideoEventTypeCameraFocalLengthApplied,
+
+  /// @nodoc
+  @JsonValue(6)
+  localVideoEventTypeCameraFocalLengthFallbackToDefault,
 }
 
 /// @nodoc

--- a/lib/src/agora_base.g.dart
+++ b/lib/src/agora_base.g.dart
@@ -2997,6 +2997,8 @@ const _$LocalVideoEventTypeEnumMap = {
       2,
   LocalVideoEventType.localVideoEventTypeScreenCaptureStoppedByUser: 3,
   LocalVideoEventType.localVideoEventTypeScreenCaptureSystemInternalError: 4,
+  LocalVideoEventType.localVideoEventTypeCameraFocalLengthApplied: 5,
+  LocalVideoEventType.localVideoEventTypeCameraFocalLengthFallbackToDefault: 6,
 };
 
 const _$LocalVideoStreamReasonEnumMap = {

--- a/lib/src/binding/event_handler_param_json.g.dart
+++ b/lib/src/binding/event_handler_param_json.g.dart
@@ -1909,6 +1909,8 @@ const _$LocalVideoEventTypeEnumMap = {
       2,
   LocalVideoEventType.localVideoEventTypeScreenCaptureStoppedByUser: 3,
   LocalVideoEventType.localVideoEventTypeScreenCaptureSystemInternalError: 4,
+  LocalVideoEventType.localVideoEventTypeCameraFocalLengthApplied: 5,
+  LocalVideoEventType.localVideoEventTypeCameraFocalLengthFallbackToDefault: 6,
 };
 
 RtcEngineEventHandlerOnLocalVideoStateChangedJson

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -23,11 +23,11 @@ A new flutter plugin project.
     s.dependency 'AgoraRtcEngine_macOS', '4.6.0'
   else
     # iris dependencies start
-    s.dependency 'AgoraIrisRTC_macOS2', '4.6.2-build.1'
+    s.dependency 'AgoraIrisRTC_macOS', '4.6.4-build.3'
     # iris dependencies end
 
     # native dependencies start
-    s.dependency 'AgoraVideo_Special_macOS', '4.6.2.70'
+    s.dependency 'AgoraRtcEngine_macOS_Preview', '4.6.4-build.3'
     # native dependencies end
   end
 

--- a/macos/agora_rtc_engine.podspec
+++ b/macos/agora_rtc_engine.podspec
@@ -23,7 +23,7 @@ A new flutter plugin project.
     s.dependency 'AgoraRtcEngine_macOS', '4.6.0'
   else
     # iris dependencies start
-    s.dependency 'AgoraIrisRTC_macOS', '4.6.4-build.3'
+    s.dependency 'AgoraIrisRTC_macOS', '4.6.4-build.4'
     # iris dependencies end
 
     # native dependencies start

--- a/macos/agora_rtc_engine/Package.swift
+++ b/macos/agora_rtc_engine/Package.swift
@@ -46,8 +46,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS-4.6.4-build.3.zip",
-            checksum: "8d5de39bfed309073a38d0f7c409140a44e243f0a92c8bc5c3def9bb9b5d2328"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS-4.6.4-build.4.zip",
+            checksum: "fc68fc284b99673226c5fd2d1ac48d450abe7bde7c562b8fca846d9f8fdad417"
         )
     ]
 )

--- a/macos/agora_rtc_engine/Package.swift
+++ b/macos/agora_rtc_engine/Package.swift
@@ -46,8 +46,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "AgoraRtcWrapper",
-            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS2-4.6.2-build.1.zip",
-            checksum: "dbfe2db86b0cb2c1012202212248bd6588173020c357dc13fc5a6dcf0a7b97cf"
+            url: "https://download.agora.io/sdk/release/AgoraIrisRTC_macOS-4.6.4-build.3.zip",
+            checksum: "8d5de39bfed309073a38d0f7c409140a44e243f0a92c8bc5c3def9bb9b5d2328"
         )
     ]
 )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   json_annotation: ^4.4.0
-  ffi: ^1.1.2
+  ffi: '>=1.1.2 <3.0.0'
   async: ^2.11.0
   meta: ^1.7.0
   iris_method_channel: ^2.2.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: agora_rtc_engine
 description: >-
   Flutter plugin of Agora RTC SDK, allow you to simply integrate Agora Video
   Calling or Live Video Streaming to your app with just a few lines of code.
-version: 6.6.3
+version: 6.6.4
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/tree/main
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: agora_rtc_engine
 description: >-
   Flutter plugin of Agora RTC SDK, allow you to simply integrate Agora Video
   Calling or Live Video Streaming to your app with just a few lines of code.
-version: 6.6.4
+version: 6.6.3
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/tree/main
 environment:

--- a/test/camera_capturer_configuration_example_test.dart
+++ b/test/camera_capturer_configuration_example_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const examplePath =
+      'example/lib/examples/advanced/camera_capturer_configuration/camera_capturer_configuration.dart';
+  const indexPath = 'example/lib/examples/advanced/index.dart';
+  const joinChannelVideoPath =
+      'example/lib/examples/basic/join_channel_video/join_channel_video.dart';
+
+  late String example;
+  late String index;
+  late String joinChannelVideo;
+
+  setUpAll(() {
+    example = File(examplePath).readAsStringSync();
+    index = File(indexPath).readAsStringSync();
+    joinChannelVideo = File(joinChannelVideoPath).readAsStringSync();
+  });
+
+  test('registers the dedicated Android example', () {
+    expect(example, contains('class CameraCapturerConfiguration'));
+    expect(
+      index,
+      matches(RegExp(
+        r"if \(!kIsWeb && Platform\.isAndroid\)\s*\{\s*'name': 'CameraCapturerConfiguration',\s*'widget': const CameraCapturerConfiguration\(\)\s*\}",
+      )),
+    );
+  });
+
+  test('configures selected camera settings before joining', () {
+    expect(example,
+        contains('await _engine.setCameraCapturerConfiguration(cameraConfig)'));
+    expect(example, contains('CameraDirection.values'));
+    expect(example, contains('CameraFocalLengthType.values'));
+    expect(example, contains('cameraDirection: _cameraDirection'));
+    expect(example, contains('cameraFocalLengthType: _cameraFocalLengthType'));
+    expect(example,
+        contains('followEncodeDimensionRatio: _followEncodeDimensionRatio'));
+    expect(example, contains('format: agora.VideoFormat('));
+    expect(example, contains('int.tryParse(_widthController.text) ?? 960'));
+    expect(example, contains('int.tryParse(_heightController.text) ?? 540'));
+    expect(example, contains('int.tryParse(_fpsController.text) ?? 15'));
+    expect(example, contains('controller: _widthController'));
+    expect(example, contains('controller: _heightController'));
+    expect(example, contains('controller: _fpsController'));
+    for (final controller in [
+      '_widthController',
+      '_heightController',
+      '_fpsController',
+    ]) {
+      expect(
+        RegExp(
+          'controller: ${RegExp.escape(controller)},'
+          r'\s*decoration: const InputDecoration\([^)]*\),'
+          r'\s*keyboardType: TextInputType\.number,'
+          r'\s*enabled: !_isJoined,',
+        ).hasMatch(example),
+        isTrue,
+        reason: '$controller must be disabled while joined',
+      );
+    }
+    expect(example, contains('int.tryParse(_uidController.text) ?? 0'));
+    final setConfig =
+        example.indexOf('_engine.setCameraCapturerConfiguration(cameraConfig)');
+    final startPreview = example.indexOf('_engine.startPreview()');
+    final join = example.indexOf('_engine.joinChannel(');
+    expect(setConfig, lessThan(startPreview));
+    expect(startPreview, lessThan(join));
+  });
+
+  test('logs local focal-length event details only in the dedicated example',
+      () {
+    expect(example, contains('onLocalVideoEvent:'));
+    expect(example, contains('source: \$source'));
+    expect(example, contains('event: \$event'));
+    expect(example, contains('value: \${event.value()}'));
+    expect(
+      example,
+      isNot(contains('localVideoEventTypeCameraFocalLengthApplied')),
+    );
+    expect(
+      example,
+      isNot(contains('localVideoEventTypeCameraFocalLengthFallbackToDefault')),
+    );
+    expect(joinChannelVideo, isNot(contains('onLocalVideoEvent')));
+  });
+}

--- a/test/local_video_event_type_test.dart
+++ b/test/local_video_event_type_test.dart
@@ -1,0 +1,23 @@
+import 'package:agora_rtc_engine/src/agora_base.dart';
+import 'package:agora_rtc_engine/src/binding/event_handler_param_json.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('decodes camera focal length local video events', () {
+    final applied = RtcEngineEventHandlerOnLocalVideoEventJson.fromJson(
+      const {'source': 0, 'event': 5},
+    );
+    final fallback = RtcEngineEventHandlerOnLocalVideoEventJson.fromJson(
+      const {'source': 0, 'event': 6},
+    );
+
+    expect(
+      applied.event,
+      LocalVideoEventType.localVideoEventTypeCameraFocalLengthApplied,
+    );
+    expect(
+      fallback.event,
+      LocalVideoEventType.localVideoEventTypeCameraFocalLengthFallbackToDefault,
+    );
+  });
+}

--- a/tool/terra/terra_config_main.yaml
+++ b/tool/terra/terra_config_main.yaml
@@ -3,18 +3,18 @@ parsers:
     package: '@agoraio-extensions/cxx-parser'
     args:
       includeHeaderDirs:
-        - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include'
+        - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include'
       parseFiles:
         include:
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/*.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/*.h'
         exclude:
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/AgoraRefPtr.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/time_utils.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/AgoraOptional.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/AgoraRefPtr.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/IAgoraMediaComponentFactory.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/IAgoraParameter.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/rte*.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/AgoraRefPtr.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/time_utils.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/AgoraOptional.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/AgoraRefPtr.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/IAgoraMediaComponentFactory.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/IAgoraParameter.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/rte*.h'
 
   - name: IrisApiIdParser
     package: '@agoraio-extensions/terra_shared_configs'
@@ -24,15 +24,15 @@ parsers:
     args:
       customHeaderFileNamePrefix: 'Custom'
       includeHeaderDirs:
-        - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include'
+        - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include'
       parseFiles:
         include:
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/*.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/custom_headers/*.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/*.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/custom_headers/*.h'
         exclude:
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/time_utils.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/IAgoraMediaComponentFactory.h'
-          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.2.70/include/rte*.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/time_utils.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/IAgoraMediaComponentFactory.h'
+          - '@agoraio-extensions/terra_shared_configs:headers/rtc_4.6.4/include/rte*.h'
 
   - path: parsers/cud_node_parser.ts
     args:

--- a/windows/cmake/DownloadSDK.cmake
+++ b/windows/cmake/DownloadSDK.cmake
@@ -1,9 +1,9 @@
 # iris dependencies start
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.6.2-build.1_DCG_Windows_Video_Standalone_20260212_0947_31926.zip")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.6.4-build.3_DCG_Windows_Video_Standalone_20260829_0249_311051.zip")
 # iris dependencies end
 
 # native dependencies start
-set(NATIVE_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_rel.v4.6.2.70_31618_FULL_20260211_1724_1009714.zip")
+set(NATIVE_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/AgoraRtcEngine_windows_Preview_4.6.4-build.3_Video_20260829_144642.zip")
 # native dependencies end
 
 function(download_and_extract URL TARGET_DIR EXTRACTED_DIR)

--- a/windows/cmake/DownloadSDK.cmake
+++ b/windows/cmake/DownloadSDK.cmake
@@ -1,5 +1,5 @@
 # iris dependencies start
-set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.6.4-build.3_DCG_Windows_Video_Standalone_20260829_0249_311051.zip")
+set(IRIS_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/iris_4.6.4-build.4_DCG_Windows_Video_Standalone_20260831_0943_311053.zip")
 # iris dependencies end
 
 # native dependencies start


### PR DESCRIPTION
## Summary

- bump `agora_rtc_engine` to `6.6.4` and update Native/Iris dependencies across Android, iOS, macOS, Windows, and SwiftPM
- add camera capturer configuration example and local video focal-length event bindings/tests
- fix compact dependency parsing when Iris `Build version` and a Native SPM `tag` coexist

## Validation

- `node --test ci/update_spm_deps.test.mjs` (56/56 passed)
- dependency update and code generation completed successfully in #2697