### PR TITLE
fix: stabilize release consumer and latest Flutter CI

### DIFF
--- a/.github/workflows/release_consumer_smoke.yml
+++ b/.github/workflows/release_consumer_smoke.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
   consumer_smoke_git:
-    name: 'Consumer Smoke Test (git, ${{ matrix.platform }})'
+    name: 'Consumer Smoke Test (git, ${{ matrix.platform }}, ${{ matrix.dependency_manager }})'
     runs-on: ${{ matrix.os }}
     needs: prepare
     if: ${{ needs.prepare.outputs.should_run == 'true' }}
@@ -92,14 +92,25 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: android
+            dependency_manager: default
           - os: ubuntu-latest
             platform: web
+            dependency_manager: default
           - os: macos-latest
             platform: ios
+            dependency_manager: swiftpm
           - os: macos-latest
             platform: macos
+            dependency_manager: swiftpm
+          - os: macos-latest
+            platform: ios
+            dependency_manager: cocoapods
+          - os: macos-latest
+            platform: macos
+            dependency_manager: cocoapods
           - os: windows-latest
             platform: windows
+            dependency_manager: default
     steps:
       - name: Checkout repository 🛎️
         uses: actions/checkout@v4
@@ -121,6 +132,7 @@ jobs:
         shell: bash
         env:
           CONSUMER_PLATFORM: ${{ matrix.platform }}
+          APPLE_DEPENDENCY_MANAGER: ${{ matrix.dependency_manager }}
           PACKAGE_SOURCE: git
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
           GIT_REF: ${{ needs.prepare.outputs.release_version }}
@@ -128,7 +140,7 @@ jobs:
         run: bash ci/run_flutter_release_consumer_smoke_test.sh
 
   consumer_smoke_pub:
-    name: 'Consumer Smoke Test (pub, ${{ matrix.platform }})'
+    name: 'Consumer Smoke Test (pub, ${{ matrix.platform }}, ${{ matrix.dependency_manager }})'
     runs-on: ${{ matrix.os }}
     needs: prepare
     if: ${{ needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.run_pub == 'true' }}
@@ -138,14 +150,25 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: android
+            dependency_manager: default
           - os: ubuntu-latest
             platform: web
+            dependency_manager: default
           - os: macos-latest
             platform: ios
+            dependency_manager: swiftpm
           - os: macos-latest
             platform: macos
+            dependency_manager: swiftpm
+          - os: macos-latest
+            platform: ios
+            dependency_manager: cocoapods
+          - os: macos-latest
+            platform: macos
+            dependency_manager: cocoapods
           - os: windows-latest
             platform: windows
+            dependency_manager: default
     steps:
       - name: Checkout repository 🛎️
         uses: actions/checkout@v4
@@ -167,6 +190,7 @@ jobs:
         shell: bash
         env:
           CONSUMER_PLATFORM: ${{ matrix.platform }}
+          APPLE_DEPENDENCY_MANAGER: ${{ matrix.dependency_manager }}
           PACKAGE_SOURCE: pub
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: bash ci/run_flutter_release_consumer_smoke_test.sh

--- a/.github/workflows/release_consumer_smoke.yml
+++ b/.github/workflows/release_consumer_smoke.yml
@@ -1,6 +1,20 @@
 name: 'Release Consumer Smoke'
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Existing Git tag and package version to test'
+        required: true
+        type: string
+      release_type:
+        description: 'Standard tests both Git and pub.dev; special tests Git only'
+        required: true
+        type: choice
+        default: standard
+        options:
+          - standard
+          - special
   workflow_run:
     workflows: ['Release to pub.dev and GitHub']
     types:
@@ -17,23 +31,37 @@ jobs:
       git_url: ${{ steps.metadata.outputs.git_url }}
       run_pub: ${{ steps.metadata.outputs.run_pub }}
     steps:
-      - name: Download release metadata
+      - name: Resolve release metadata
         id: metadata
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
+          MANUAL_RELEASE_VERSION: ${{ inputs.release_version }}
+          MANUAL_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           set -euo pipefail
 
-          RUN_ID="${{ github.event.workflow_run.id }}"
-          mkdir -p metadata
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ ! "${MANUAL_RELEASE_VERSION}" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+              echo "Invalid release version: ${MANUAL_RELEASE_VERSION}" >&2
+              exit 1
+            fi
 
-          gh run download "$RUN_ID" \
-            --repo "${REPOSITORY}" \
-            -n release-metadata \
-            -D metadata
+            RELEASE_VERSION="${MANUAL_RELEASE_VERSION}"
+            RELEASE_TYPE="${MANUAL_RELEASE_TYPE}"
+            GIT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+            DRY_RUN=false
+          else
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            mkdir -p metadata
 
-          source metadata/release-metadata.env
+            gh run download "$RUN_ID" \
+              --repo "${REPOSITORY}" \
+              -n release-metadata \
+              -D metadata
+
+            source metadata/release-metadata.env
+          fi
 
           if [[ "${DRY_RUN}" == "true" ]]; then
             echo "Release workflow was dry-run, skipping consumer smoke."

--- a/.github/workflows/run_test_weekly_latest_stable.yml
+++ b/.github/workflows/run_test_weekly_latest_stable.yml
@@ -379,16 +379,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout as agora_rtc_engine
+        uses: actions/checkout@v4
+        with:
+          path: agora_rtc_engine
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ needs.resolve_flutter_version.outputs.flutter_channel }}
           flutter-version: ${{ needs.resolve_flutter_version.outputs.flutter_version }}
           cache: true
       - run: flutter pub get
+        working-directory: agora_rtc_engine
       - name: Run flutter build ios --no-codesign --simulator
         run: flutter build ios --no-codesign --simulator
-        working-directory: example
+        working-directory: agora_rtc_engine/example
         env:
           IOS_SIMULATOR_SDK_VERSION: 18.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'io.agora.agora_rtc_ng'
     }
-    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    compileSdkVersion safeExtGet('compileSdkVersion', 34)
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'io.agora.agora_rtc_ng'
     }
-    compileSdkVersion safeExtGet('compileSdkVersion', 34)
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)

--- a/ci/run_flutter_release_consumer_smoke_test.sh
+++ b/ci/run_flutter_release_consumer_smoke_test.sh
@@ -58,6 +58,14 @@ trap cleanup EXIT
 
 "${FLUTTER_BIN}" create --platforms="${CONSUMER_PLATFORM}" --org io.agora.smoke "${APP_DIR}"
 
+if [[ "${CONSUMER_PLATFORM}" == "android" ]]; then
+  if [[ -f "${APP_DIR}/android/build.gradle.kts" ]]; then
+    echo 'extra["compileSdkVersion"] = 34' >> "${APP_DIR}/android/build.gradle.kts"
+  else
+    echo 'ext.compileSdkVersion = 34' >> "${APP_DIR}/android/build.gradle"
+  fi
+fi
+
 if [[ "${PACKAGE_SOURCE}" == "git" ]]; then
   cat >"${DEPENDENCY_FILE}" <<EOF
   ${PACKAGE_NAME}:

--- a/ci/run_flutter_release_consumer_smoke_test.sh
+++ b/ci/run_flutter_release_consumer_smoke_test.sh
@@ -12,6 +12,7 @@ GIT_URL="${GIT_URL:-}"
 GIT_REF="${GIT_REF:-${RELEASE_VERSION}}"
 FLUTTER_BIN="${FLUTTER_BIN:-flutter}"
 POD_BIN="${POD_BIN:-pod}"
+APPLE_DEPENDENCY_MANAGER="${APPLE_DEPENDENCY_MANAGER:-default}"
 
 case "${CONSUMER_PLATFORM}" in
   android|ios|macos|web|windows)
@@ -27,6 +28,15 @@ case "${PACKAGE_SOURCE}" in
     ;;
   *)
     echo "Unsupported PACKAGE_SOURCE: ${PACKAGE_SOURCE}" >&2
+    exit 1
+    ;;
+esac
+
+case "${APPLE_DEPENDENCY_MANAGER}" in
+  default|swiftpm|cocoapods)
+    ;;
+  *)
+    echo "Unsupported APPLE_DEPENDENCY_MANAGER: ${APPLE_DEPENDENCY_MANAGER}" >&2
     exit 1
     ;;
 esac
@@ -57,6 +67,12 @@ cleanup() {
 trap cleanup EXIT
 
 "${FLUTTER_BIN}" create --platforms="${CONSUMER_PLATFORM}" --org io.agora.smoke "${APP_DIR}"
+
+if [[ "${APPLE_DEPENDENCY_MANAGER}" == "swiftpm" ]]; then
+  "${FLUTTER_BIN}" config --enable-swift-package-manager
+elif [[ "${APPLE_DEPENDENCY_MANAGER}" == "cocoapods" ]]; then
+  "${FLUTTER_BIN}" config --no-enable-swift-package-manager
+fi
 
 if [[ "${CONSUMER_PLATFORM}" == "android" ]]; then
   if [[ -f "${APP_DIR}/android/build.gradle.kts" ]]; then

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
-
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/test_shard/rendering_test/android/gradle/wrapper/gradle-wrapper.properties
+++ b/test_shard/rendering_test/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/test_shard/rendering_test/android/settings.gradle
+++ b/test_shard/rendering_test/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/windows/cmake/DownloadSDK.cmake
+++ b/windows/cmake/DownloadSDK.cmake
@@ -9,6 +9,8 @@ set(NATIVE_SDK_DOWNLOAD_URL "https://download.agora.io/sdk/release/AgoraRtcEngin
 function(download_and_extract URL TARGET_DIR EXTRACTED_DIR)
     message(STATUS "Downloading ${URL} to ${TARGET_DIR}")
 
+    file(MAKE_DIRECTORY "${TARGET_DIR}")
+
     # Escape the URL for the command line
     string(REPLACE "+" "%2B" URL_ESCAPED ${URL})
 
@@ -62,8 +64,14 @@ endfunction()
 
 set(CONST_EXTRACTED_DIR_NAME "lib")
 
+# Consumer projects expose the plugin through a symlink, which is not a safe extraction root.
+set(SDK_DOWNLOAD_ROOT "${CMAKE_CURRENT_BINARY_DIR}/third_party")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.plugin_dev")
+    set(SDK_DOWNLOAD_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
+endif()
+
 # Download and extract the Iris SDK
-set(IRIS_DOWNLOAD_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/iris")
+set(IRIS_DOWNLOAD_PATH "${SDK_DOWNLOAD_ROOT}/iris")
 set(IRIS_EXTRACTED_DIR "${IRIS_DOWNLOAD_PATH}/${CONST_EXTRACTED_DIR_NAME}")
 
 # Download and extract the Iris SDK if the plugin is not in development mode
@@ -108,7 +116,7 @@ endif()
 
 
 # Download and extract the Native SDK
-set(NATIVE_DOWNLOAD_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/native")
+set(NATIVE_DOWNLOAD_PATH "${SDK_DOWNLOAD_ROOT}/native")
 set(NATIVE_EXTRACTED_DIR "${NATIVE_DOWNLOAD_PATH}/${CONST_EXTRACTED_DIR_NAME}")
 
 # Download and extract the Native SDK if the plugin is not in development mode


### PR DESCRIPTION
## Summary

- set an Android consumer compile SDK baseline that also reaches iris_method_channel
- extract Windows SDK archives under the build directory instead of the plugin symlink
- update example and rendering Android toolchain versions for latest stable Flutter
- check out the repository as agora_rtc_engine for the weekly iOS SwiftPM build
- allow Release Consumer Smoke to run manually against an existing version or Git commit
- test iOS and macOS consumers with both SwiftPM and CocoaPods

## Validation

Local:
- Flutter 3.47.1 example release APK build passed
- Flutter 3.47.1 rendering debug APK build passed
- fresh pub 6.6.4 Android consumer APK build passed
- fresh Git tag 6.6.4 Android consumer APK build passed
- iOS simulator SwiftPM build passed from an agora_rtc_engine checkout
- Bash syntax, workflow YAML parse, and git diff checks passed

GitHub Actions:
- PR-commit Git consumer smoke passed on Android, iOS, macOS, Windows, and Web: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/34198512748
- latest stable weekly verification: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/34196616152
- SwiftPM plus CocoaPods consumer matrix: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/34199471060

The standard 6.6.4 run intentionally exercises the already-published artifact. Its Windows jobs still reproduce the old package issue because the published 6.6.4 package cannot contain this PR fix: https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/34196629983

Fixes failures seen in:
- https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/33855303941
- https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/actions/runs/33976504048
